### PR TITLE
feat: show log type based on sdk

### DIFF
--- a/internal/setup/flag_toggle.go
+++ b/internal/setup/flag_toggle.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"fmt"
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -9,6 +10,7 @@ import (
 type flagToggleModel struct {
 	enabled bool
 	flagKey string
+	logType string
 }
 
 func NewFlagToggle() flagToggleModel {
@@ -39,7 +41,7 @@ func (m flagToggleModel) View() string {
 	margin := 1
 	if m.enabled {
 		bgColor = "#3d9c51"
-		furtherInstructions = "\n\nCheck your [browser|application logs] to see the change!"
+		furtherInstructions = fmt.Sprintf("\n\nCheck your %s to see the change!", m.logType)
 		margin = 2
 		toggle = "ON"
 	}

--- a/internal/setup/sdks.go
+++ b/internal/setup/sdks.go
@@ -18,9 +18,15 @@ var (
 	_ list.Item = sdk{}
 )
 
+const (
+	serverSideLogs = "application logs"
+	clientSideLogs = "browser"
+)
+
 type sdk struct {
 	Name                 string `json:"name"`
 	InstructionsFileName string `json:"instructionFile"`
+	LogType              string `json:"logType"`
 }
 
 func (s sdk) FilterValue() string { return "" }
@@ -37,38 +43,47 @@ func NewSdk() tea.Model {
 		{
 			Name:                 "JavaScript",
 			InstructionsFileName: sdkInstructionsFilePath + "js.md",
+			LogType:              clientSideLogs,
 		},
 		{
 			Name:                 "Node.js (server)",
 			InstructionsFileName: sdkInstructionsFilePath + "coming_soon.md",
+			LogType:              serverSideLogs,
 		},
 		{
 			Name:                 "Python",
 			InstructionsFileName: sdkInstructionsFilePath + "python.md",
+			LogType:              serverSideLogs,
 		},
 		{
 			Name:                 "Java",
 			InstructionsFileName: sdkInstructionsFilePath + "coming_soon.md",
+			LogType:              serverSideLogs,
 		},
 		{
 			Name:                 "Android",
 			InstructionsFileName: sdkInstructionsFilePath + "coming_soon.md",
+			LogType:              clientSideLogs,
 		},
 		{
 			Name:                 "React Native",
 			InstructionsFileName: sdkInstructionsFilePath + "coming_soon.md",
+			LogType:              clientSideLogs,
 		},
 		{
 			Name:                 "Ruby",
 			InstructionsFileName: sdkInstructionsFilePath + "coming_soon.md",
+			LogType:              serverSideLogs,
 		},
 		{
 			Name:                 "Flutter",
 			InstructionsFileName: sdkInstructionsFilePath + "coming_soon.md",
+			LogType:              clientSideLogs,
 		},
 		{
 			Name:                 ".NET",
 			InstructionsFileName: sdkInstructionsFilePath + "coming_soon.md",
+			LogType:              clientSideLogs,
 		},
 	}
 

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -94,6 +94,7 @@ func (m WizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					model = m.steps[flagToggleStep]
 					f2, ok := model.(flagToggleModel)
 					if ok {
+						f2.logType = m.currSdk.LogType
 						f2.flagKey = m.currFlagKey
 						m.steps[flagToggleStep] = f2
 					}


### PR DESCRIPTION
Small change to make the toggle step a bit more dynamic/realistic for the demo

client side sdk is chosen:
![image](https://github.com/launchdarkly/ld-cli/assets/55991524/ec0892e0-4a5c-4e7d-9255-ccb7eb2d842d)

server side sdk is chosen:
![image](https://github.com/launchdarkly/ld-cli/assets/55991524/501fdfc6-bd5b-41f4-90b0-ca97864a8781)
