### PR TITLE
chore: rename to ldcli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,80 +1,80 @@
 # Changelog
 
-## [0.0.1](https://github.com/launchdarkly/ld-cli/compare/v1.1.4...v0.0.1) (2024-03-22)
+## [0.0.1](https://github.com/launchdarkly/ldcli/compare/v1.1.4...v0.0.1) (2024-03-22)
 
 
 ### Features
 
-* Add auto create step in UI ([#10](https://github.com/launchdarkly/ld-cli/issues/10)) ([fb2fb5c](https://github.com/launchdarkly/ld-cli/commit/fb2fb5cf202af0966c264d217d92958174be250b))
-* Add flags create command ([#56](https://github.com/launchdarkly/ld-cli/issues/56)) ([19add8d](https://github.com/launchdarkly/ld-cli/commit/19add8d1daa0c60a510d29697996f74660233a2d))
-* add methods to send real (local) API requests for demo ([#54](https://github.com/launchdarkly/ld-cli/issues/54)) ([6b48414](https://github.com/launchdarkly/ld-cli/commit/6b48414eafaf7590e5cab9b5700abbe0dce363c8))
-* add new input model, use in projects step ([#30](https://github.com/launchdarkly/ld-cli/issues/30)) ([fbc9d0f](https://github.com/launchdarkly/ld-cli/commit/fbc9d0fe55caf8977fa5279adb6dd250f056819a))
-* Add project create command structure ([#33](https://github.com/launchdarkly/ld-cli/issues/33)) ([f33ebb9](https://github.com/launchdarkly/ld-cli/commit/f33ebb9b60a46cb7cd0710f7e21d29d54cbe6584))
-* add sdk wizard step ([#29](https://github.com/launchdarkly/ld-cli/issues/29)) ([c4dc7d0](https://github.com/launchdarkly/ld-cli/commit/c4dc7d0b4e6b540a14243a399982f7930f067ea8))
-* Adding release please ([#4](https://github.com/launchdarkly/ld-cli/issues/4)) ([4515a4c](https://github.com/launchdarkly/ld-cli/commit/4515a4c06a29c4c08fa7cb821cd424a6f60e898b))
-* create binaries in GitHub actions ([#9](https://github.com/launchdarkly/ld-cli/issues/9)) ([9528f8d](https://github.com/launchdarkly/ld-cli/commit/9528f8d6ddf07bc7f2ca947248e858b423d7329d))
-* create flag as first step in wizard ([#42](https://github.com/launchdarkly/ld-cli/issues/42)) ([7f62386](https://github.com/launchdarkly/ld-cli/commit/7f6238627212c4000cab99ad0506e25843fbedbc))
-* list projects err handling ([#21](https://github.com/launchdarkly/ld-cli/issues/21)) ([2ab3668](https://github.com/launchdarkly/ld-cli/commit/2ab3668be4a6cf2ef04dfd5fe25a3d14801030e6))
-* Make styling consistent ([#47](https://github.com/launchdarkly/ld-cli/issues/47)) ([c46c510](https://github.com/launchdarkly/ld-cli/commit/c46c5107bc729c5b93e375a5e813ad18f7862046))
-* render markdown ([#41](https://github.com/launchdarkly/ld-cli/issues/41)) ([83837ad](https://github.com/launchdarkly/ld-cli/commit/83837adaf884f0d0aaa55420494a6a77b065a5da))
-* select child resources based on parent key ([#31](https://github.com/launchdarkly/ld-cli/issues/31)) ([85c30ee](https://github.com/launchdarkly/ld-cli/commit/85c30eed5ecd2c0346e05163a5b7f805f73c98ce))
-* show list of sdks in setup wizard ([#43](https://github.com/launchdarkly/ld-cli/issues/43)) ([a984580](https://github.com/launchdarkly/ld-cli/commit/a9845803e6d86071dc47a5016f78a9c62e7db335))
-* toggle flag ([#45](https://github.com/launchdarkly/ld-cli/issues/45)) ([ac3b5c3](https://github.com/launchdarkly/ld-cli/commit/ac3b5c32db48da37258f41d7004079978fe0becc))
-* use tab to toggle, add final step ([#50](https://github.com/launchdarkly/ld-cli/issues/50)) ([33a447d](https://github.com/launchdarkly/ld-cli/commit/33a447d4ab473a581a24e1e9351ff4b0ca9efc10))
-* We added release please. Currently it only does a github release (hopefully) ([4515a4c](https://github.com/launchdarkly/ld-cli/commit/4515a4c06a29c4c08fa7cb821cd424a6f60e898b))
+* Add auto create step in UI ([#10](https://github.com/launchdarkly/ldcli/issues/10)) ([fb2fb5c](https://github.com/launchdarkly/ldcli/commit/fb2fb5cf202af0966c264d217d92958174be250b))
+* Add flags create command ([#56](https://github.com/launchdarkly/ldcli/issues/56)) ([19add8d](https://github.com/launchdarkly/ldcli/commit/19add8d1daa0c60a510d29697996f74660233a2d))
+* add methods to send real (local) API requests for demo ([#54](https://github.com/launchdarkly/ldcli/issues/54)) ([6b48414](https://github.com/launchdarkly/ldcli/commit/6b48414eafaf7590e5cab9b5700abbe0dce363c8))
+* add new input model, use in projects step ([#30](https://github.com/launchdarkly/ldcli/issues/30)) ([fbc9d0f](https://github.com/launchdarkly/ldcli/commit/fbc9d0fe55caf8977fa5279adb6dd250f056819a))
+* Add project create command structure ([#33](https://github.com/launchdarkly/ldcli/issues/33)) ([f33ebb9](https://github.com/launchdarkly/ldcli/commit/f33ebb9b60a46cb7cd0710f7e21d29d54cbe6584))
+* add sdk wizard step ([#29](https://github.com/launchdarkly/ldcli/issues/29)) ([c4dc7d0](https://github.com/launchdarkly/ldcli/commit/c4dc7d0b4e6b540a14243a399982f7930f067ea8))
+* Adding release please ([#4](https://github.com/launchdarkly/ldcli/issues/4)) ([4515a4c](https://github.com/launchdarkly/ldcli/commit/4515a4c06a29c4c08fa7cb821cd424a6f60e898b))
+* create binaries in GitHub actions ([#9](https://github.com/launchdarkly/ldcli/issues/9)) ([9528f8d](https://github.com/launchdarkly/ldcli/commit/9528f8d6ddf07bc7f2ca947248e858b423d7329d))
+* create flag as first step in wizard ([#42](https://github.com/launchdarkly/ldcli/issues/42)) ([7f62386](https://github.com/launchdarkly/ldcli/commit/7f6238627212c4000cab99ad0506e25843fbedbc))
+* list projects err handling ([#21](https://github.com/launchdarkly/ldcli/issues/21)) ([2ab3668](https://github.com/launchdarkly/ldcli/commit/2ab3668be4a6cf2ef04dfd5fe25a3d14801030e6))
+* Make styling consistent ([#47](https://github.com/launchdarkly/ldcli/issues/47)) ([c46c510](https://github.com/launchdarkly/ldcli/commit/c46c5107bc729c5b93e375a5e813ad18f7862046))
+* render markdown ([#41](https://github.com/launchdarkly/ldcli/issues/41)) ([83837ad](https://github.com/launchdarkly/ldcli/commit/83837adaf884f0d0aaa55420494a6a77b065a5da))
+* select child resources based on parent key ([#31](https://github.com/launchdarkly/ldcli/issues/31)) ([85c30ee](https://github.com/launchdarkly/ldcli/commit/85c30eed5ecd2c0346e05163a5b7f805f73c98ce))
+* show list of sdks in setup wizard ([#43](https://github.com/launchdarkly/ldcli/issues/43)) ([a984580](https://github.com/launchdarkly/ldcli/commit/a9845803e6d86071dc47a5016f78a9c62e7db335))
+* toggle flag ([#45](https://github.com/launchdarkly/ldcli/issues/45)) ([ac3b5c3](https://github.com/launchdarkly/ldcli/commit/ac3b5c32db48da37258f41d7004079978fe0becc))
+* use tab to toggle, add final step ([#50](https://github.com/launchdarkly/ldcli/issues/50)) ([33a447d](https://github.com/launchdarkly/ldcli/commit/33a447d4ab473a581a24e1e9351ff4b0ca9efc10))
+* We added release please. Currently it only does a github release (hopefully) ([4515a4c](https://github.com/launchdarkly/ldcli/commit/4515a4c06a29c4c08fa7cb821cd424a6f60e898b))
 
 
 ### Bug Fixes
 
-* remove release action since goreleaser publishes for us ([#18](https://github.com/launchdarkly/ld-cli/issues/18)) ([f749e96](https://github.com/launchdarkly/ld-cli/commit/f749e965fc35e39ed2623673b4e46fc4d9e220e6))
-* uncomment conditional in release-please for release-ldcli ([#12](https://github.com/launchdarkly/ld-cli/issues/12)) ([8938c1b](https://github.com/launchdarkly/ld-cli/commit/8938c1b79e36dc5f227f0c8fd020b00053464f39))
-* update dry-run to false in release-please github workflow ([#14](https://github.com/launchdarkly/ld-cli/issues/14)) ([ea3c089](https://github.com/launchdarkly/ld-cli/commit/ea3c089fc4be846bbe341feaa277ce7fd0b25526))
-* Update release-please.yml to dry-run: false ([#15](https://github.com/launchdarkly/ld-cli/issues/15)) ([237c775](https://github.com/launchdarkly/ld-cli/commit/237c775937a96f11b9e7c8415a8c62df445187b2))
+* remove release action since goreleaser publishes for us ([#18](https://github.com/launchdarkly/ldcli/issues/18)) ([f749e96](https://github.com/launchdarkly/ldcli/commit/f749e965fc35e39ed2623673b4e46fc4d9e220e6))
+* uncomment conditional in release-please for release-ldcli ([#12](https://github.com/launchdarkly/ldcli/issues/12)) ([8938c1b](https://github.com/launchdarkly/ldcli/commit/8938c1b79e36dc5f227f0c8fd020b00053464f39))
+* update dry-run to false in release-please github workflow ([#14](https://github.com/launchdarkly/ldcli/issues/14)) ([ea3c089](https://github.com/launchdarkly/ldcli/commit/ea3c089fc4be846bbe341feaa277ce7fd0b25526))
+* Update release-please.yml to dry-run: false ([#15](https://github.com/launchdarkly/ldcli/issues/15)) ([237c775](https://github.com/launchdarkly/ldcli/commit/237c775937a96f11b9e7c8415a8c62df445187b2))
 
 
 ### Miscellaneous Chores
 
-* release 0.0.1 ([#51](https://github.com/launchdarkly/ld-cli/issues/51)) ([73ef41e](https://github.com/launchdarkly/ld-cli/commit/73ef41e7cef0715ee20918fae6c14a026ea477f9))
+* release 0.0.1 ([#51](https://github.com/launchdarkly/ldcli/issues/51)) ([73ef41e](https://github.com/launchdarkly/ldcli/commit/73ef41e7cef0715ee20918fae6c14a026ea477f9))
 
-## [1.1.4](https://github.com/launchdarkly/ld-cli/compare/v1.1.3...v1.1.4) (2024-03-12)
-
-
-### Bug Fixes
-
-* remove release action since goreleaser publishes for us ([#18](https://github.com/launchdarkly/ld-cli/issues/18)) ([f749e96](https://github.com/launchdarkly/ld-cli/commit/f749e965fc35e39ed2623673b4e46fc4d9e220e6))
-
-## [1.1.3](https://github.com/launchdarkly/ld-cli/compare/v1.1.2...v1.1.3) (2024-03-12)
+## [1.1.4](https://github.com/launchdarkly/ldcli/compare/v1.1.3...v1.1.4) (2024-03-12)
 
 
 ### Bug Fixes
 
-* Update release-please.yml to dry-run: false ([#15](https://github.com/launchdarkly/ld-cli/issues/15)) ([237c775](https://github.com/launchdarkly/ld-cli/commit/237c775937a96f11b9e7c8415a8c62df445187b2))
+* remove release action since goreleaser publishes for us ([#18](https://github.com/launchdarkly/ldcli/issues/18)) ([f749e96](https://github.com/launchdarkly/ldcli/commit/f749e965fc35e39ed2623673b4e46fc4d9e220e6))
 
-## [1.1.2](https://github.com/launchdarkly/ld-cli/compare/v1.1.1...v1.1.2) (2024-03-12)
-
-
-### Bug Fixes
-
-* update dry-run to false in release-please github workflow ([#14](https://github.com/launchdarkly/ld-cli/issues/14)) ([ea3c089](https://github.com/launchdarkly/ld-cli/commit/ea3c089fc4be846bbe341feaa277ce7fd0b25526))
-
-## [1.1.1](https://github.com/launchdarkly/ld-cli/compare/v1.1.0...v1.1.1) (2024-03-12)
+## [1.1.3](https://github.com/launchdarkly/ldcli/compare/v1.1.2...v1.1.3) (2024-03-12)
 
 
 ### Bug Fixes
 
-* uncomment conditional in release-please for release-ldcli ([#12](https://github.com/launchdarkly/ld-cli/issues/12)) ([8938c1b](https://github.com/launchdarkly/ld-cli/commit/8938c1b79e36dc5f227f0c8fd020b00053464f39))
+* Update release-please.yml to dry-run: false ([#15](https://github.com/launchdarkly/ldcli/issues/15)) ([237c775](https://github.com/launchdarkly/ldcli/commit/237c775937a96f11b9e7c8415a8c62df445187b2))
 
-## [1.1.0](https://github.com/launchdarkly/ld-cli/compare/v1.0.0...v1.1.0) (2024-03-12)
+## [1.1.2](https://github.com/launchdarkly/ldcli/compare/v1.1.1...v1.1.2) (2024-03-12)
+
+
+### Bug Fixes
+
+* update dry-run to false in release-please github workflow ([#14](https://github.com/launchdarkly/ldcli/issues/14)) ([ea3c089](https://github.com/launchdarkly/ldcli/commit/ea3c089fc4be846bbe341feaa277ce7fd0b25526))
+
+## [1.1.1](https://github.com/launchdarkly/ldcli/compare/v1.1.0...v1.1.1) (2024-03-12)
+
+
+### Bug Fixes
+
+* uncomment conditional in release-please for release-ldcli ([#12](https://github.com/launchdarkly/ldcli/issues/12)) ([8938c1b](https://github.com/launchdarkly/ldcli/commit/8938c1b79e36dc5f227f0c8fd020b00053464f39))
+
+## [1.1.0](https://github.com/launchdarkly/ldcli/compare/v1.0.0...v1.1.0) (2024-03-12)
 
 
 ### Features
 
-* create binaries in GitHub actions ([#9](https://github.com/launchdarkly/ld-cli/issues/9)) ([9528f8d](https://github.com/launchdarkly/ld-cli/commit/9528f8d6ddf07bc7f2ca947248e858b423d7329d))
+* create binaries in GitHub actions ([#9](https://github.com/launchdarkly/ldcli/issues/9)) ([9528f8d](https://github.com/launchdarkly/ldcli/commit/9528f8d6ddf07bc7f2ca947248e858b423d7329d))
 
 ## 1.0.0 (2024-03-08)
 
 
 ### Features
 
-* Adding release please ([#4](https://github.com/launchdarkly/ld-cli/issues/4)) ([4515a4c](https://github.com/launchdarkly/ld-cli/commit/4515a4c06a29c4c08fa7cb821cd424a6f60e898b))
-* We added release please. Currently it only does a github release (hopefully) ([4515a4c](https://github.com/launchdarkly/ld-cli/commit/4515a4c06a29c4c08fa7cb821cd424a6f60e898b))
+* Adding release please ([#4](https://github.com/launchdarkly/ldcli/issues/4)) ([4515a4c](https://github.com/launchdarkly/ldcli/commit/4515a4c06a29c4c08fa7cb821cd424a6f60e898b))
+* We added release please. Currently it only does a github release (hopefully) ([4515a4c](https://github.com/launchdarkly/ldcli/commit/4515a4c06a29c4c08fa7cb821cd424a6f60e898b))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LD-CLI
+# ldcli
 
 ## Commands
 

--- a/cmd/flags/create.go
+++ b/cmd/flags/create.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"ld-cli/internal/errors"
-	"ld-cli/internal/flags"
+	"ldcli/internal/errors"
+	"ldcli/internal/flags"
 )
 
 func NewCreateCmd() *cobra.Command {

--- a/cmd/flags/update.go
+++ b/cmd/flags/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"ld-cli/internal/flags"
+	"ldcli/internal/flags"
 )
 
 func NewUpdateCmd() *cobra.Command {

--- a/cmd/projects/create.go
+++ b/cmd/projects/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"ld-cli/internal/projects"
+	"ldcli/internal/projects"
 )
 
 func NewCreateCmd() *cobra.Command {

--- a/cmd/projects/list.go
+++ b/cmd/projects/list.go
@@ -8,8 +8,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"ld-cli/internal/errors"
-	"ld-cli/internal/projects"
+	"ldcli/internal/errors"
+	"ldcli/internal/projects"
 )
 
 func NewListCmd() *cobra.Command {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"ld-cli/cmd/flags"
-	"ld-cli/cmd/projects"
-	errs "ld-cli/internal/errors"
+	"ldcli/cmd/flags"
+	"ldcli/cmd/projects"
+	errs "ldcli/internal/errors"
 )
 
 func newRootCommand() *cobra.Command {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -8,7 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
-	"ld-cli/internal/setup"
+	"ldcli/internal/setup"
 )
 
 var setupCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ld-cli
+module ldcli
 
 go 1.20
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -3,7 +3,7 @@ package flags
 import (
 	"context"
 	"encoding/json"
-	"ld-cli/internal/errors"
+	"ldcli/internal/errors"
 
 	ldapi "github.com/launchdarkly/api-client-go/v14"
 )

--- a/internal/projects/projects.go
+++ b/internal/projects/projects.go
@@ -3,7 +3,7 @@ package projects
 import (
 	"context"
 	"encoding/json"
-	"ld-cli/internal/errors"
+	"ldcli/internal/errors"
 
 	ldapi "github.com/launchdarkly/api-client-go/v14"
 )

--- a/internal/projects/projects_test.go
+++ b/internal/projects/projects_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"ld-cli/internal/errors"
+	"ldcli/internal/errors"
 )
 
 type GetProjectsResponse struct{}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "ld-cli/cmd"
+import "ldcli/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Looks like we needed to rename the module in go.mod to ld-cli. I also updated the name of our github repo to `ldcli`. So I updated the changelog to reflect that as well. 