### PR TITLE
feat: add toggle on and off aliases to update flag

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -22,14 +22,19 @@ func NewFlagsCmd(client flags.Client) (*cobra.Command, error) {
 		return nil, err
 	}
 
-	toggleUpdateCmd, err := NewToggleUpdateCmd(client)
+	toggleOnUpdateCmd, err := NewToggleOnUpdateCmd(client)
+	if err != nil {
+		return nil, err
+	}
+	toggleOffUpdateCmd, err := NewToggleOffUpdateCmd(client)
 	if err != nil {
 		return nil, err
 	}
 
 	cmd.AddCommand(createCmd)
 	cmd.AddCommand(updateCmd)
-	cmd.AddCommand(toggleUpdateCmd)
+	cmd.AddCommand(toggleOnUpdateCmd)
+	cmd.AddCommand(toggleOffUpdateCmd)
 
 	return cmd, nil
 }

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -22,8 +22,14 @@ func NewFlagsCmd(client flags.Client) (*cobra.Command, error) {
 		return nil, err
 	}
 
+	toggleUpdateCmd, err := NewToggleUpdateCmd(client)
+	if err != nil {
+		return nil, err
+	}
+
 	cmd.AddCommand(createCmd)
 	cmd.AddCommand(updateCmd)
+	cmd.AddCommand(toggleUpdateCmd)
 
 	return cmd, nil
 }

--- a/cmd/flags/update.go
+++ b/cmd/flags/update.go
@@ -25,7 +25,6 @@ func NewUpdateCmd(client flags.Client) (*cobra.Command, error) {
 
 	cmd.Flags().StringP(cliflags.DataFlag, "d", "", "Input data in JSON")
 	err := cmd.MarkFlagRequired(cliflags.DataFlag)
-
 	if err != nil {
 		return nil, err
 	}
@@ -57,34 +56,47 @@ func NewUpdateCmd(client flags.Client) (*cobra.Command, error) {
 	return cmd, nil
 }
 
-func NewToggleUpdateCmd(client flags.Client) (*cobra.Command, error) {
+func NewToggleOnUpdateCmd(client flags.Client) (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Args:    validators.Validate(),
-		Long:    "Update a flag",
-		RunE:    runUpdate(client),
-		Short:   "Update a flag",
-		Use:     "toggle-on",
-		Aliases: []string{"toggle-off"},
+		Args:  validators.Validate(),
+		Long:  "Turn a flag on",
+		RunE:  runUpdate(client),
+		Short: "Turn a flag on",
+		Use:   "toggle-on",
 	}
 
-	var err error
+	return setToggleCommandFlags(cmd)
+}
 
-	cmd.Flags().String("envKey", "", "Environment key")
-	err = cmd.MarkFlagRequired("envKey")
+func NewToggleOffUpdateCmd(client flags.Client) (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Args:  validators.Validate(),
+		Long:  "Turn a flag off",
+		RunE:  runUpdate(client),
+		Short: "Turn a flag off",
+		Use:   "toggle-off",
+	}
+
+	return setToggleCommandFlags(cmd)
+}
+
+func setToggleCommandFlags(cmd *cobra.Command) (*cobra.Command, error) {
+	cmd.Flags().StringP(cliflags.EnvironmentFlag, "e", "", "Environment key")
+	err := cmd.MarkFlagRequired(cliflags.EnvironmentFlag)
 	if err != nil {
 		return nil, err
 	}
-	err = viper.BindPFlag("envKey", cmd.Flags().Lookup("envKey"))
+	err = viper.BindPFlag(cliflags.EnvironmentFlag, cmd.Flags().Lookup(cliflags.EnvironmentFlag))
 	if err != nil {
 		return nil, err
 	}
 
-	cmd.Flags().String("key", "", "Flag key")
-	err = cmd.MarkFlagRequired("key")
+	cmd.Flags().String(cliflags.FlagFlag, "", "Flag key")
+	err = cmd.MarkFlagRequired(cliflags.FlagFlag)
 	if err != nil {
 		return nil, err
 	}
-	err = viper.BindPFlag("key", cmd.Flags().Lookup("key"))
+	err = viper.BindPFlag(cliflags.FlagFlag, cmd.Flags().Lookup(cliflags.FlagFlag))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/flags/update.go
+++ b/cmd/flags/update.go
@@ -101,12 +101,12 @@ func setToggleCommandFlags(cmd *cobra.Command) (*cobra.Command, error) {
 		return nil, err
 	}
 
-	cmd.Flags().String("projKey", "", "Project key")
-	err = cmd.MarkFlagRequired("projKey")
+	cmd.Flags().String(cliflags.ProjectFlag, "", "Project key")
+	err = cmd.MarkFlagRequired(cliflags.ProjectFlag)
 	if err != nil {
 		return nil, err
 	}
-	err = viper.BindPFlag("projKey", cmd.Flags().Lookup("projKey"))
+	err = viper.BindPFlag(cliflags.ProjectFlag, cmd.Flags().Lookup(cliflags.ProjectFlag))
 	if err != nil {
 		return nil, err
 	}
@@ -119,11 +119,12 @@ func runUpdate(client flags.Client) func(*cobra.Command, []string) error {
 		// rebind flags used in other subcommands
 		_ = viper.BindPFlag(cliflags.DataFlag, cmd.Flags().Lookup(cliflags.DataFlag))
 		_ = viper.BindPFlag(cliflags.ProjectFlag, cmd.Flags().Lookup(cliflags.ProjectFlag))
+		_ = viper.BindPFlag(cliflags.FlagFlag, cmd.Flags().Lookup(cliflags.FlagFlag))
 
 		var patch []ldapi.PatchOperation
 		if cmd.CalledAs() == "toggle-on" || cmd.CalledAs() == "toggle-off" {
-			_ = viper.BindPFlag("envKey", cmd.Flags().Lookup("envKey"))
-			err := json.Unmarshal([]byte(buildPatch(viper.GetString("envKey"), cmd.CalledAs() == "toggle-on")), &patch)
+			_ = viper.BindPFlag(cliflags.EnvironmentFlag, cmd.Flags().Lookup(cliflags.EnvironmentFlag))
+			err := json.Unmarshal([]byte(buildPatch(viper.GetString(cliflags.EnvironmentFlag), cmd.CalledAs() == "toggle-on")), &patch)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Based on Danny's suggestion, I went with creating a second command to create the `toggle-on` and `toggle-off` aliases