### PR TITLE
feat: setting version dynamically

### DIFF
--- a/cmd/cmdtest.go
+++ b/cmd/cmdtest.go
@@ -21,7 +21,7 @@ func CallCmd(
 	projectsClient *projects.MockClient,
 	args []string,
 ) ([]byte, error) {
-	rootCmd, err := NewRootCommand(flagsClient, membersClient, projectsClient)
+	rootCmd, err := NewRootCommand(flagsClient, membersClient, projectsClient, "test")
 	require.NoError(t, err)
 	b := bytes.NewBufferString("")
 	rootCmd.SetOut(b)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -17,11 +16,12 @@ import (
 	"ldcli/internal/projects"
 )
 
-func NewRootCommand(flagsClient flags.Client, membersClient members.Client, projectsClient projects.Client) (*cobra.Command, error) {
+func NewRootCommand(flagsClient flags.Client, membersClient members.Client, projectsClient projects.Client, version string) (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Use:   "ldcli",
-		Short: "LaunchDarkly CLI",
-		Long:  "LaunchDarkly CLI to control your feature flags",
+		Use:     "ldcli",
+		Short:   "LaunchDarkly CLI",
+		Long:    "LaunchDarkly CLI to control your feature flags",
+		Version: version,
 
 		// Handle errors differently based on type.
 		// We don't want to show the usage if the user has the right structure but invalid data such as
@@ -30,24 +30,13 @@ func NewRootCommand(flagsClient flags.Client, membersClient members.Client, proj
 		SilenceUsage:  true,
 	}
 
-	versionByteValue, err := os.ReadFile(".release-please-manifest.json")
-	if err != nil {
-		return nil, err
-	}
-
-	var rpManifest struct {
-		Version string `json:"."`
-	}
-	json.Unmarshal(versionByteValue, &rpManifest)
-	cmd.Version = rpManifest.Version
-
 	cmd.PersistentFlags().StringP(
 		"accessToken",
 		"t",
 		"",
 		"LaunchDarkly personal access token",
 	)
-	err = cmd.MarkPersistentFlagRequired("accessToken")
+	err := cmd.MarkPersistentFlagRequired("accessToken")
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +78,8 @@ func NewRootCommand(flagsClient flags.Client, membersClient members.Client, proj
 	return cmd, nil
 }
 
-func Execute() {
-	rootCmd, err := NewRootCommand(flags.NewClient(), members.NewClient(), projects.NewClient())
+func Execute(version string) {
+	rootCmd, err := NewRootCommand(flags.NewClient(), members.NewClient(), projects.NewClient(), version)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"ldcli/internal/flags"
+)
+
+func TestCreate(t *testing.T) {
+	t.Run("with valid flags prints version", func(t *testing.T) {
+		client := flags.MockClient{}
+		args := []string{
+			"--version",
+		}
+
+		output, err := CallCmd(t, &client, nil, nil, args)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(output), `ldcli version test`)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,10 @@ package main
 
 import "ldcli/cmd"
 
+var (
+	version = "dev"
+)
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(version)
 }


### PR DESCRIPTION
[go releaser sets main.version via ldflag to our tag (with the v removed).](https://goreleaser.com/cookbooks/using-main.version/) I'm making use of this to get the version number dynamically.

Included a test, the test version was set to "test".

If you want to test this locally try
```
go build -ldflags="-s -w -X main.version=0.2.0"
```
Then run the generated binary
```
./ldcli --version
```