### PR TITLE
feat: sdk instruction find replace  handle missing instructions

### DIFF
--- a/internal/quickstart/choose_sdk.go
+++ b/internal/quickstart/choose_sdk.go
@@ -79,8 +79,7 @@ type sdkDetail struct {
 func (s sdkDetail) FilterValue() string { return "" }
 
 var SDKs = []sdkDetail{
-	// TODO: react is still internal
-	// {CanonicalName: "react", DisplayName: "React", SDKType: clientSideSDK},
+	{canonicalName: "react", displayName: "React", kind: clientSideSDK},
 	{canonicalName: "node-server", displayName: "Node.js (server-side)", kind: serverSideSDK},
 	{canonicalName: "python", displayName: "Python", kind: serverSideSDK},
 	{canonicalName: "java", displayName: "Java", kind: serverSideSDK},

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -115,6 +115,10 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case errMsg:
 		m.err = msg.err
+	case noInstructionsMsg:
+		m.currentStep += 1
+
+		return m, cmd
 	default:
 	}
 

--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -8,6 +8,8 @@ type fetchSDKInstructionsMsg struct {
 	name          string
 }
 
+// errMsg is sent when there is an error in one of the steps that the container model needs to
+// know about.
 type errMsg struct {
 	err error
 }
@@ -15,5 +17,14 @@ type errMsg struct {
 func sendErr(err error) tea.Cmd {
 	return func() tea.Msg {
 		return errMsg{err: err}
+	}
+}
+
+// noInstructionsMsg is sent when we can't find the SDK instructions repository for the given SDK.
+type noInstructionsMsg struct{}
+
+func sendNoInstructions() tea.Cmd {
+	return func() tea.Msg {
+		return noInstructionsMsg{}
 	}
 }

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -3,7 +3,6 @@ package quickstart
 import (
 	"fmt"
 	"io"
-	"ldcli/internal/errors"
 	"ldcli/internal/sdks"
 	"net/http"
 	"time"
@@ -51,14 +50,14 @@ func (m showSDKInstructionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, sendErr(err)
 		}
 
-		if resp.StatusCode != 200 {
-			return m, sendErr(errors.NewError(fmt.Sprintf("could not find %s SDK instructions", msg.name)))
+		if resp.StatusCode == 404 {
+			m.sdk = msg.name
+
+			return m, sendNoInstructions()
 		}
 
-		instructions := sdks.ReplaceFlagKey(string(body), msg.flagKey)
-
 		m.sdk = msg.name
-		m.instructions = instructions
+		m.instructions = sdks.ReplaceFlagKey(string(body), msg.flagKey)
 	}
 
 	return m, nil


### PR DESCRIPTION
If we can't find the SDK instructions sample repository, we can skip showing it and go to the next step. We don't need to show an error since the user can't do anything about it.

There's no "hello-react" repository, but we plan to make one soon. This handles both situations where it doesn't exist and where it does.