### PR TITLE
fix: Don't require any flags when running help as command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,12 @@ func NewRootCommand(flagsClient flags.Client, membersClient members.Client, proj
 		Short:   "LaunchDarkly CLI",
 		Long:    "LaunchDarkly CLI to control your feature flags",
 		Version: version,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// disable required flags when running help as a command, not a flag
+			if cmd.Name() == "help" {
+				cmd.DisableFlagParsing = true
+			}
+		},
 
 		// Handle errors differently based on type.
 		// We don't want to show the usage if the user has the right structure but invalid data such as


### PR DESCRIPTION
Running `ldcli help` would error because it expected the require `access-token` flag. This disables flag parsing for the help command so nothing is required.

Using `--help` as a flag continues to work.