### PR TITLE
chore: Refactor container update

### DIFF
--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -2,12 +2,6 @@ package quickstart
 
 import tea "github.com/charmbracelet/bubbletea"
 
-type fetchSDKInstructionsMsg struct {
-	canonicalName string
-	flagKey       string
-	name          string
-}
-
 // errMsg is sent when there is an error in one of the steps that the container model needs to
 // know about.
 type errMsg struct {
@@ -17,6 +11,21 @@ type errMsg struct {
 func sendErr(err error) tea.Cmd {
 	return func() tea.Msg {
 		return errMsg{err: err}
+	}
+}
+
+type fetchSDKInstructionsMsg struct {
+	canonicalName string
+	flagKey       string
+	name          string
+}
+
+func sendFetchSDKInstructionsMsg(canonicalName string, displayName string) tea.Cmd {
+	return func() tea.Msg {
+		return fetchSDKInstructionsMsg{
+			canonicalName: canonicalName,
+			name:          displayName,
+		}
 	}
 }
 


### PR DESCRIPTION
Changes the container model's Update method to send and consume `fetchSDKInstructionsMsg` to show the SDK instructions during setup. Originally we were going off the more roundabount way of using the enter key press after incrementing the current step.