### PR TITLE
fix: remove create flag placeholder text

### DIFF
--- a/internal/quickstart/create_flag.go
+++ b/internal/quickstart/create_flag.go
@@ -10,7 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-const defaultFlagName = "my new flag"
+const defaultFlagName = "My New Flag"
 
 type createFlagModel struct {
 	accessToken string
@@ -24,7 +24,6 @@ func NewCreateFlagModel(client flags.Client, accessToken, baseUri string) tea.Mo
 	ti.Focus()
 	ti.CharLimit = 156
 	ti.Width = 20
-	ti.Placeholder = defaultFlagName
 
 	return createFlagModel{
 		accessToken: accessToken,
@@ -69,7 +68,8 @@ func (m createFlagModel) View() string {
 		MarginLeft(2)
 
 	return fmt.Sprintf(
-		"Name your first feature flag (enter for default value):\n\n%s",
+		"Name your first feature flag (enter for default value `%s`):\n\n%s",
+		defaultFlagName,
 		style.Render(m.textInput.View()),
 	) + "\n"
 }

--- a/internal/quickstart/create_flag.go
+++ b/internal/quickstart/create_flag.go
@@ -68,7 +68,7 @@ func (m createFlagModel) View() string {
 		MarginLeft(2)
 
 	return fmt.Sprintf(
-		"Name your first feature flag (enter for default value `%s`):\n\n%s",
+		"Name your first feature flag (enter for default value %q):\n\n%s",
 		defaultFlagName,
 		style.Render(m.textInput.View()),
 	) + "\n"


### PR DESCRIPTION
removes the placeholder text in the text input model and instead moves it up to the title. 
![image](https://github.com/launchdarkly/ldcli/assets/55991524/e1f63d42-b595-4af8-b04b-ba6177b81454)
