### PR TITLE
fix: add instructions to continue from show sdk step

### DIFF
--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -78,7 +78,7 @@ func (m showSDKInstructionsModel) View() string {
 
 	return wordwrap.String(
 		fmt.Sprintf(
-			"Set up your application. Here are the steps to incorporate the LaunchDarkly %s SDK into your code.\n%s",
+			"Set up your application. Here are the steps to incorporate the LaunchDarkly %s SDK into your code.\n%s\n\n (hit enter to continue)",
 			m.sdk,
 			style.Render(md),
 		),

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -78,7 +78,7 @@ func (m showSDKInstructionsModel) View() string {
 
 	return wordwrap.String(
 		fmt.Sprintf(
-			"Set up your application. Here are the steps to incorporate the LaunchDarkly %s SDK into your code.\n%s\n\n (hit enter to continue)",
+			"Set up your application. Here are the steps to incorporate the LaunchDarkly %s SDK into your code.\n%s\n\n (press enter to continue)",
 			m.sdk,
 			style.Render(md),
 		),


### PR DESCRIPTION
![image](https://github.com/launchdarkly/ldcli/assets/55991524/ad07b8e7-1d1b-4fd8-b9db-06b5a27c7a72)