### PR TITLE
feat: Can go back to choose SDK page from show SDK instructions

### DIFF
--- a/internal/quickstart/choose_sdk.go
+++ b/internal/quickstart/choose_sdk.go
@@ -37,10 +37,6 @@ func NewChooseSDKModel(selectedIndex int) tea.Model {
 	l.SetShowStatusBar(false)
 	l.SetFilteringEnabled(false) // TODO: try to get filtering working
 	l.Paginator.PerPage = 5
-	// disable these because we've overridden "left" to go back and leaving NextPage without
-	// PrevPage would be confusing
-	l.KeyMap.PrevPage.SetEnabled(false)
-	l.KeyMap.NextPage.SetEnabled(false)
 
 	return chooseSDKModel{
 		list:          l,

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -92,7 +92,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sdk.kind,
 		)
 		m.currentStep += 1
-	case fetchedSDKInstructions, fetchedEnv, toggledFlagMsg:
+	case fetchedSDKInstructions, fetchedEnv, selectedSDKMsg, toggledFlagMsg:
 		m.currentModel, cmd = m.currentModel.Update(msg)
 	case showToggleFlagMsg:
 		m.currentModel = NewToggleFlagModel(
@@ -103,8 +103,6 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sdk.kind,
 		)
 		m.currentStep += 1
-	case selectedSDKMsg:
-		m.currentModel, cmd = m.currentModel.Update(msg)
 	default:
 		log.Printf("container default: %T\n", msg)
 	}
@@ -147,8 +145,8 @@ type keyMap struct {
 
 var keys = keyMap{
 	Back: key.NewBinding(
-		key.WithKeys("left"),
-		key.WithHelp("back", "go back"),
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "go back"),
 	),
 	Enter: key.NewBinding(
 		key.WithKeys("enter"),

--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -71,10 +71,7 @@ type fetchedSDKInstructions struct {
 }
 
 type choseSDKMsg struct {
-	canonicalName string
-	displayName   string
-	sdkKind       string
-	url           string
+	sdk sdkDetail
 }
 
 func sendChoseSDKMsg(sdk sdkDetail) tea.Cmd {
@@ -84,10 +81,7 @@ func sendChoseSDKMsg(sdk sdkDetail) tea.Cmd {
 		}
 
 		return choseSDKMsg{
-			canonicalName: sdk.canonicalName,
-			displayName:   sdk.displayName,
-			url:           sdk.url,
-			sdkKind:       sdk.kind,
+			sdk: sdk,
 		}
 	}
 }
@@ -147,3 +141,13 @@ func sendFetchEnv(accessToken string, baseUri string, key string, projKey string
 
 // noInstructionsMsg is sent when we can't find the SDK instructions repository for the given SDK.
 type noInstructionsMsg struct{}
+
+type selectedSDKMsg struct {
+	index int
+}
+
+func sendSelectedSDKMsg(index int) tea.Cmd {
+	return func() tea.Msg {
+		return selectedSDKMsg{index: index}
+	}
+}


### PR DESCRIPTION
A user can go back to choose another SDK once they're on the instructions page. We should show this in the help text once we have that.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
