### PR TITLE
fix: The completion command should not require any flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,8 +32,8 @@ func NewRootCommand(
 		Long:    "LaunchDarkly CLI to control your feature flags",
 		Version: version,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			// disable required flags when running help as a command, not a flag
-			if cmd.Name() == "help" {
+			// disable required flags when running certain commands, not a flag
+			if cmd.Name() == "help" || cmd.Parent().Name() == "completion" {
 				cmd.DisableFlagParsing = true
 			}
 		},


### PR DESCRIPTION
[story](https://app.shortcut.com/launchdarkly/story/239156/running-ldcli-completion-bash-should-not-require-access-token)

When a user runs `ldcli completion bash` they should not require the `access-token` flag.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
