### PR TITLE
fix: Show SDK name in instructions

### DIFF
--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -57,7 +57,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmd = tea.Quit
 		case key.Matches(msg, keys.Back):
 			// if showing SDK instructions, let the user go back to choose a different SDK
-			if m.currentStep == 2 {
+			if m.currentStep == 3 {
 				m.currentStep -= 1
 				m.currentModel = NewChooseSDKModel(m.sdk.index)
 				cmd = m.currentModel.Init()
@@ -71,6 +71,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.accessToken,
 			m.baseUri,
 			msg.sdk.canonicalName,
+			msg.sdk.displayName,
 			msg.sdk.url,
 			m.flagKey,
 		)

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -12,21 +12,21 @@ import (
 )
 
 type showSDKInstructionsModel struct {
-	instructions string
-	sdk          string
-
-	canonicalName string
-	flagKey       string
-	url           string
-	sdkKey        string
 	accessToken   string
 	baseUri       string
+	canonicalName string
+	displayName   string
+	flagKey       string
+	instructions  string
+	sdkKey        string
+	url           string
 }
 
 func NewShowSDKInstructionsModel(
 	accessToken string,
 	baseUri string,
 	canonicalName string,
+	displayName string,
 	url string,
 	flagKey string,
 ) tea.Model {
@@ -34,6 +34,7 @@ func NewShowSDKInstructionsModel(
 		accessToken:   accessToken,
 		baseUri:       baseUri,
 		canonicalName: canonicalName,
+		displayName:   displayName,
 		flagKey:       flagKey,
 		url:           url,
 	}
@@ -79,7 +80,7 @@ func (m showSDKInstructionsModel) View() string {
 	return wordwrap.String(
 		fmt.Sprintf(
 			"Set up your application. Here are the steps to incorporate the LaunchDarkly %s SDK into your code.\n%s\n\n (press enter to continue)",
-			m.sdk,
+			m.displayName,
 			style.Render(md),
 		),
 		0,


### PR DESCRIPTION
before:
![Screenshot 2024-04-03 at 3 44 55 PM](https://github.com/launchdarkly/ldcli/assets/306396/df6992d7-246f-452f-96d2-ac6427688427)
after:
![Screenshot 2024-04-03 at 3 45 08 PM](https://github.com/launchdarkly/ldcli/assets/306396/2d1e943d-712e-4d4c-ae9c-7b7193f217a9)
