### PR TITLE
chore: update access-token flag help text

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ func NewRootCommand(
 	cmd.PersistentFlags().String(
 		cliflags.AccessTokenFlag,
 		"",
-		"LaunchDarkly API token",
+		"LaunchDarkly API token with write-level access",
 	)
 	err := cmd.MarkPersistentFlagRequired(cliflags.AccessTokenFlag)
 	if err != nil {


### PR DESCRIPTION
![image](https://github.com/launchdarkly/ldcli/assets/55991524/a52135e0-baf4-4307-a382-46186833094d)

Adding a link to the account settings page felt like it would be too long. 