### PR TITLE
feat: Can go back to any previous setup page

### DIFF
--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -65,10 +65,26 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quitting = true
 			cmd = tea.Quit
 		case key.Matches(msg, keys.Back):
-			// if showing SDK instructions, let the user go back to choose a different SDK
-			if m.currentStep == stepShowSDKInstructions {
+			switch m.currentStep {
+			case stepCreateFlag:
+				// can't go back
+			case stepChooseSDK:
+				m.currentStep -= 1
+				m.currentModel = NewCreateFlagModel(m.flagsClient, m.accessToken, m.baseUri)
+			case stepShowSDKInstructions:
 				m.currentStep -= 1
 				m.currentModel = NewChooseSDKModel(m.sdk.index)
+				cmd = m.currentModel.Init()
+			case stepToggleFlag:
+				m.currentStep -= 1
+				m.currentModel = NewShowSDKInstructionsModel(
+					m.accessToken,
+					m.baseUri,
+					m.sdk.canonicalName,
+					m.sdk.displayName,
+					m.sdk.url,
+					m.flagKey,
+				)
 				cmd = m.currentModel.Init()
 			}
 		default:


### PR DESCRIPTION
You can go back to any page in the setup flow (but not any farther). This doesn't save the flag name to show on the create flag page yet. I can follow up to have that page say
> Name your first feature flag (enter for default value "{the previously created flag name}"):