### PR TITLE
fix: Setup error messages should show above help text

### DIFF
--- a/internal/quickstart/choose_sdk.go
+++ b/internal/quickstart/choose_sdk.go
@@ -90,9 +90,7 @@ func (m chooseSDKModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m chooseSDKModel) View() string {
-	helpView := m.help.View(m.helpKeys)
-
-	return m.list.View() + "\n\n" + helpView
+	return m.list.View() + footerView(m.help.View(m.helpKeys), nil)
 }
 
 type sdkDetail struct {
@@ -158,8 +156,6 @@ func (d sdkDelegate) Render(w io.Writer, m list.Model, index int, listItem list.
 		return
 	}
 
-	str := fmt.Sprintf("%d. %s", index+1, i.displayName)
-
 	fn := sdkStyle.Render
 	if index == m.Index() {
 		fn = func(s ...string) string {
@@ -167,5 +163,5 @@ func (d sdkDelegate) Render(w io.Writer, m list.Model, index int, listItem list.
 		}
 	}
 
-	fmt.Fprint(w, fn(str))
+	fmt.Fprint(w, fn(fmt.Sprintf("%d. %s", index+1, i.displayName)))
 }

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -7,7 +7,6 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/wordwrap"
 
 	"ldcli/internal/flags"
@@ -36,7 +35,6 @@ type ContainerModel struct {
 	err          error
 	flagKey      string
 	flagsClient  flags.Client
-	quitMsg      string // TODO: set this?
 	quitting     bool
 	sdk          sdkDetail
 	totalSteps   int
@@ -113,7 +111,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.currentStep += 1
 		m.err = nil
 	case errMsg:
-		m.err = msg.err
+		m.currentModel, cmd = m.currentModel.Update(msg)
 	case noInstructionsMsg:
 		// skip the ShowSDKInstructionsModel and move along to toggling the flag
 		m.currentModel = NewToggleFlagModel(
@@ -145,26 +143,6 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m ContainerModel) View() string {
 	out := fmt.Sprintf("\nStep %d of %d\n"+m.currentModel.View(), m.currentStep, m.totalSteps)
-
-	if m.err != nil {
-		if m.quitting {
-			out := m.quitMsg + "\n\n"
-			out += m.err.Error()
-
-			return lipgloss.
-				NewStyle().
-				SetString(out).
-				Render() + "\n"
-		}
-
-		// show error and stay on the same step
-		out += "\n" + lipgloss.
-			NewStyle().
-			SetString(m.err.Error()).
-			Render() + "\n"
-
-		return out
-	}
 
 	if m.quitting {
 		return ""

--- a/internal/quickstart/create_flag.go
+++ b/internal/quickstart/create_flag.go
@@ -18,6 +18,7 @@ type createFlagModel struct {
 	accessToken string
 	baseUri     string
 	client      flags.Client
+	err         error
 	help        help.Model
 	helpKeys    keyMap
 	textInput   textinput.Model
@@ -65,6 +66,8 @@ func (m createFlagModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			m.textInput, cmd = m.textInput.Update(msg)
 		}
+	case errMsg:
+		m.err = msg.err
 	}
 
 	return m, cmd
@@ -73,10 +76,9 @@ func (m createFlagModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m createFlagModel) View() string {
 	style := lipgloss.NewStyle().
 		MarginLeft(2)
-	helpView := m.help.View(m.helpKeys)
 
 	return fmt.Sprintf(
 		"Name your first feature flag (enter for default value):%s",
 		style.Render(m.textInput.View()),
-	) + "\n\n" + helpView
+	) + footerView(m.help.View(m.helpKeys), m.err)
 }

--- a/internal/quickstart/help.go
+++ b/internal/quickstart/help.go
@@ -1,6 +1,8 @@
 package quickstart
 
-import "github.com/charmbracelet/bubbles/key"
+import (
+	"github.com/charmbracelet/bubbles/key"
+)
 
 var (
 	BindingBack = key.NewBinding(
@@ -92,4 +94,16 @@ var pressableKeys = keyMap{
 		key.WithKeys("tab"),
 		key.WithHelp("tab", "toggle"),
 	),
+}
+
+// footerView shows any error messages and help text.
+func footerView(helpView string, err error) string {
+	var errView string
+	spacer := "\n\n\n"
+	if err != nil {
+		spacer = "\n\n"
+		errView = "\n" + err.Error()
+	}
+
+	return errView + spacer + helpView
 }

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -86,7 +86,6 @@ func (m showSDKInstructionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m showSDKInstructionsModel) View() string {
 	style := lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false)
-	helpView := m.help.View(m.helpKeys)
 	md, err := m.renderMarkdown()
 	if err != nil {
 		return fmt.Sprintf("error rendering instructions: %s", err)
@@ -103,7 +102,7 @@ func (m showSDKInstructionsModel) View() string {
 			style.Render(md),
 		),
 		0,
-	) + "\n\n" + helpView
+	) + footerView(m.help.View(m.helpKeys), nil)
 }
 
 func (m showSDKInstructionsModel) renderMarkdown() (string, error) {

--- a/internal/quickstart/toggle_flag.go
+++ b/internal/quickstart/toggle_flag.go
@@ -16,6 +16,7 @@ type toggleFlagModel struct {
 	baseUri        string
 	client         flags.Client
 	enabled        bool
+	err            error
 	flagKey        string
 	flagWasEnabled bool
 	help           help.Model
@@ -54,6 +55,8 @@ func (m toggleFlagModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.enabled = !m.enabled
 			return m, sendToggleFlagMsg(m.client, m.accessToken, m.baseUri, m.flagKey, m.enabled)
 		}
+	case errMsg:
+		m.err = msg.err
 	}
 
 	return m, cmd
@@ -75,10 +78,9 @@ func (m toggleFlagModel) View() string {
 		margin = 2
 		toggle = "ON"
 	}
-	helpView := m.help.View(m.helpKeys)
 
 	if m.flagWasEnabled {
-		furtherInstructions = fmt.Sprintf("\n\nCheck your %s to see the change!\n\n(press ctrl + c to quit)", logTypeMap[m.sdkKind])
+		furtherInstructions = fmt.Sprintf("\n\nCheck your %s to see the change!", logTypeMap[m.sdkKind])
 	}
 
 	toggleStyle := lipgloss.NewStyle().
@@ -86,5 +88,5 @@ func (m toggleFlagModel) View() string {
 		Padding(0, 1).
 		MarginRight(margin)
 
-	return title + "\n\n" + toggleStyle.Render(toggle) + m.flagKey + furtherInstructions + "\n\n" + helpView
+	return title + "\n\n" + toggleStyle.Render(toggle) + m.flagKey + furtherInstructions + footerView(m.help.View(m.helpKeys), m.err)
 }


### PR DESCRIPTION
Error messages should show above the help text during setup.

![Apr-05-2024 14-48-32](https://github.com/launchdarkly/ldcli/assets/306396/38672b2b-406e-4645-b26f-f52ac192b9fe)
Ignore the leftover SDK instructions line -- we can fix that in [this story](https://app.shortcut.com/launchdarkly/story/239306/make-sdk-instructions-scrollable).