### PR TITLE
build: manual publish, remove if

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -17,7 +17,6 @@ jobs:
     permissions:
       id-token: write # Needed to obtain Docker tokens
       contents: write # Needed to upload release artifacts
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     outputs: 
       hashes: ${{ steps.publish.outputs.hashes }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Images and Artifacts
+name: Manually Publish Images and Artifacts
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Looks like the previous manual run stopped due to the included if statement.
Also renamed the manual-publish workflow to `Manually Publish Images and Artifacts`