### PR TITLE
feat: make sdk instructions scrollable

### DIFF
--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -110,6 +110,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.flagKey = msg.flagKey // TODO: figure out if we maintain state here or pass in another message
 		m.currentStep += 1
 		m.err = nil
+		cmd = sendEnableMouseCellMotionMsg()
 	case errMsg:
 		m.currentModel, cmd = m.currentModel.Update(msg)
 	case noInstructionsMsg:
@@ -122,7 +123,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sdk.kind,
 		)
 		m.currentStep += 1
-	case fetchedSDKInstructions, fetchedEnv, selectedSDKMsg, toggledFlagMsg, spinner.TickMsg:
+	case fetchedSDKInstructions, fetchedEnv, selectedSDKMsg, toggledFlagMsg, spinner.TickMsg, tea.MouseMsg:
 		m.currentModel, cmd = m.currentModel.Update(msg)
 		m.err = nil
 	case showToggleFlagMsg:

--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -124,6 +124,12 @@ func sendShowToggleFlagMsg() tea.Cmd {
 	}
 }
 
+func sendEnableMouseCellMotionMsg() tea.Cmd {
+	return func() tea.Msg {
+		return tea.EnableMouseCellMotion()
+	}
+}
+
 type fetchedEnv struct {
 	sdkKey string
 }

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -9,12 +9,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/reflow/wordwrap"
 	"ldcli/internal/sdks"
 )
 
 const (
-	viewportWidth  = 78
+	viewportWidth  = 80
 	viewportHeight = 30
 )
 
@@ -110,7 +109,7 @@ func (m showSDKInstructionsModel) View() string {
 
 	instructions := fmt.Sprintf("Set up your application in your Default project & Test environment.\n\nHere are the steps to incorporate the LaunchDarkly %s SDK into your code. You should have everything you need to get started, including the flag from the previous step and your SDK key from your Test environment already embedded in the code!\n", m.displayName)
 
-	return wordwrap.String(instructions, viewportWidth*1.5) + m.viewport.View() + "\n(press enter to continue)" + footerView(m.help.View(m.helpKeys), nil)
+	return instructions + m.viewport.View() + "\n(press enter to continue)" + footerView(m.help.View(m.helpKeys), nil)
 }
 
 func (m showSDKInstructionsModel) renderMarkdown() (string, error) {

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -48,6 +48,7 @@ func NewShowSDKInstructionsModel(
 		BorderStyle(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("62")).
 		PaddingRight(2)
+	vp.MouseWheelEnabled = true
 
 	return showSDKInstructionsModel{
 		accessToken:   accessToken,
@@ -85,6 +86,8 @@ func (m showSDKInstructionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			m.viewport, cmd = m.viewport.Update(msg)
 		}
+	case tea.MouseMsg:
+		m.viewport, cmd = m.viewport.Update(msg)
 	case fetchedSDKInstructions:
 		m.instructions = sdks.ReplaceFlagKey(string(msg.instructions), m.flagKey)
 	case fetchedEnv:

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -116,9 +116,17 @@ func (m showSDKInstructionsModel) View() string {
 }
 
 func (m showSDKInstructionsModel) renderMarkdown() (string, error) {
-	out, err := glamour.Render(m.instructions, "auto")
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(viewportWidth),
+	)
 	if err != nil {
 		return "", err
+	}
+
+	out, err := renderer.Render(m.instructions)
+	if err != nil {
+		return out, err
 	}
 
 	return out, nil

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -2,16 +2,20 @@ package quickstart
 
 import (
 	"fmt"
-
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/wordwrap"
-
 	"ldcli/internal/sdks"
+)
+
+const (
+	viewportWidth  = 78
+	viewportHeight = 30
 )
 
 type showSDKInstructionsModel struct {
@@ -26,6 +30,7 @@ type showSDKInstructionsModel struct {
 	sdkKey        string
 	spinner       spinner.Model
 	url           string
+	viewport      viewport.Model
 }
 
 func NewShowSDKInstructionsModel(
@@ -39,6 +44,12 @@ func NewShowSDKInstructionsModel(
 	s := spinner.New()
 	s.Spinner = spinner.Points
 
+	vp := viewport.New(viewportWidth, viewportHeight)
+	vp.Style = lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("62")).
+		PaddingRight(2)
+
 	return showSDKInstructionsModel{
 		accessToken:   accessToken,
 		baseUri:       baseUri,
@@ -50,8 +61,9 @@ func NewShowSDKInstructionsModel(
 			Back: BindingBack,
 			Quit: BindingQuit,
 		},
-		spinner: s,
-		url:     url,
+		spinner:  s,
+		url:      url,
+		viewport: vp,
 	}
 }
 
@@ -71,12 +83,19 @@ func (m showSDKInstructionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, pressableKeys.Enter):
 			// TODO: only if all data are fetched?
 			cmd = sendShowToggleFlagMsg()
+		default:
+			m.viewport, cmd = m.viewport.Update(msg)
 		}
 	case fetchedSDKInstructions:
 		m.instructions = sdks.ReplaceFlagKey(string(msg.instructions), m.flagKey)
 	case fetchedEnv:
 		m.sdkKey = msg.sdkKey
 		m.instructions = sdks.ReplaceSDKKey(string(m.instructions), msg.sdkKey)
+		md, err := m.renderMarkdown()
+		if err != nil {
+			return m, sendErr(err)
+		}
+		m.viewport.SetContent(md)
 	case spinner.TickMsg:
 		m.spinner, cmd = m.spinner.Update(msg)
 	}
@@ -85,24 +104,13 @@ func (m showSDKInstructionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m showSDKInstructionsModel) View() string {
-	style := lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false)
-	md, err := m.renderMarkdown()
-	if err != nil {
-		return fmt.Sprintf("error rendering instructions: %s", err)
-	}
-
 	if m.instructions == "" || m.sdkKey == "" {
 		return m.spinner.View() + fmt.Sprintf(" Fetching %s SDK instructions...", m.displayName)
 	}
 
-	return wordwrap.String(
-		fmt.Sprintf(
-			"Set up your application in your Default project & Test environment.\n\nHere are the steps to incorporate the LaunchDarkly %s SDK into your code. You should have everything you need to get started, including the flag from the previous step and your SDK key from your Test environment already embedded in the code!\n%s\n\n (press enter to continue)",
-			m.displayName,
-			style.Render(md),
-		),
-		0,
-	) + footerView(m.help.View(m.helpKeys), nil)
+	instructions := fmt.Sprintf("Set up your application in your Default project & Test environment.\n\nHere are the steps to incorporate the LaunchDarkly %s SDK into your code. You should have everything you need to get started, including the flag from the previous step and your SDK key from your Test environment already embedded in the code!\n", m.displayName)
+
+	return wordwrap.String(instructions, viewportWidth*1.5) + m.viewport.View() + "\n(press enter to continue)" + footerView(m.help.View(m.helpKeys), nil)
 }
 
 func (m showSDKInstructionsModel) renderMarkdown() (string, error) {

--- a/tools.go
+++ b/tools.go
@@ -1,8 +1,0 @@
-//go:build tools
-// +build tools
-
-package tools
-
-import (
-	_ "github.com/charmbracelet/bubbles/viewport"
-)

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,8 @@
+//go:build tools
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/charmbracelet/bubbles/viewport"
+)

--- a/vendor/github.com/charmbracelet/bubbles/viewport/keymap.go
+++ b/vendor/github.com/charmbracelet/bubbles/viewport/keymap.go
@@ -1,0 +1,48 @@
+package viewport
+
+import "github.com/charmbracelet/bubbles/key"
+
+const spacebar = " "
+
+// KeyMap defines the keybindings for the viewport. Note that you don't
+// necessary need to use keybindings at all; the viewport can be controlled
+// programmatically with methods like Model.LineDown(1). See the GoDocs for
+// details.
+type KeyMap struct {
+	PageDown     key.Binding
+	PageUp       key.Binding
+	HalfPageUp   key.Binding
+	HalfPageDown key.Binding
+	Down         key.Binding
+	Up           key.Binding
+}
+
+// DefaultKeyMap returns a set of pager-like default keybindings.
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		PageDown: key.NewBinding(
+			key.WithKeys("pgdown", spacebar, "f"),
+			key.WithHelp("f/pgdn", "page down"),
+		),
+		PageUp: key.NewBinding(
+			key.WithKeys("pgup", "b"),
+			key.WithHelp("b/pgup", "page up"),
+		),
+		HalfPageUp: key.NewBinding(
+			key.WithKeys("u", "ctrl+u"),
+			key.WithHelp("u", "½ page up"),
+		),
+		HalfPageDown: key.NewBinding(
+			key.WithKeys("d", "ctrl+d"),
+			key.WithHelp("d", "½ page down"),
+		),
+		Up: key.NewBinding(
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑/k", "up"),
+		),
+		Down: key.NewBinding(
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓/j", "down"),
+		),
+	}
+}

--- a/vendor/github.com/charmbracelet/bubbles/viewport/viewport.go
+++ b/vendor/github.com/charmbracelet/bubbles/viewport/viewport.go
@@ -1,0 +1,405 @@
+package viewport
+
+import (
+	"math"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// New returns a new model with the given width and height as well as default
+// key mappings.
+func New(width, height int) (m Model) {
+	m.Width = width
+	m.Height = height
+	m.setInitialValues()
+	return m
+}
+
+// Model is the Bubble Tea model for this viewport element.
+type Model struct {
+	Width  int
+	Height int
+	KeyMap KeyMap
+
+	// Whether or not to respond to the mouse. The mouse must be enabled in
+	// Bubble Tea for this to work. For details, see the Bubble Tea docs.
+	MouseWheelEnabled bool
+
+	// The number of lines the mouse wheel will scroll. By default, this is 3.
+	MouseWheelDelta int
+
+	// YOffset is the vertical scroll position.
+	YOffset int
+
+	// YPosition is the position of the viewport in relation to the terminal
+	// window. It's used in high performance rendering only.
+	YPosition int
+
+	// Style applies a lipgloss style to the viewport. Realistically, it's most
+	// useful for setting borders, margins and padding.
+	Style lipgloss.Style
+
+	// HighPerformanceRendering bypasses the normal Bubble Tea renderer to
+	// provide higher performance rendering. Most of the time the normal Bubble
+	// Tea rendering methods will suffice, but if you're passing content with
+	// a lot of ANSI escape codes you may see improved rendering in certain
+	// terminals with this enabled.
+	//
+	// This should only be used in program occupying the entire terminal,
+	// which is usually via the alternate screen buffer.
+	HighPerformanceRendering bool
+
+	initialized bool
+	lines       []string
+}
+
+func (m *Model) setInitialValues() {
+	m.KeyMap = DefaultKeyMap()
+	m.MouseWheelEnabled = true
+	m.MouseWheelDelta = 3
+	m.initialized = true
+}
+
+// Init exists to satisfy the tea.Model interface for composability purposes.
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+// AtTop returns whether or not the viewport is at the very top position.
+func (m Model) AtTop() bool {
+	return m.YOffset <= 0
+}
+
+// AtBottom returns whether or not the viewport is at or past the very bottom
+// position.
+func (m Model) AtBottom() bool {
+	return m.YOffset >= m.maxYOffset()
+}
+
+// PastBottom returns whether or not the viewport is scrolled beyond the last
+// line. This can happen when adjusting the viewport height.
+func (m Model) PastBottom() bool {
+	return m.YOffset > m.maxYOffset()
+}
+
+// ScrollPercent returns the amount scrolled as a float between 0 and 1.
+func (m Model) ScrollPercent() float64 {
+	if m.Height >= len(m.lines) {
+		return 1.0
+	}
+	y := float64(m.YOffset)
+	h := float64(m.Height)
+	t := float64(len(m.lines) - 1)
+	v := y / (t - h)
+	return math.Max(0.0, math.Min(1.0, v))
+}
+
+// SetContent set the pager's text content. For high performance rendering the
+// Sync command should also be called.
+func (m *Model) SetContent(s string) {
+	s = strings.ReplaceAll(s, "\r\n", "\n") // normalize line endings
+	m.lines = strings.Split(s, "\n")
+
+	if m.YOffset > len(m.lines)-1 {
+		m.GotoBottom()
+	}
+}
+
+// maxYOffset returns the maximum possible value of the y-offset based on the
+// viewport's content and set height.
+func (m Model) maxYOffset() int {
+	return max(0, len(m.lines)-m.Height)
+}
+
+// visibleLines returns the lines that should currently be visible in the
+// viewport.
+func (m Model) visibleLines() (lines []string) {
+	if len(m.lines) > 0 {
+		top := max(0, m.YOffset)
+		bottom := clamp(m.YOffset+m.Height, top, len(m.lines))
+		lines = m.lines[top:bottom]
+	}
+	return lines
+}
+
+// scrollArea returns the scrollable boundaries for high performance rendering.
+func (m Model) scrollArea() (top, bottom int) {
+	top = max(0, m.YPosition)
+	bottom = max(top, top+m.Height)
+	if top > 0 && bottom > top {
+		bottom--
+	}
+	return top, bottom
+}
+
+// SetYOffset sets the Y offset.
+func (m *Model) SetYOffset(n int) {
+	m.YOffset = clamp(n, 0, m.maxYOffset())
+}
+
+// ViewDown moves the view down by the number of lines in the viewport.
+// Basically, "page down".
+func (m *Model) ViewDown() []string {
+	if m.AtBottom() {
+		return nil
+	}
+
+	return m.LineDown(m.Height)
+}
+
+// ViewUp moves the view up by one height of the viewport. Basically, "page up".
+func (m *Model) ViewUp() []string {
+	if m.AtTop() {
+		return nil
+	}
+
+	return m.LineUp(m.Height)
+}
+
+// HalfViewDown moves the view down by half the height of the viewport.
+func (m *Model) HalfViewDown() (lines []string) {
+	if m.AtBottom() {
+		return nil
+	}
+
+	return m.LineDown(m.Height / 2)
+}
+
+// HalfViewUp moves the view up by half the height of the viewport.
+func (m *Model) HalfViewUp() (lines []string) {
+	if m.AtTop() {
+		return nil
+	}
+
+	return m.LineUp(m.Height / 2)
+}
+
+// LineDown moves the view down by the given number of lines.
+func (m *Model) LineDown(n int) (lines []string) {
+	if m.AtBottom() || n == 0 || len(m.lines) == 0 {
+		return nil
+	}
+
+	// Make sure the number of lines by which we're going to scroll isn't
+	// greater than the number of lines we actually have left before we reach
+	// the bottom.
+	m.SetYOffset(m.YOffset + n)
+
+	// Gather lines to send off for performance scrolling.
+	bottom := clamp(m.YOffset+m.Height, 0, len(m.lines))
+	top := clamp(m.YOffset+m.Height-n, 0, bottom)
+	return m.lines[top:bottom]
+}
+
+// LineUp moves the view down by the given number of lines. Returns the new
+// lines to show.
+func (m *Model) LineUp(n int) (lines []string) {
+	if m.AtTop() || n == 0 || len(m.lines) == 0 {
+		return nil
+	}
+
+	// Make sure the number of lines by which we're going to scroll isn't
+	// greater than the number of lines we are from the top.
+	m.SetYOffset(m.YOffset - n)
+
+	// Gather lines to send off for performance scrolling.
+	top := max(0, m.YOffset)
+	bottom := clamp(m.YOffset+n, 0, m.maxYOffset())
+	return m.lines[top:bottom]
+}
+
+// TotalLineCount returns the total number of lines (both hidden and visible) within the viewport.
+func (m Model) TotalLineCount() int {
+	return len(m.lines)
+}
+
+// VisibleLineCount returns the number of the visible lines within the viewport.
+func (m Model) VisibleLineCount() int {
+	return len(m.visibleLines())
+}
+
+// GotoTop sets the viewport to the top position.
+func (m *Model) GotoTop() (lines []string) {
+	if m.AtTop() {
+		return nil
+	}
+
+	m.SetYOffset(0)
+	return m.visibleLines()
+}
+
+// GotoBottom sets the viewport to the bottom position.
+func (m *Model) GotoBottom() (lines []string) {
+	m.SetYOffset(m.maxYOffset())
+	return m.visibleLines()
+}
+
+// Sync tells the renderer where the viewport will be located and requests
+// a render of the current state of the viewport. It should be called for the
+// first render and after a window resize.
+//
+// For high performance rendering only.
+func Sync(m Model) tea.Cmd {
+	if len(m.lines) == 0 {
+		return nil
+	}
+	top, bottom := m.scrollArea()
+	return tea.SyncScrollArea(m.visibleLines(), top, bottom)
+}
+
+// ViewDown is a high performance command that moves the viewport up by a given
+// number of lines. Use Model.ViewDown to get the lines that should be rendered.
+// For example:
+//
+//	lines := model.ViewDown(1)
+//	cmd := ViewDown(m, lines)
+func ViewDown(m Model, lines []string) tea.Cmd {
+	if len(lines) == 0 {
+		return nil
+	}
+	top, bottom := m.scrollArea()
+	return tea.ScrollDown(lines, top, bottom)
+}
+
+// ViewUp is a high performance command the moves the viewport down by a given
+// number of lines height. Use Model.ViewUp to get the lines that should be
+// rendered.
+func ViewUp(m Model, lines []string) tea.Cmd {
+	if len(lines) == 0 {
+		return nil
+	}
+	top, bottom := m.scrollArea()
+	return tea.ScrollUp(lines, top, bottom)
+}
+
+// Update handles standard message-based viewport updates.
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m, cmd = m.updateAsModel(msg)
+	return m, cmd
+}
+
+// Author's note: this method has been broken out to make it easier to
+// potentially transition Update to satisfy tea.Model.
+func (m Model) updateAsModel(msg tea.Msg) (Model, tea.Cmd) {
+	if !m.initialized {
+		m.setInitialValues()
+	}
+
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, m.KeyMap.PageDown):
+			lines := m.ViewDown()
+			if m.HighPerformanceRendering {
+				cmd = ViewDown(m, lines)
+			}
+
+		case key.Matches(msg, m.KeyMap.PageUp):
+			lines := m.ViewUp()
+			if m.HighPerformanceRendering {
+				cmd = ViewUp(m, lines)
+			}
+
+		case key.Matches(msg, m.KeyMap.HalfPageDown):
+			lines := m.HalfViewDown()
+			if m.HighPerformanceRendering {
+				cmd = ViewDown(m, lines)
+			}
+
+		case key.Matches(msg, m.KeyMap.HalfPageUp):
+			lines := m.HalfViewUp()
+			if m.HighPerformanceRendering {
+				cmd = ViewUp(m, lines)
+			}
+
+		case key.Matches(msg, m.KeyMap.Down):
+			lines := m.LineDown(1)
+			if m.HighPerformanceRendering {
+				cmd = ViewDown(m, lines)
+			}
+
+		case key.Matches(msg, m.KeyMap.Up):
+			lines := m.LineUp(1)
+			if m.HighPerformanceRendering {
+				cmd = ViewUp(m, lines)
+			}
+		}
+
+	case tea.MouseMsg:
+		if !m.MouseWheelEnabled || msg.Action != tea.MouseActionPress {
+			break
+		}
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			lines := m.LineUp(m.MouseWheelDelta)
+			if m.HighPerformanceRendering {
+				cmd = ViewUp(m, lines)
+			}
+
+		case tea.MouseButtonWheelDown:
+			lines := m.LineDown(m.MouseWheelDelta)
+			if m.HighPerformanceRendering {
+				cmd = ViewDown(m, lines)
+			}
+		}
+	}
+
+	return m, cmd
+}
+
+// View renders the viewport into a string.
+func (m Model) View() string {
+	if m.HighPerformanceRendering {
+		// Just send newlines since we're going to be rendering the actual
+		// content separately. We still need to send something that equals the
+		// height of this view so that the Bubble Tea standard renderer can
+		// position anything below this view properly.
+		return strings.Repeat("\n", max(0, m.Height-1))
+	}
+
+	w, h := m.Width, m.Height
+	if sw := m.Style.GetWidth(); sw != 0 {
+		w = min(w, sw)
+	}
+	if sh := m.Style.GetHeight(); sh != 0 {
+		h = min(h, sh)
+	}
+	contentWidth := w - m.Style.GetHorizontalFrameSize()
+	contentHeight := h - m.Style.GetVerticalFrameSize()
+	contents := lipgloss.NewStyle().
+		Width(contentWidth).      // pad to width.
+		Height(contentHeight).    // pad to height.
+		MaxHeight(contentHeight). // truncate height if taller.
+		MaxWidth(contentWidth).   // truncate width if wider.
+		Render(strings.Join(m.visibleLines(), "\n"))
+	return m.Style.Copy().
+		UnsetWidth().UnsetHeight(). // Style size already applied in contents.
+		Render(contents)
+}
+
+func clamp(v, low, high int) int {
+	if high < low {
+		low, high = high, low
+	}
+	return min(high, max(low, v))
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,6 +54,7 @@ github.com/charmbracelet/bubbles/paginator
 github.com/charmbracelet/bubbles/runeutil
 github.com/charmbracelet/bubbles/spinner
 github.com/charmbracelet/bubbles/textinput
+github.com/charmbracelet/bubbles/viewport
 # github.com/charmbracelet/bubbletea v0.25.0
 ## explicit; go 1.17
 github.com/charmbracelet/bubbletea


### PR DESCRIPTION

https://github.com/launchdarkly/ldcli/assets/55991524/fe35ac14-d33e-41b8-8d03-851176469058

Adds a viewport for displaying the SDK instructions, which should be scrollable both with up/down keys as well as a mouse wheel. 