### PR TITLE
feat: Use new sdk instructions instead of hello READMEs

### DIFF
--- a/internal/quickstart/choose_sdk.go
+++ b/internal/quickstart/choose_sdk.go
@@ -94,11 +94,12 @@ func (m chooseSDKModel) View() string {
 }
 
 type sdkDetail struct {
-	canonicalName string
-	displayName   string
-	index         int
-	kind          string
-	url           string // custom URL if it differs from the other SDKs
+	canonicalName   string
+	displayName     string
+	index           int
+	kind            string
+	url             string // custom URL if it differs from the other SDKs
+	hasInstructions bool   // to remove when we get all instructions loaded
 }
 
 func (s sdkDetail) FilterValue() string { return "" }
@@ -106,7 +107,7 @@ func (s sdkDetail) FilterValue() string { return "" }
 var SDKs = []sdkDetail{
 	// {canonicalName: "react", displayName: "React", kind: clientSideSDK},
 	{canonicalName: "node-server", displayName: "Node.js (server-side)", kind: serverSideSDK},
-	{canonicalName: "python", displayName: "Python", kind: serverSideSDK},
+	{canonicalName: "python", displayName: "Python", kind: serverSideSDK, hasInstructions: true},
 	{canonicalName: "java", displayName: "Java", kind: serverSideSDK},
 	{canonicalName: "dotnet-server", displayName: ".NET (server-side)", kind: serverSideSDK},
 	{canonicalName: "js", displayName: "JavaScript", kind: clientSideSDK},

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -88,6 +88,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.sdk.displayName,
 					m.sdk.url,
 					m.flagKey,
+					m.sdk.hasInstructions,
 				)
 				cmd = m.currentModel.Init()
 			}
@@ -103,6 +104,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			msg.sdk.displayName,
 			msg.sdk.url,
 			m.flagKey,
+			msg.sdk.hasInstructions,
 		)
 		cmd = m.currentModel.Init()
 		m.sdk = msg.sdk

--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -131,6 +132,17 @@ func sendFetchSDKInstructionsMsg(url string) tea.Cmd {
 		}
 
 		return fetchedSDKInstructions{instructions: body}
+	}
+}
+
+func sendReadSDKInstructionsMsg(filename string) tea.Cmd {
+	return func() tea.Msg {
+		content, err := os.ReadFile(fmt.Sprintf("internal/sdks/sdk_instructions/%s.md", filename))
+		if err != nil {
+			return errMsg{err: err}
+		}
+
+		return fetchedSDKInstructions{instructions: content}
 	}
 }
 

--- a/internal/sdks/sdk_instructions/python.md
+++ b/internal/sdks/sdk_instructions/python.md
@@ -25,8 +25,7 @@ from ldclient.config import Config
 
 # Create a helper function for rendering messages.
 def show_message(s):
-print("*** %s" % s)
-print()
+    print("*** {}".format(s))
 
 # Initialize the ldclient with your environment-specific SDK key.
 if __name__ == "__main__":
@@ -44,9 +43,9 @@ exit()
 context = Context.builder('example-user-key').name('Sandy').build()
 
 # Call LaunchDarkly with the feature flag key you want to evaluate.
-flag_value = ldclient.get().variation("my-new-flag", context, False)
+flag_value = ldclient.get().variation("my-flag-key", context, False)
 
-show_message("Feature flag 'my-new-flag' is %s for this user" % (flag_value))
+show_message("Feature flag 'my-flag-key' is {} for this user".format(flag_value))
 
 # Here we ensure that the SDK shuts down cleanly and has a chance to deliver analytics
 # events to LaunchDarkly before the program exits. If analytics events are not delivered,

--- a/internal/sdks/sdk_instructions/python.md
+++ b/internal/sdks/sdk_instructions/python.md
@@ -26,17 +26,18 @@ from ldclient.config import Config
 # Create a helper function for rendering messages.
 def show_message(s):
     print("*** {}".format(s))
+    print()
 
 # Initialize the ldclient with your environment-specific SDK key.
 if __name__ == "__main__":
-ldclient.set_config(Config("1234567890abcdef"))
+    ldclient.set_config(Config("1234567890abcdef"))
 
 # The SDK starts up the first time ldclient.get() is called.
 if ldclient.get().is_initialized():
-show_message("SDK successfully initialized!")
+    show_message("SDK successfully initialized!")
 else:
-show_message("SDK failed to initialize")
-exit()
+    show_message("SDK failed to initialize")
+    exit()
 
 # Set up the evaluation context. This context should appear on your LaunchDarkly contexts
 # dashboard soon after you run the demo.

--- a/internal/sdks/sdk_instructions/python.md
+++ b/internal/sdks/sdk_instructions/python.md
@@ -1,0 +1,57 @@
+# Set up your application
+
+If you want to skip ahead, the final code is available in our [GitHub repository](https://github.com/launchdarkly/hello-python).
+
+
+1. Create a new directory:
+
+```bash
+mkdir hello-python && cd hello-python
+```
+
+2. Next, create a file called `requirements.txt` with the SDK dependency and install it:
+
+```bash
+echo "launchdarkly-server-sdk==9.3.1" >> requirements.txt && pip install -r requirements.txt
+```
+
+3. Create a file called `test.py` and add the following code:
+
+```python
+# Import the LaunchDarkly client.
+import ldclient
+from ldclient import Context
+from ldclient.config import Config
+
+# Create a helper function for rendering messages.
+def show_message(s):
+print("*** %s" % s)
+print()
+
+# Initialize the ldclient with your environment-specific SDK key.
+if __name__ == "__main__":
+ldclient.set_config(Config("1234567890abcdef"))
+
+# The SDK starts up the first time ldclient.get() is called.
+if ldclient.get().is_initialized():
+show_message("SDK successfully initialized!")
+else:
+show_message("SDK failed to initialize")
+exit()
+
+# Set up the evaluation context. This context should appear on your LaunchDarkly contexts
+# dashboard soon after you run the demo.
+context = Context.builder('example-user-key').name('Sandy').build()
+
+# Call LaunchDarkly with the feature flag key you want to evaluate.
+flag_value = ldclient.get().variation("my-new-flag", context, False)
+
+show_message("Feature flag 'my-new-flag' is %s for this user" % (flag_value))
+
+# Here we ensure that the SDK shuts down cleanly and has a chance to deliver analytics
+# events to LaunchDarkly before the program exits. If analytics events are not delivered,
+# the user properties and flag usage statistics will not appear on your dashboard. In a
+# normal long-running application, the SDK would continue running and events would be
+# delivered automatically in the background.
+ldclient.get().close()
+```


### PR DESCRIPTION
Copies the instructions from the guided quickstart [here](https://github.com/launchdarkly/gonfalon/tree/main/static/ld/components/getStarted/sdk) as markdown files to render in the setup flow. Starting with just one SDK (python) to establish the pattern. 

![image](https://github.com/launchdarkly/ldcli/assets/55991524/b66046d0-cb6d-487f-b3e5-3079f574a8eb)
