### PR TITLE
fix: space above pagination dots and pagination bug

### DIFF
--- a/internal/quickstart/choose_sdk.go
+++ b/internal/quickstart/choose_sdk.go
@@ -31,7 +31,7 @@ type chooseSDKModel struct {
 }
 
 func NewChooseSDKModel(selectedIndex int) tea.Model {
-	l := list.New(sdksToItems(), sdkDelegate{}, 30, 14)
+	l := list.New(sdksToItems(), sdkDelegate{}, 20, 9)
 	l.Title = "Select your SDK:\n"
 	// reset title styles
 	l.Styles.Title = lipgloss.NewStyle()
@@ -40,7 +40,6 @@ func NewChooseSDKModel(selectedIndex int) tea.Model {
 	l.SetShowPagination(true)
 	l.SetShowStatusBar(false)
 	l.SetFilteringEnabled(false) // TODO: try to get filtering working
-	l.Paginator.PerPage = 5
 
 	return chooseSDKModel{
 		help: help.New(),

--- a/internal/quickstart/choose_sdk.go
+++ b/internal/quickstart/choose_sdk.go
@@ -31,7 +31,7 @@ type chooseSDKModel struct {
 }
 
 func NewChooseSDKModel(selectedIndex int) tea.Model {
-	l := list.New(sdksToItems(), sdkDelegate{}, 20, 9)
+	l := list.New(sdksToItems(), sdkDelegate{}, 30, 9)
 	l.Title = "Select your SDK:\n"
 	// reset title styles
 	l.Styles.Title = lipgloss.NewStyle()


### PR DESCRIPTION
I removed the extra space between the choose sdk list and the pagination dots.
![CleanShot 2024-04-09 at 15 56 58@2x](https://github.com/launchdarkly/ldcli/assets/58448919/cc7a562f-8389-46fa-bea9-9bc826bf3f5a)


bug fix: we were only showing 15 items total. This was due to setting pagination.PerPage manually to 5. We can't manually control this property without bugs due to how list.updatePagination() works. Setting the list height to 9 shows us 5 items, and displays all 24-25 items.

video: https://share.cleanshot.com/bs9YgdBF