### PR TITLE
fix: remove mouse wheel support from show sdk & show scroll options in help view

### DIFF
--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -114,7 +114,6 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.flagKey = msg.flag.key
 		m.currentStep += 1
 		m.err = nil
-		cmd = sendEnableMouseCellMotionMsg()
 	case errMsg:
 		m.currentModel, cmd = m.currentModel.Update(msg)
 	case noInstructionsMsg:
@@ -127,7 +126,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sdk.kind,
 		)
 		m.currentStep += 1
-	case fetchedSDKInstructions, fetchedEnv, selectedSDKMsg, toggledFlagMsg, spinner.TickMsg, createdFlagMsg, tea.MouseMsg:
+	case fetchedSDKInstructions, fetchedEnv, selectedSDKMsg, toggledFlagMsg, spinner.TickMsg, createdFlagMsg:
 		m.currentModel, cmd = m.currentModel.Update(msg)
 		m.err = nil
 	case showToggleFlagMsg:

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -94,8 +94,6 @@ func (m showSDKInstructionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			m.viewport, cmd = m.viewport.Update(msg)
 		}
-	case tea.MouseMsg:
-		m.viewport, cmd = m.viewport.Update(msg)
 	case fetchedSDKInstructions:
 		m.instructions = sdks.ReplaceFlagKey(string(msg.instructions), m.flagKey)
 	case fetchedEnv:
@@ -117,9 +115,7 @@ func (m showSDKInstructionsModel) View() string {
 	if m.instructions == "" || m.sdkKey == "" {
 		return m.spinner.View() + fmt.Sprintf(" Fetching %s SDK instructions...", m.displayName)
 	}
-
 	instructions := fmt.Sprintf("Set up your application in your Default project & Test environment.\n\nHere are the steps to incorporate the LaunchDarkly %s SDK into your code. You should have everything you need to get started, including the flag from the previous step and your SDK key from your Test environment already embedded in the code!\n", m.displayName)
-
 	return instructions + m.viewport.View() + "\n(press enter to continue)" + footerView(m.help.View(m.helpKeys), nil)
 }
 

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -51,16 +51,21 @@ func NewShowSDKInstructionsModel(
 		BorderForeground(lipgloss.Color("62")).
 		PaddingRight(2)
 
+	h := help.New()
+	h.ShowAll = true
+
 	return showSDKInstructionsModel{
 		accessToken:   accessToken,
 		baseUri:       baseUri,
 		canonicalName: canonicalName,
 		displayName:   displayName,
 		flagKey:       flagKey,
-		help:          help.New(),
+		help:          h,
 		helpKeys: keyMap{
-			Back: BindingBack,
-			Quit: BindingQuit,
+			Back:       BindingBack,
+			CursorDown: BindingCursorDown,
+			CursorUp:   BindingCursorUp,
+			Quit:       BindingQuit,
 		},
 		spinner:             s,
 		url:                 url,


### PR DESCRIPTION
Removes mouse wheel support from the viewport, because with this enabled we're unable to highlight the text within to copy/paste (which is kinda the whole point of it). 

![image](https://github.com/launchdarkly/ldcli/assets/55991524/eb75db86-0e8a-426d-83a6-13d026333981)
