### PR TITLE
fix: remove side borders from show SDK viewport

### DIFF
--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -114,7 +114,6 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.flagKey = msg.flag.key
 		m.currentStep += 1
 		m.err = nil
-		cmd = sendEnableMouseCellMotionMsg()
 	case errMsg:
 		m.currentModel, cmd = m.currentModel.Update(msg)
 	case noInstructionsMsg:
@@ -127,7 +126,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sdk.kind,
 		)
 		m.currentStep += 1
-	case fetchedSDKInstructions, fetchedEnv, selectedSDKMsg, toggledFlagMsg, spinner.TickMsg, createdFlagMsg, tea.MouseMsg:
+	case fetchedSDKInstructions, fetchedEnv, selectedSDKMsg, toggledFlagMsg, spinner.TickMsg, createdFlagMsg:
 		m.currentModel, cmd = m.currentModel.Update(msg)
 		m.err = nil
 	case showToggleFlagMsg:

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -94,8 +94,6 @@ func (m showSDKInstructionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			m.viewport, cmd = m.viewport.Update(msg)
 		}
-	case tea.MouseMsg:
-		m.viewport, cmd = m.viewport.Update(msg)
 	case fetchedSDKInstructions:
 		m.instructions = sdks.ReplaceFlagKey(string(msg.instructions), m.flagKey)
 	case fetchedEnv:
@@ -117,9 +115,7 @@ func (m showSDKInstructionsModel) View() string {
 	if m.instructions == "" || m.sdkKey == "" {
 		return m.spinner.View() + fmt.Sprintf(" Fetching %s SDK instructions...", m.displayName)
 	}
-
 	instructions := fmt.Sprintf("Set up your application in your Default project & Test environment.\n\nHere are the steps to incorporate the LaunchDarkly %s SDK into your code. You should have everything you need to get started, including the flag from the previous step and your SDK key from your Test environment already embedded in the code!\n", m.displayName)
-
 	return instructions + m.viewport.View() + "\n(press enter to continue)" + footerView(m.help.View(m.helpKeys), nil)
 }
 

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -47,8 +47,10 @@ func NewShowSDKInstructionsModel(
 
 	vp := viewport.New(viewportWidth, viewportHeight)
 	vp.Style = lipgloss.NewStyle().
-		BorderStyle(lipgloss.RoundedBorder()).
+		BorderStyle(lipgloss.ThickBorder()).
 		BorderForeground(lipgloss.Color("62")).
+		BorderTop(true).
+		BorderBottom(true).
 		PaddingRight(2)
 
 	h := help.New()

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -51,16 +51,21 @@ func NewShowSDKInstructionsModel(
 		BorderForeground(lipgloss.Color("62")).
 		PaddingRight(2)
 
+	h := help.New()
+	h.ShowAll = true
+
 	return showSDKInstructionsModel{
 		accessToken:   accessToken,
 		baseUri:       baseUri,
 		canonicalName: canonicalName,
 		displayName:   displayName,
 		flagKey:       flagKey,
-		help:          help.New(),
+		help:          h,
 		helpKeys: keyMap{
-			Back: BindingBack,
-			Quit: BindingQuit,
+			Back:       BindingBack,
+			CursorDown: BindingCursorDown,
+			CursorUp:   BindingCursorUp,
+			Quit:       BindingQuit,
 		},
 		spinner:             s,
 		url:                 url,


### PR DESCRIPTION
I noticed that when copy/pasting the sdk instructions with a border for the viewport, we end up with something like this on the clipboard: 
```
│  3. Create a file called  test.py  and add the following code:                 │
│                                                                                │
│    # Import the LaunchDarkly client.                                           │
│    import ldclient                                                             │
│    from ldclient import Context                                                │
│    from ldclient.config import Config                                          │
│                                                                                │
│    # Create a helper function for rendering messages.                          │
│    def show_message(s):                                                        │
│        print("*** {}".format(s))                                               │
│        print()                                                                 │
```

My proposed solution is to remove the side borders - with the additional help keys at the bottom it should hopefully be clear that the text is scrollable, but open to opinions. 

![borders](https://github.com/launchdarkly/ldcli/assets/55991524/4280c247-569f-4985-9f33-9a2e35c87e9a)


An alternative would be to use a `HiddenBackground` with a `BorderBackground` color, which would look something like this: 
![image](https://github.com/launchdarkly/ldcli/assets/55991524/38ba21e8-88da-42ff-9492-260da4da7c48)