### PR TITLE
chore: don't refetch envs when going back from show sdk step

### DIFF
--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -33,6 +33,7 @@ type ContainerModel struct {
 	baseUri            string
 	currentModel       tea.Model
 	currentStep        int
+	envKeys            *envKeys
 	environmentsClient environments.Client
 	err                error
 	flagKey            string
@@ -100,6 +101,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.sdk.url,
 					m.flagKey,
 					m.sdk.hasInstructions,
+					m.envKeys,
 				)
 				cmd = m.currentModel.Init()
 			}
@@ -117,6 +119,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			msg.sdk.url,
 			m.flagKey,
 			msg.sdk.hasInstructions,
+			nil,
 		)
 		cmd = m.currentModel.Init()
 		m.sdk = msg.sdk
@@ -138,7 +141,11 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sdk.kind,
 		)
 		m.currentStep += 1
-	case fetchedSDKInstructionsMsg, fetchedEnvMsg, selectedSDKMsg, toggledFlagMsg, spinner.TickMsg, createdFlagMsg:
+	case fetchedEnvMsg:
+		m.envKeys = &msg.envKeys
+		m.currentModel, cmd = m.currentModel.Update(msg)
+		m.err = nil
+	case fetchedSDKInstructionsMsg, selectedSDKMsg, toggledFlagMsg, spinner.TickMsg, createdFlagMsg:
 		m.gettingStarted = false
 		m.currentModel, cmd = m.currentModel.Update(msg)
 		m.err = nil

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -33,7 +33,7 @@ type ContainerModel struct {
 	baseUri            string
 	currentModel       tea.Model
 	currentStep        int
-	envKeys            *envKeys
+	envKeys            *environment
 	environmentsClient environments.Client
 	err                error
 	flagKey            string

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -119,7 +119,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			msg.sdk.url,
 			m.flagKey,
 			msg.sdk.hasInstructions,
-			nil,
+			m.envKeys,
 		)
 		cmd = m.currentModel.Init()
 		m.sdk = msg.sdk

--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 
@@ -155,8 +156,7 @@ func showToggleFlag() tea.Cmd {
 }
 
 type fetchedEnvMsg struct {
-	clientSideID string
-	sdkKey       string
+	envKeys envKeys
 }
 
 func fetchEnv(
@@ -181,7 +181,13 @@ func fetchEnv(
 			return errMsg{err: err}
 		}
 
-		return fetchedEnvMsg{clientSideID: resp.ClientSideId, sdkKey: resp.SDKKey}
+		log.Print("here we are", resp)
+
+		return fetchedEnvMsg{envKeys: envKeys{
+			sdkKey:       resp.SDKKey,
+			mobileKey:    "", //TODO: add in when main merged
+			clientSideId: resp.ClientSideId,
+		}}
 	}
 }
 

--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 
@@ -180,8 +179,6 @@ func fetchEnv(
 		if err != nil {
 			return errMsg{err: err}
 		}
-
-		log.Print("here we are", resp)
 
 		return fetchedEnvMsg{envKeys: envKeys{
 			sdkKey:       resp.SDKKey,

--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -155,7 +155,7 @@ func showToggleFlag() tea.Cmd {
 }
 
 type fetchedEnvMsg struct {
-	envKeys envKeys
+	envKeys environment
 }
 
 func fetchEnv(
@@ -180,7 +180,7 @@ func fetchEnv(
 			return errMsg{err: err}
 		}
 
-		return fetchedEnvMsg{envKeys: envKeys{
+		return fetchedEnvMsg{envKeys: environment{
 			sdkKey:       resp.SDKKey,
 			mobileKey:    "", //TODO: add in when main merged
 			clientSideId: resp.ClientSideId,

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -37,7 +37,6 @@ type showSDKInstructionsModel struct {
 	help                help.Model
 	helpKeys            keyMap
 	instructions        string
-	sdkKey              string
 	spinner             spinner.Model
 	url                 string
 	viewport            viewport.Model

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -19,7 +19,7 @@ const (
 	viewportHeight = 30
 )
 
-type envKeys struct {
+type environment struct {
 	sdkKey       string
 	mobileKey    string
 	clientSideId string
@@ -30,7 +30,7 @@ type showSDKInstructionsModel struct {
 	baseUri             string
 	canonicalName       string
 	displayName         string
-	envKeys             *envKeys
+	envKeys             *environment
 	environmentsClient  environments.Client
 	flagKey             string
 	hasInstructionsFile bool // TODO: remove when we have all instructions saved
@@ -51,7 +51,7 @@ func NewShowSDKInstructionsModel(
 	url string,
 	flagKey string,
 	hasInstructionsFile bool,
-	envKeys *envKeys,
+	envKeys *environment,
 ) tea.Model {
 	s := spinner.New()
 	s.Spinner = spinner.Points


### PR DESCRIPTION
no need to refetch the env when re-choosing a new SDK when we already have the keys! this makes the loading of sdk steps a lot quicker if you're checking out a bunch of different sdks and going back and forth between steps