### PR TITLE
fix: embed instructions files & show error during show sdk step

### DIFF
--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"ldcli/internal/environments"
 	"ldcli/internal/errors"
 	"ldcli/internal/flags"
+	"ldcli/internal/sdks"
 )
 
 // errMsg is sent when there is an error in one of the steps that the container model needs to
@@ -114,7 +114,7 @@ func chooseSDK(sdk sdkDetail) tea.Cmd {
 
 func readSDKInstructions(filename string) tea.Cmd {
 	return func() tea.Msg {
-		content, err := os.ReadFile(fmt.Sprintf("internal/sdks/sdk_instructions/%s.md", filename))
+		content, err := sdks.InstructionFiles.ReadFile(fmt.Sprintf("sdk_instructions/%s.md", filename))
 		if err != nil {
 			return errMsg{err: err}
 		}

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -2,6 +2,7 @@ package quickstart
 
 import (
 	"fmt"
+
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -9,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
+
 	"ldcli/internal/environments"
 	"ldcli/internal/sdks"
 )

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -137,9 +137,15 @@ func (m showSDKInstructionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m showSDKInstructionsModel) View() string {
-	if m.instructions == "" || m.environment == nil {
-		return m.spinner.View() + fmt.Sprintf(" Fetching %s SDK instructions...\n", m.displayName) + footerView(m.help.View(m.helpKeys), m.err)
+	if m.err != nil {
+		m.help.ShowAll = false
+		return footerView(m.help.View(m.helpKeys), m.err)
 	}
+
+	if m.instructions == "" || m.environment == nil {
+		return m.spinner.View() + fmt.Sprintf(" Fetching %s SDK instructions...\n", m.displayName) + footerView(m.help.View(m.helpKeys), nil)
+	}
+
 	instructions := fmt.Sprintf(`
 Here are the steps to set up a test app to see feature flagging in action
 using the %s SDK in your Default project & Test environment.

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -9,7 +9,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
-
 	"ldcli/internal/environments"
 	"ldcli/internal/sdks"
 )
@@ -32,6 +31,7 @@ type showSDKInstructionsModel struct {
 	displayName        string
 	environment        *environment
 	environmentsClient environments.Client
+	err                error
 	flagKey            string
 	help               help.Model
 	helpKeys           keyMap
@@ -129,6 +129,8 @@ func (m showSDKInstructionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.viewport.SetContent(md)
 	case spinner.TickMsg:
 		m.spinner, cmd = m.spinner.Update(msg)
+	case errMsg:
+		m.err = msg.err
 	}
 
 	return m, cmd
@@ -136,7 +138,7 @@ func (m showSDKInstructionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m showSDKInstructionsModel) View() string {
 	if m.instructions == "" || m.environment == nil {
-		return m.spinner.View() + fmt.Sprintf(" Fetching %s SDK instructions...", m.displayName)
+		return m.spinner.View() + fmt.Sprintf(" Fetching %s SDK instructions...\n", m.displayName) + footerView(m.help.View(m.helpKeys), m.err)
 	}
 	instructions := fmt.Sprintf(`
 Here are the steps to set up a test app to see feature flagging in action

--- a/internal/sdks/sdks.go
+++ b/internal/sdks/sdks.go
@@ -1,9 +1,13 @@
 package sdks
 
 import (
+	"embed"
 	"regexp"
 	"strings"
 )
+
+//go:embed sdk_instructions/*.md
+var InstructionFiles embed.FS
 
 // ReplaceFlagKey changes the placeholder flag key in the SDK instructions to the flag key from
 // the user.


### PR DESCRIPTION
The new instruction files weren't readable from the binary, so now we are embedding them! 

Also this error was getting swallowed, resulting in an infinite spinner, so if something goes wrong with reading the file (or fetching the env) we'll now surface that too. 

![image](https://github.com/launchdarkly/ldcli/assets/55991524/8f05e001-7ef0-415b-9ff4-f9a1b02efe7c)
