### PR TITLE
feat: add config set flag

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -80,8 +80,19 @@ func run() func(*cobra.Command, []string) error {
 			}
 
 			return writeConfig(config.NewConfig(rawConfig), v, setKeyFn)
-		case viper.GetBool(UnsetFlag):
-			fmt.Fprintln(cmd.OutOrStdout(), "called --unset flag")
+		case viper.IsSet(UnsetFlag):
+			config, v, err := getConfig()
+			if err != nil {
+				return err
+			}
+
+			unsetKeyFn := func(key string, value interface{}, v *viper.Viper) {
+				if key != viper.GetString("unset") {
+					v.Set(key, value)
+				}
+			}
+
+			return writeConfig(config, v, unsetKeyFn)
 		}
 
 		return nil

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -54,7 +55,31 @@ func run() func(*cobra.Command, []string) error {
 
 			fmt.Fprint(cmd.OutOrStdout(), string(configJSON)+"\n")
 		case viper.GetBool(SetFlag):
-			fmt.Fprintln(cmd.OutOrStdout(), "called --set flag")
+			// flag needs two arguments: a key and value
+			if len(args)%2 != 0 {
+				return errors.New("flag needs an argument: --set")
+			}
+
+			rawConfig, v, err := getRawConfig()
+			if err != nil {
+				return err
+			}
+
+			// add arg pairs to config
+			// where each argument is --set arg1 val1 --set arg2 val2
+			for i, a := range args {
+				if i%2 == 0 {
+					rawConfig[a] = struct{}{}
+				} else {
+					rawConfig[args[i-1]] = a
+				}
+			}
+
+			setKeyFn := func(key string, value interface{}, v *viper.Viper) {
+				v.Set(key, value)
+			}
+
+			return writeConfig(config.NewConfig(rawConfig), v, setKeyFn)
 		case viper.GetBool(UnsetFlag):
 			fmt.Fprintln(cmd.OutOrStdout(), "called --unset flag")
 		}
@@ -84,6 +109,27 @@ func getConfig() (config.ConfigFile, *viper.Viper, error) {
 	return c, v, nil
 }
 
+// getRawConfig builds a map of the values in the config file.
+func getRawConfig() (map[string]interface{}, *viper.Viper, error) {
+	v, err := getViperWithConfigFile()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	data, err := os.ReadFile(v.ConfigFileUsed())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	config := make(map[string]interface{}, 0)
+	err = yaml.Unmarshal([]byte(data), &config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return config, v, nil
+}
+
 // getViperWithConfigFile ensures the viper instance has a config file written to the filesystem.
 // We want to write the file when someone runs a config command.
 func getViperWithConfigFile() (*viper.Viper, error) {
@@ -104,4 +150,37 @@ func getViperWithConfigFile() (*viper.Viper, error) {
 	}
 
 	return v, nil
+}
+
+// writeConfig writes the values in config to the config file based on the filter function.
+func writeConfig(
+	conf config.ConfigFile,
+	v *viper.Viper,
+	filterFn func(key string, value interface{}, v *viper.Viper),
+) error {
+	// create a new viper instance since the existing one has the command name and flags already set,
+	// and these will get written to the config file.
+	newViper := viper.New()
+	newViper.SetConfigFile(v.ConfigFileUsed())
+
+	configYAML, err := yaml.Marshal(conf)
+	if err != nil {
+		return err
+	}
+	rawConfig := make(map[string]interface{})
+	err = yaml.Unmarshal(configYAML, &rawConfig)
+	if err != nil {
+		return err
+	}
+
+	for key, value := range rawConfig {
+		filterFn(key, value, newViper)
+	}
+
+	err = newViper.WriteConfig()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ func GetConfigPath() string {
 		}
 		configPath = filepath.Join(home, ".config")
 	}
+
 	return filepath.Join(configPath, "ldcli")
 }
 


### PR DESCRIPTION
The set flag takes a key/value pair and writes them to the config file if they are relevant. It ignores arbitrary keys and for now only supports:

* access-token
* base-uri

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
