### PR TITLE
feat: add config unset flag

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -80,8 +80,19 @@ func run() func(*cobra.Command, []string) error {
 			}
 
 			return writeConfig(config.NewConfig(rawConfig), v, setKeyFn)
-		case viper.GetBool(UnsetFlag):
-			fmt.Fprintln(cmd.OutOrStdout(), "called --unset flag")
+		case viper.IsSet(UnsetFlag):
+			config, v, err := getConfig()
+			if err != nil {
+				return err
+			}
+
+			unsetKeyFn := func(key string, value interface{}, v *viper.Viper) {
+				if key != viper.GetString("unset") {
+					v.Set(key, value)
+				}
+			}
+
+			return writeConfig(config, v, unsetKeyFn)
 		}
 
 		return nil


### PR DESCRIPTION
The unset flag takes a value removes it from the config file if it is relevant. It ignores arbitrary keys and for now only supports:

* access-token
* base-uri

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
