### PR TITLE
feat: add get subcommand to flag

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -17,6 +17,10 @@ func NewFlagsCmd(client flags.Client) (*cobra.Command, error) {
 	if err != nil {
 		return nil, err
 	}
+	getCmd, err := NewGetCmd(client)
+	if err != nil {
+		return nil, err
+	}
 	updateCmd, err := NewUpdateCmd(client)
 	if err != nil {
 		return nil, err
@@ -32,6 +36,7 @@ func NewFlagsCmd(client flags.Client) (*cobra.Command, error) {
 	}
 
 	cmd.AddCommand(createCmd)
+	cmd.AddCommand(getCmd)
 	cmd.AddCommand(updateCmd)
 	cmd.AddCommand(toggleOnUpdateCmd)
 	cmd.AddCommand(toggleOffUpdateCmd)

--- a/cmd/flags/get.go
+++ b/cmd/flags/get.go
@@ -61,7 +61,7 @@ func runGet(client flags.Client) func(*cobra.Command, []string) error {
 		_ = viper.BindPFlag(cliflags.ProjectFlag, cmd.Flags().Lookup(cliflags.ProjectFlag))
 		_ = viper.BindPFlag(cliflags.EnvironmentFlag, cmd.Flags().Lookup(cliflags.EnvironmentFlag))
 
-		response, err := client.Read(
+		response, err := client.Get(
 			context.Background(),
 			viper.GetString(cliflags.AccessTokenFlag),
 			viper.GetString(cliflags.BaseURIFlag),

--- a/cmd/flags/get.go
+++ b/cmd/flags/get.go
@@ -1,0 +1,80 @@
+package flags
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"ldcli/cmd/cliflags"
+	"ldcli/cmd/validators"
+	"ldcli/internal/flags"
+)
+
+func NewGetCmd(client flags.Client) (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Args:  validators.Validate(),
+		Long:  "Get a flag to check its details",
+		RunE:  runGet(client),
+		Short: "Get a flag",
+		Use:   "get",
+	}
+
+	cmd.Flags().StringP(cliflags.FlagFlag, "", "", "Flag key")
+	err := cmd.MarkFlagRequired(cliflags.FlagFlag)
+	if err != nil {
+		return nil, err
+	}
+	err = viper.BindPFlag(cliflags.FlagFlag, cmd.Flags().Lookup(cliflags.FlagFlag))
+	if err != nil {
+		return nil, err
+	}
+
+	cmd.Flags().String(cliflags.ProjectFlag, "", "Project key")
+	err = cmd.MarkFlagRequired(cliflags.ProjectFlag)
+	if err != nil {
+		return nil, err
+	}
+	err = viper.BindPFlag(cliflags.ProjectFlag, cmd.Flags().Lookup(cliflags.ProjectFlag))
+	if err != nil {
+		return nil, err
+	}
+
+	cmd.Flags().String(cliflags.EnvironmentFlag, "", "Environment key")
+	err = cmd.MarkFlagRequired(cliflags.EnvironmentFlag)
+	if err != nil {
+		return nil, err
+	}
+	err = viper.BindPFlag(cliflags.EnvironmentFlag, cmd.Flags().Lookup(cliflags.EnvironmentFlag))
+	if err != nil {
+		return nil, err
+	}
+
+	return cmd, nil
+}
+
+func runGet(client flags.Client) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		// rebind flags used in other subcommands
+		_ = viper.BindPFlag(cliflags.FlagFlag, cmd.Flags().Lookup(cliflags.FlagFlag))
+		_ = viper.BindPFlag(cliflags.ProjectFlag, cmd.Flags().Lookup(cliflags.ProjectFlag))
+		_ = viper.BindPFlag(cliflags.EnvironmentFlag, cmd.Flags().Lookup(cliflags.EnvironmentFlag))
+
+		response, err := client.Read(
+			context.Background(),
+			viper.GetString(cliflags.AccessTokenFlag),
+			viper.GetString(cliflags.BaseURIFlag),
+			viper.GetString(cliflags.FlagFlag),
+			viper.GetString(cliflags.ProjectFlag),
+			viper.GetString(cliflags.EnvironmentFlag),
+		)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), string(response)+"\n")
+
+		return nil
+	}
+}

--- a/cmd/flags/get.go
+++ b/cmd/flags/get.go
@@ -21,7 +21,7 @@ func NewGetCmd(client flags.Client) (*cobra.Command, error) {
 		Use:   "get",
 	}
 
-	cmd.Flags().StringP(cliflags.FlagFlag, "", "", "Flag key")
+	cmd.Flags().String(cliflags.FlagFlag, "", "Flag key")
 	err := cmd.MarkFlagRequired(cliflags.FlagFlag)
 	if err != nil {
 		return nil, err

--- a/cmd/flags/get_test.go
+++ b/cmd/flags/get_test.go
@@ -23,7 +23,7 @@ func TestGet(t *testing.T) {
 	t.Run("with valid flags calls API", func(t *testing.T) {
 		client := flags.MockClient{}
 		client.
-			On("Read", mockArgs...).
+			On("Get", mockArgs...).
 			Return([]byte(cmd.ValidResponse), nil)
 		args := []string{
 			"flags", "get",
@@ -45,7 +45,7 @@ func TestGet(t *testing.T) {
 		defer teardownTest(t)
 		client := flags.MockClient{}
 		client.
-			On("Read", mockArgs...).
+			On("Get", mockArgs...).
 			Return([]byte(cmd.ValidResponse), nil)
 		args := []string{
 			"flags", "get",
@@ -63,7 +63,7 @@ func TestGet(t *testing.T) {
 	t.Run("with an error response is an error", func(t *testing.T) {
 		client := flags.MockClient{}
 		client.
-			On("Read", mockArgs...).
+			On("Get", mockArgs...).
 			Return([]byte(`{}`), errors.NewError("An error"))
 		args := []string{
 			"flags", "get",

--- a/cmd/flags/get_test.go
+++ b/cmd/flags/get_test.go
@@ -1,0 +1,91 @@
+package flags_test
+
+import (
+	"ldcli/cmd"
+	"ldcli/internal/errors"
+	"ldcli/internal/flags"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGet(t *testing.T) {
+	errorHelp := ". See `ldcli flags get --help` for supported flags and usage."
+	mockArgs := []interface{}{
+		"testAccessToken",
+		"http://test.com",
+		"test-key",
+		"test-proj-key",
+		"test-env-key",
+	}
+
+	t.Run("with valid flags calls API", func(t *testing.T) {
+		client := flags.MockClient{}
+		client.
+			On("Read", mockArgs...).
+			Return([]byte(cmd.ValidResponse), nil)
+		args := []string{
+			"flags", "get",
+			"--access-token", "testAccessToken",
+			"--base-uri", "http://test.com",
+			"--flag", "test-key",
+			"--project", "test-proj-key",
+			"--environment", "test-env-key",
+		}
+
+		output, err := cmd.CallCmd(t, nil, &client, nil, nil, args)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"valid": true}`, string(output))
+	})
+
+	t.Run("with valid flags from environment variables calls API", func(t *testing.T) {
+		teardownTest := cmd.SetupTestEnvVars(t)
+		defer teardownTest(t)
+		client := flags.MockClient{}
+		client.
+			On("Read", mockArgs...).
+			Return([]byte(cmd.ValidResponse), nil)
+		args := []string{
+			"flags", "get",
+			"--flag", "test-key",
+			"--project", "test-proj-key",
+			"--environment", "test-env-key",
+		}
+
+		output, err := cmd.CallCmd(t, nil, &client, nil, nil, args)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"valid": true}`, string(output))
+	})
+
+	t.Run("with an error response is an error", func(t *testing.T) {
+		client := flags.MockClient{}
+		client.
+			On("Read", mockArgs...).
+			Return([]byte(`{}`), errors.NewError("An error"))
+		args := []string{
+			"flags", "get",
+			"--access-token", "testAccessToken",
+			"--base-uri", "http://test.com",
+			"--flag", "test-key",
+			"--project", "test-proj-key",
+			"--environment", "test-env-key",
+		}
+
+		_, err := cmd.CallCmd(t, nil, &client, nil, nil, args)
+
+		require.EqualError(t, err, "An error")
+	})
+
+	t.Run("with missing required flags is an error", func(t *testing.T) {
+		args := []string{
+			"flags", "get",
+		}
+
+		_, err := cmd.CallCmd(t, nil, &flags.MockClient{}, nil, nil, args)
+
+		assert.EqualError(t, err, `required flag(s) "access-token", "environment", "flag", "project" not set`+errorHelp)
+	})
+}

--- a/cmd/flags/get_test.go
+++ b/cmd/flags/get_test.go
@@ -88,4 +88,19 @@ func TestGet(t *testing.T) {
 
 		assert.EqualError(t, err, `required flag(s) "access-token", "environment", "flag", "project" not set`+errorHelp)
 	})
+
+	t.Run("with invalid base-uri is an error", func(t *testing.T) {
+		args := []string{
+			"flags", "get",
+			"--access-token", "testAccessToken",
+			"--base-uri", "invalid",
+			"--flag", "test-key",
+			"--project", "test-proj-key",
+			"--environment", "test-env-key",
+		}
+
+		_, err := cmd.CallCmd(t, nil, &flags.MockClient{}, nil, nil, args)
+
+		assert.EqualError(t, err, "base-uri is invalid"+errorHelp)
+	})
 }

--- a/internal/flags/client.go
+++ b/internal/flags/client.go
@@ -19,6 +19,7 @@ type UpdateInput struct {
 
 type Client interface {
 	Create(ctx context.Context, accessToken, baseURI, name, key, projKey string) ([]byte, error)
+	Read(ctx context.Context, accessToken, baseURI, key, projKey, envKey string) ([]byte, error)
 	Update(
 		ctx context.Context,
 		accessToken,
@@ -54,7 +55,28 @@ func (c FlagsClient) Create(
 	flag, _, err := client.FeatureFlagsApi.PostFeatureFlag(ctx, projectKey).FeatureFlagBody(*post).Execute()
 	if err != nil {
 		return nil, errors.NewLDAPIError(err)
+	}
 
+	responseJSON, err := json.Marshal(flag)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseJSON, nil
+}
+
+func (c FlagsClient) Read(
+	ctx context.Context,
+	accessToken,
+	baseURI,
+	key,
+	projectKey,
+	environmentKey string,
+) ([]byte, error) {
+	client := client.New(accessToken, baseURI, c.cliVersion)
+	flag, _, err := client.FeatureFlagsApi.GetFeatureFlag(ctx, projectKey, key).Env(environmentKey).Execute()
+	if err != nil {
+		return nil, errors.NewLDAPIError(err)
 	}
 
 	responseJSON, err := json.Marshal(flag)

--- a/internal/flags/client.go
+++ b/internal/flags/client.go
@@ -19,7 +19,7 @@ type UpdateInput struct {
 
 type Client interface {
 	Create(ctx context.Context, accessToken, baseURI, name, key, projKey string) ([]byte, error)
-	Read(ctx context.Context, accessToken, baseURI, key, projKey, envKey string) ([]byte, error)
+	Get(ctx context.Context, accessToken, baseURI, key, projKey, envKey string) ([]byte, error)
 	Update(
 		ctx context.Context,
 		accessToken,
@@ -65,7 +65,7 @@ func (c FlagsClient) Create(
 	return responseJSON, nil
 }
 
-func (c FlagsClient) Read(
+func (c FlagsClient) Get(
 	ctx context.Context,
 	accessToken,
 	baseURI,

--- a/internal/flags/mock_client.go
+++ b/internal/flags/mock_client.go
@@ -25,7 +25,7 @@ func (c *MockClient) Create(
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-func (c *MockClient) Read(
+func (c *MockClient) Get(
 	ctx context.Context,
 	accessToken,
 	baseURI,

--- a/internal/flags/mock_client.go
+++ b/internal/flags/mock_client.go
@@ -25,6 +25,19 @@ func (c *MockClient) Create(
 	return args.Get(0).([]byte), args.Error(1)
 }
 
+func (c *MockClient) Read(
+	ctx context.Context,
+	accessToken,
+	baseURI,
+	key,
+	projKey,
+	envKey string,
+) ([]byte, error) {
+	args := c.Called(accessToken, baseURI, key, projKey, envKey)
+
+	return args.Get(0).([]byte), args.Error(1)
+}
+
 func (c *MockClient) Update(
 	ctx context.Context,
 	accessToken,


### PR DESCRIPTION
example command on staging: `go run main.go flags get --project=very-important-project --environment=production --flag=sunny-test-flag-7`

GIF: 
![CleanShot 2024-04-15 at 15 13 14](https://github.com/launchdarkly/ldcli/assets/58448919/d29b1ee7-e759-4f19-86cd-c34236723b25)

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
