### PR TITLE
fix: Change config file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ LaunchDarkly CLI commands
 - `setup` guides you through creating your first flag, connecting an SDK, and evaluating your flag in your Test environment
 
 ### Resource Commands
+
 Resource commands mirror the LaunchDarkly API and make requests for a given resource. To see a full list of resources supported by the CLI, enter `ldcli --help` into your terminal, and to see the commands available for a given resource
 
 To see the commands available for a given resource:
@@ -52,6 +53,7 @@ _(coming soon!)_
 
 [//]: # (TODO: add info about how to opt out)
 
+Running `ldcli config --set access-token {your access token}` will create a configuration file located at `$HOME/.ldcli-config.yml` with the access token. Further commands will read from this file so you do not need to specify the access token each time.
 
 ## Contributing
 
@@ -59,7 +61,7 @@ We encourage pull requests and other contributions from the community. Check out
 
 ## Verifying build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](./PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](./PROVENANCE.md).
 
 ## About LaunchDarkly
 

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -53,6 +53,10 @@ func run() func(*cobra.Command, []string) error {
 				return err
 			}
 
+			if string(configJSON) == "{}" {
+				return nil
+			}
+
 			fmt.Fprint(cmd.OutOrStdout(), string(configJSON)+"\n")
 		case viper.GetBool(SetFlag):
 			// flag needs two arguments: a key and value
@@ -146,18 +150,14 @@ func getRawConfig() (map[string]interface{}, *viper.Viper, error) {
 func getViperWithConfigFile() (*viper.Viper, error) {
 	v := viper.GetViper()
 	if err := v.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			newViper := viper.New()
-			newViper.SetConfigFile(config.GetConfigFile())
-			err = newViper.WriteConfigAs(config.GetConfigFile())
-			if err != nil {
-				return nil, err
-			}
-
-			return newViper, nil
+		newViper := viper.New()
+		newViper.SetConfigFile(config.GetConfigFile())
+		err = newViper.WriteConfig()
+		if err != nil {
+			return nil, err
 		}
 
-		return nil, err
+		return newViper, nil
 	}
 
 	return v, nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,10 +60,7 @@ func NewRootCommand(
 	}
 
 	if useConfigFile {
-		err := setFlagsFromConfig()
-		if err != nil {
-			return nil, err
-		}
+		setFlagsFromConfig()
 	}
 
 	viper.SetEnvPrefix("LD")
@@ -143,18 +140,7 @@ func Execute(analyticsTracker analytics.Tracker, version string) {
 }
 
 // setFlagsFromConfig reads in the config file if it exists and uses any flag values for commands.
-func setFlagsFromConfig() error {
-	viper.AddConfigPath(config.GetConfigPath())
-	viper.SetConfigType("yml")
-	viper.SetConfigName("config")
-
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			// ignore if file not found
-		} else {
-			return err
-		}
-	}
-
-	return nil
+func setFlagsFromConfig() {
+	viper.SetConfigFile(config.GetConfigFile())
+	_ = viper.ReadInConfig()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,15 +2,13 @@ package config
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
 
 	"ldcli/cmd/cliflags"
 )
 
-const FileName = "config.yml"
+const Filename = ".ldcli-config.yml"
 
 // ConfigFile represents the data stored in the config file.
 type ConfigFile struct {
@@ -35,20 +33,15 @@ func NewConfig(rawConfig map[string]interface{}) ConfigFile {
 }
 
 func GetConfigPath() string {
-	configPath := os.Getenv("XDG_CONFIG_HOME")
-	if configPath == "" {
-		home, err := homedir.Dir()
-		if err != nil {
-			return ""
-		}
-		configPath = filepath.Join(home, ".config")
+	home, err := homedir.Dir()
+	if err != nil {
+		return ""
 	}
 
-	return filepath.Join(configPath, "ldcli")
+	return home
 }
 
 // GetConfigFile gets the full path to the config file.
-// TODO: we should ensure this works on windows, linux, macos.
 func GetConfigFile() string {
-	return fmt.Sprintf("%s/%s", GetConfigPath(), FileName)
+	return fmt.Sprintf("%s/%s", GetConfigPath(), Filename)
 }


### PR DESCRIPTION
Running `ldcli config --list`, `--set foo bar`, or `--unset foo` without a config file should not error now.

If we keep it in the home directory instead of in a nested one, we don't need to worry about creating the directory if it does not exist.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
