### PR TITLE
fix: Show help when running `ldcli config`

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -97,6 +97,8 @@ func run() func(*cobra.Command, []string) error {
 			}
 
 			return writeConfig(config, v, unsetKeyFn)
+		default:
+			return cmd.Help()
 		}
 
 		return nil

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,0 +1,24 @@
+package config_test
+
+import (
+	"ldcli/cmd"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoFlag(t *testing.T) {
+	expected, err := os.ReadFile("testdata/help.golden")
+	require.NoError(t, err)
+	args := []string{
+		"config",
+	}
+
+	output, err := cmd.CallCmd(t, nil, nil, nil, nil, args)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(output))
+}

--- a/cmd/config/testdata/help.golden
+++ b/cmd/config/testdata/help.golden
@@ -1,0 +1,14 @@
+View and modify specific configuration values
+
+Usage:
+  ldcli config [flags]
+
+Flags:
+  -h, --help           help for config
+      --list           List configs
+      --set            Set a config field to a value
+      --unset string   Unset a config field
+
+Global Flags:
+      --access-token string   LaunchDarkly API token with write-level access
+      --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")


### PR DESCRIPTION
Running `ldcli config` without a flag didn't show anything. Now it shows the help text like other commands.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
