### PR TITLE
fix: Fix dry-run for npm publish

### DIFF
--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -3,10 +3,10 @@ description: Publish an npm package.
 inputs:
   prerelease:
     description: 'Is this a prerelease. If so, then the latest tag will not be updated in npm.'
-    required: true
-  dry_run:
+    required: false
+  dry-run:
     description: 'Is this a dry run. If so no package will be published.'
-    required: true
+    required: false
 
 runs:
   using: composite
@@ -17,4 +17,4 @@ runs:
         ./scripts/publish-npm.sh
       env:
         LD_RELEASE_IS_PRERELEASE: ${{ inputs.prerelease }}
-        LD_RELEASE_IS_DRYRUN: ${{ inputs.dry_run }}
+        LD_RELEASE_IS_DRYRUN: ${{ inputs.dry-run }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -2,7 +2,7 @@ name: Manually Publish Images and Artifacts
 on:
   workflow_dispatch:
     inputs:
-      dry_run:
+      dry-run:
         description: 'Skip publishing to DockerHub and Homebrew'
         type: boolean
         required: false
@@ -35,7 +35,7 @@ jobs:
       - uses: ./.github/actions/publish
         id: publish
         with:
-          dry-run: ${{ inputs.dry_run }}
+          dry-run: ${{ inputs.dry-run }}
           token: ${{ secrets.GITHUB_TOKEN }}
           homebrew-gh-secret: ${{secrets.HOMEBREW_DEPLOY_KEY}}
           tag: ${{ inputs.tag }}
@@ -65,6 +65,7 @@ jobs:
         name: Publish NPM Package
         uses: ./.github/actions/publish-npm
         with:
+          dry-run: ${{ inputs.dry-run }}
           prerelease: ${{ inputs.prerelease }}
 
   release-ldcli-provenance:


### PR DESCRIPTION
Fixes the `dry-run` flag so the value in the job to publish to npm doesn't default to true.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
