### PR TITLE
fix: Don't panic with nil tracking response body

### DIFF
--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -62,11 +62,13 @@ func (c *Client) SendEvent(
 		if err != nil { //nolint:staticcheck
 			// TODO: log error
 		}
-		if resp != nil {
-			resp.Body.Close()
+		if resp == nil {
+			c.wg.Done()
+			return
 		}
+		resp.Body.Close()
 
-		_, err := io.ReadAll(resp.Body)
+		_, err = io.ReadAll(resp.Body)
 		if err != nil { //nolint:staticcheck
 			// TODO: log error
 		}

--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -231,9 +231,6 @@ func fetchFlagStatus(
 	}
 }
 
-// noInstructionsMsg is sent when we can't find the SDK instructions repository for the given SDK.
-type noInstructionsMsg struct{}
-
 type selectedSDKMsg struct {
 	index int
 }


### PR DESCRIPTION
If using a structurally valid URL but semantically wrong, the analytics tracking would try to read from a nil response which would panic.
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
