### PR TITLE
fix: Don't find/replace FLAG_KEY in SDK instructions

### DIFF
--- a/internal/sdks/sdks.go
+++ b/internal/sdks/sdks.go
@@ -22,8 +22,6 @@ func ReplaceFlagKey(instructions string, key string) string {
 		key,
 		"my-boolean-flag",
 		key,
-		"FLAG_KEY",
-		key,
 		"<flag key>",
 		key,
 	)

--- a/internal/sdks/sdks_test.go
+++ b/internal/sdks/sdks_test.go
@@ -25,17 +25,17 @@ func TestReplaceFlagKey(t *testing.T) {
 			body:     "# title ```const featureFlagKey = \"my-boolean-flag\"```",
 			expected: "# title ```const featureFlagKey = \"real-flag-key\"```",
 		},
-		"replaces placeholder FLAG_KEY": {
-			body:     "# title ```const featureFlagKey = \"my-boolean-flag\"```",
-			expected: "# title ```const featureFlagKey = \"real-flag-key\"```",
-		},
 		"replaces placeholder <flag key>": {
-			body:     "# title ```hello_erlang_server:get(<<\"FLAG_KEY\">>)```",
+			body:     "# title ```hello_erlang_server:get(<<\"my-flag-key\">>)```",
 			expected: "# title ```hello_erlang_server:get(<<\"real-flag-key\">>)```",
 		},
 		"replaces camelCase <myFlagKey>": {
 			body:     "# title ```const featureFlagKey = \"myFlagKey\"```",
 			expected: "# title ```const featureFlagKey = \"realFlagKey\"```",
+		},
+		"does not replace BOOLEAN_FLAG_KEY": {
+			body:     "# title ```val BOOLEAN_FLAG_KEY = \"myFlagKey\"```",
+			expected: "# title ```val BOOLEAN_FLAG_KEY = \"realFlagKey\"```",
 		},
 	}
 	for name, tt := range tests {


### PR DESCRIPTION
This was breaking java and android examples.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
