### PR TITLE
feat: output flag multiple resources

### DIFF
--- a/cmd/projects/list.go
+++ b/cmd/projects/list.go
@@ -9,6 +9,7 @@ import (
 
 	"ldcli/cmd/cliflags"
 	"ldcli/cmd/validators"
+	"ldcli/internal/output"
 	"ldcli/internal/projects"
 )
 
@@ -35,7 +36,15 @@ func runList(client projects.Client) func(*cobra.Command, []string) error {
 			return err
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(), string(response)+"\n")
+		output, err := output.CmdOutput(
+			viper.GetString(cliflags.OutputFlag),
+			output.NewMultipleOutputterFn(response),
+		)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), string(output)+"\n")
 
 		return nil
 	}

--- a/cmd/projects/list_test.go
+++ b/cmd/projects/list_test.go
@@ -17,12 +17,20 @@ func TestList(t *testing.T) {
 		"testAccessToken",
 		"http://test.com",
 	}
+	stubbedResponse := `{
+		"items": [
+			{
+				"key": "test-key",
+				"name": "test-name"
+			}
+		]
+	}`
 
 	t.Run("with valid flags calls API", func(t *testing.T) {
 		client := projects.MockClient{}
 		client.
 			On("List", mockArgs...).
-			Return([]byte(cmd.ValidResponse), nil)
+			Return([]byte(stubbedResponse), nil)
 		clients := cmd.APIClients{
 			ProjectsClient: &client,
 		}
@@ -30,12 +38,13 @@ func TestList(t *testing.T) {
 			"projects", "list",
 			"--access-token", "testAccessToken",
 			"--base-uri", "http://test.com",
+			"--output", "json",
 		}
 
 		output, err := cmd.CallCmd(t, clients, args)
 
 		require.NoError(t, err)
-		assert.JSONEq(t, `{"valid": true}`, string(output))
+		assert.JSONEq(t, stubbedResponse, string(output))
 	})
 
 	t.Run("with valid flags from environment variables calls API", func(t *testing.T) {
@@ -44,19 +53,20 @@ func TestList(t *testing.T) {
 		client := projects.MockClient{}
 		client.
 			On("List", mockArgs...).
-			Return([]byte(cmd.ValidResponse), nil)
+			Return([]byte(stubbedResponse), nil)
 		clients := cmd.APIClients{
 			ProjectsClient: &client,
 		}
 		args := []string{
 			"projects",
 			"list",
+			"--output", "json",
 		}
 
 		output, err := cmd.CallCmd(t, clients, args)
 
 		require.NoError(t, err)
-		assert.JSONEq(t, `{"valid": true}`, string(output))
+		assert.JSONEq(t, stubbedResponse, string(output))
 	})
 
 	t.Run("with an error response is an error", func(t *testing.T) {

--- a/internal/output/multiple_outputter.go
+++ b/internal/output/multiple_outputter.go
@@ -1,0 +1,49 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+var multiplePlaintextOutputFn = func(r resource) string {
+	return fmt.Sprintf("* %s (%s)", r.Name, r.Key)
+}
+
+// TODO: rename this to be "cleaner"? -- NewMultipleOutput()
+func NewMultipleOutputterFn(input []byte) multipleOutputterFn {
+	return multipleOutputterFn{
+		input: input,
+	}
+}
+
+type multipleOutputterFn struct {
+	input []byte
+}
+
+func (o multipleOutputterFn) New() (Outputter, error) {
+	var r resources
+	err := json.Unmarshal(o.input, &r)
+	if err != nil {
+		return MultipleOutputter{}, err
+	}
+
+	return MultipleOutputter{
+		outputFn:     multiplePlaintextOutputFn,
+		resources:    r,
+		resourceJSON: o.input,
+	}, nil
+}
+
+type MultipleOutputter struct {
+	outputFn     PlaintextOutputFn
+	resources    resources
+	resourceJSON []byte
+}
+
+func (o MultipleOutputter) JSON() string {
+	return string(o.resourceJSON)
+}
+
+func (o MultipleOutputter) String() string {
+	return formatColl(o.resources.Items, o.outputFn)
+}

--- a/internal/output/multiple_outputter_test.go
+++ b/internal/output/multiple_outputter_test.go
@@ -1,0 +1,59 @@
+package output_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"ldcli/internal/output"
+)
+
+func TestMultipleOutputter_JSON(t *testing.T) {
+	input := []byte(`{
+		"items": [
+			{
+				"key": "test-key1",
+				"name": "test-name1",
+				"other": "another-value2"
+			},
+			{
+				"key": "test-key2",
+				"name": "test-name2",
+				"other": "another-value2"
+			}
+		]
+	}`)
+	output, err := output.CmdOutput(
+		"json",
+		output.NewMultipleOutputterFn(input),
+	)
+
+	require.NoError(t, err)
+	assert.JSONEq(t, output, string(input))
+}
+
+func TestMultipleOutputter_String(t *testing.T) {
+	input := []byte(`{
+		"items": [
+			{
+				"key": "test-key1",
+				"name": "test-name1",
+				"other": "another-value2"
+			},
+			{
+				"key": "test-key2",
+				"name": "test-name2",
+				"other": "another-value2"
+			}
+		]
+	}`)
+	expected := "* test-name1 (test-key1)\n* test-name2 (test-key2)"
+	output, err := output.CmdOutput(
+		"plaintext",
+		output.NewMultipleOutputterFn(input),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, output)
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -32,6 +32,12 @@ type resource struct {
 	Name string `json:"name"`
 }
 
+// resources is the subset of data we need to display a command's plain text response for a list
+// of resources.
+type resources struct {
+	Items []resource `json:"items"`
+}
+
 // CmdOutput returns a command's response as a string formatted based on the user's requested type.
 func CmdOutput(outputKind string, outputter OutputterFn) (string, error) {
 	o, err := outputter.New()

--- a/internal/output/singular_outputter_test.go
+++ b/internal/output/singular_outputter_test.go
@@ -9,7 +9,7 @@ import (
 	"ldcli/internal/output"
 )
 
-func TestOutputter_JSON(t *testing.T) {
+func TestSingularOutputter_JSON(t *testing.T) {
 	input := []byte(`{
 		"key": "test-key",
 		"name": "test-name",
@@ -24,7 +24,7 @@ func TestOutputter_JSON(t *testing.T) {
 	assert.JSONEq(t, output, string(input))
 }
 
-func TestOutputter_String(t *testing.T) {
+func TestSingularOutputter_String(t *testing.T) {
 	input := []byte(`{
 		"key": "test-key",
 		"name": "test-name",


### PR DESCRIPTION
Use the output flag to show either JSON or plaintext for a command's response with multiple resources.

This only works for projects list, but another PR will add support to the rest of the commands.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
