### PR TITLE
feat: hardcoded resource cmds

### DIFF
--- a/cmd/resource_cmds.go
+++ b/cmd/resource_cmds.go
@@ -31,4 +31,27 @@ func addAllResourceCmds(rootCmd *cobra.Command, client *http.Client) {
 		RequiresBody: true,
 		Path:         "/api/v2/teams",
 	})
+
+	resources.NewOperationCmd(gen_TeamsResourceCmd, client, resources.OperationData{
+		Short: "Get team",
+		Long:  "Fetch a team by key.\n\n### Expanding the teams response\nLaunchDarkly supports four fields for expanding the \"Get team\" response. By default, these fields are **not** included in the response.\n\nTo expand the response, append the `expand` query parameter and add a comma-separated list with any of the following fields:\n\n* `members` includes the total count of members that belong to the team.\n* `roles` includes a paginated list of the custom roles that you have assigned to the team.\n* `projects` includes a paginated list of the projects that the team has any write access to.\n* `maintainers` includes a paginated list of the maintainers that you have assigned to the team.\n\nFor example, `expand=members,roles` includes the `members` and `roles` fields in the response.\n",
+		Use:   "get",
+		Params: []resources.Param{
+			{
+				Name:        "teamKey",
+				In:          "path",
+				Description: "The team key.",
+				Type:        "string",
+			},
+			{
+				Name:        "expand",
+				In:          "query",
+				Description: "A comma-separated list of properties that can reveal additional information in the response. Supported fields are explained above.",
+				Type:        "string",
+			},
+		},
+		HTTPMethod:   "get",
+		RequiresBody: false,
+		Path:         "/api/v2/teams/{teamKey}",
+	})
 }

--- a/cmd/resource_cmds.go
+++ b/cmd/resource_cmds.go
@@ -31,27 +31,4 @@ func addAllResourceCmds(rootCmd *cobra.Command, client *http.Client) {
 		RequiresBody: true,
 		Path:         "/api/v2/teams",
 	})
-
-	resources.NewOperationCmd(gen_TeamsResourceCmd, client, resources.OperationData{
-		Short: "Get team",
-		Long:  "Fetch a team by key.\n\n### Expanding the teams response\nLaunchDarkly supports four fields for expanding the \"Get team\" response. By default, these fields are **not** included in the response.\n\nTo expand the response, append the `expand` query parameter and add a comma-separated list with any of the following fields:\n\n* `members` includes the total count of members that belong to the team.\n* `roles` includes a paginated list of the custom roles that you have assigned to the team.\n* `projects` includes a paginated list of the projects that the team has any write access to.\n* `maintainers` includes a paginated list of the maintainers that you have assigned to the team.\n\nFor example, `expand=members,roles` includes the `members` and `roles` fields in the response.\n",
-		Use:   "get",
-		Params: []resources.Param{
-			{
-				Name:        "teamKey",
-				In:          "path",
-				Description: "The team key.",
-				Type:        "string",
-			},
-			{
-				Name:        "expand",
-				In:          "query",
-				Description: "A comma-separated list of properties that can reveal additional information in the response. Supported fields are explained above.",
-				Type:        "string",
-			},
-		},
-		HTTPMethod:   "get",
-		RequiresBody: false,
-		Path:         "/api/v2/teams/{teamKey}",
-	})
 }

--- a/cmd/resource_cmds.go
+++ b/cmd/resource_cmds.go
@@ -1,0 +1,17 @@
+// this file WILL be generated (sc-241153)
+
+package resources
+
+import "github.com/spf13/cobra"
+
+func AddAllResourceCmds(rootCmd *cobra.Command) {
+	// Resource commands
+	gen_TeamsResourceCmd := NewResourceCmd(rootCmd, "teams", "Teams is an Enterprise feature", "Teams is available to customers on an Enterprise plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact Sales](https://launchdarkly.com/contact-sales/).\\n\\nA team is a group of members in your LaunchDarkly account. A team can have maintainers who are able to add and remove team members. It also can have custom roles assigned to it that allows shared access to those roles for all team members. To learn more, read [Teams](https://docs.launchdarkly.com/home/teams).\\n\\nThe Teams API allows you to create, read, update, and delete a team.\\n\\nSeveral of the endpoints in the Teams API require one or more member IDs. The member ID is returned as part of the [List account members](/tag/Account-members#operation/getMembers) response. It is the `_id` field of each element in the `items` array.\\n\"")
+
+	// Operation commands
+	NewOperationCmd(gen_TeamsResourceCmd, OperationData{
+		Short: "Create team",
+		Long:  "Create a team. To learn more, read [Creating a team](https://docs.launchdarkly.com/home/teams/creating).\n\n### Expanding the teams response\nLaunchDarkly supports four fields for expanding the \"Create team\" response. By default, these fields are **not** included in the response.\n\nTo expand the response, append the `expand` query parameter and add a comma-separated list with any of the following fields:\n\n* `members` includes the total count of members that belong to the team.\n* `roles` includes a paginated list of the custom roles that you have assigned to the team.\n* `projects` includes a paginated list of the projects that the team has any write access to.\n* `maintainers` includes a paginated list of the maintainers that you have assigned to the team.\n\nFor example, `expand=members,roles` includes the `members` and `roles` fields in the response.\n",
+		Use:   "create",
+	})
+}

--- a/cmd/resource_cmds.go
+++ b/cmd/resource_cmds.go
@@ -1,17 +1,34 @@
 // this file WILL be generated (sc-241153)
 
-package resources
+package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"net/http"
 
-func AddAllResourceCmds(rootCmd *cobra.Command) {
+	"github.com/spf13/cobra"
+
+	"ldcli/cmd/resources"
+)
+
+func addAllResourceCmds(rootCmd *cobra.Command, client *http.Client) {
 	// Resource commands
-	gen_TeamsResourceCmd := NewResourceCmd(rootCmd, "teams", "Teams is an Enterprise feature", "Teams is available to customers on an Enterprise plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact Sales](https://launchdarkly.com/contact-sales/).\\n\\nA team is a group of members in your LaunchDarkly account. A team can have maintainers who are able to add and remove team members. It also can have custom roles assigned to it that allows shared access to those roles for all team members. To learn more, read [Teams](https://docs.launchdarkly.com/home/teams).\\n\\nThe Teams API allows you to create, read, update, and delete a team.\\n\\nSeveral of the endpoints in the Teams API require one or more member IDs. The member ID is returned as part of the [List account members](/tag/Account-members#operation/getMembers) response. It is the `_id` field of each element in the `items` array.\\n\"")
+	gen_TeamsResourceCmd := resources.NewResourceCmd(rootCmd, "teams", "Teams is an Enterprise feature", "Teams is available to customers on an Enterprise plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact Sales](https://launchdarkly.com/contact-sales/).\\n\\nA team is a group of members in your LaunchDarkly account. A team can have maintainers who are able to add and remove team members. It also can have custom roles assigned to it that allows shared access to those roles for all team members. To learn more, read [Teams](https://docs.launchdarkly.com/home/teams).\\n\\nThe Teams API allows you to create, read, update, and delete a team.\\n\\nSeveral of the endpoints in the Teams API require one or more member IDs. The member ID is returned as part of the [List account members](/tag/Account-members#operation/getMembers) response. It is the `_id` field of each element in the `items` array.\\n\"")
 
 	// Operation commands
-	NewOperationCmd(gen_TeamsResourceCmd, OperationData{
+	resources.NewOperationCmd(gen_TeamsResourceCmd, client, resources.OperationData{
 		Short: "Create team",
 		Long:  "Create a team. To learn more, read [Creating a team](https://docs.launchdarkly.com/home/teams/creating).\n\n### Expanding the teams response\nLaunchDarkly supports four fields for expanding the \"Create team\" response. By default, these fields are **not** included in the response.\n\nTo expand the response, append the `expand` query parameter and add a comma-separated list with any of the following fields:\n\n* `members` includes the total count of members that belong to the team.\n* `roles` includes a paginated list of the custom roles that you have assigned to the team.\n* `projects` includes a paginated list of the projects that the team has any write access to.\n* `maintainers` includes a paginated list of the maintainers that you have assigned to the team.\n\nFor example, `expand=members,roles` includes the `members` and `roles` fields in the response.\n",
 		Use:   "create",
+		Params: []resources.Param{
+			{
+				Name:        "expand",
+				In:          "query",
+				Description: "A comma-separated list of properties that can reveal additional information in the response. Supported fields are explained above.",
+				Type:        "string",
+			},
+		},
+		HTTPMethod:   "post",
+		RequiresBody: true,
+		Path:         "/api/v2/teams",
 	})
 }

--- a/cmd/resource_cmds.go
+++ b/cmd/resource_cmds.go
@@ -12,7 +12,12 @@ import (
 
 func addAllResourceCmds(rootCmd *cobra.Command, client *http.Client) {
 	// Resource commands
-	gen_TeamsResourceCmd := resources.NewResourceCmd(rootCmd, "teams", "Teams is an Enterprise feature", "Teams is available to customers on an Enterprise plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact Sales](https://launchdarkly.com/contact-sales/).\\n\\nA team is a group of members in your LaunchDarkly account. A team can have maintainers who are able to add and remove team members. It also can have custom roles assigned to it that allows shared access to those roles for all team members. To learn more, read [Teams](https://docs.launchdarkly.com/home/teams).\\n\\nThe Teams API allows you to create, read, update, and delete a team.\\n\\nSeveral of the endpoints in the Teams API require one or more member IDs. The member ID is returned as part of the [List account members](/tag/Account-members#operation/getMembers) response. It is the `_id` field of each element in the `items` array.\\n\"")
+	gen_TeamsResourceCmd := resources.NewResourceCmd(
+		rootCmd,
+		"teams",
+		"A team is a group of members in your LaunchDarkly account.",
+		"A team can have maintainers who are able to add and remove team members. It also can have custom roles assigned to it that allows shared access to those roles for all team members. To learn more, read [Teams](https://docs.launchdarkly.com/home/teams).\n\nThe Teams API allows you to create, read, update, and delete a team.\n\nSeveral of the endpoints in the Teams API require one or more member IDs. The member ID is returned as part of the [List account members](/tag/Account-members#operation/getMembers) response. It is the `_id` field of each element in the `items` array.",
+	)
 
 	// Operation commands
 	resources.NewOperationCmd(gen_TeamsResourceCmd, client, resources.OperationData{

--- a/cmd/resource_cmds_test.go
+++ b/cmd/resource_cmds_test.go
@@ -1,0 +1,42 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"ldcli/cmd"
+	"ldcli/internal/analytics"
+)
+
+func TestCreateTeam(t *testing.T) {
+	t.Run("help shows postTeam description", func(t *testing.T) {
+		args := []string{
+			"teams",
+			"create",
+			"--help",
+		}
+
+		output, err := cmd.CallCmd(t, cmd.APIClients{}, &analytics.NoopClient{}, args)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(output), "Create a team.")
+	})
+	t.Run("with valid flags calls makeRequest function", func(t *testing.T) {
+		args := []string{
+			"teams",
+			"create",
+			"--access-token",
+			"abcd1234",
+			"--data",
+			`{"key": "team-key", "name": "Team Name"}`,
+		}
+
+		output, err := cmd.CallCmd(t, cmd.APIClients{}, &analytics.NoopClient{}, args)
+
+		require.NoError(t, err)
+		s := string(output)
+		assert.Contains(t, s, "would be making a request to /api/v2/teams here, with args: map[data:map[key:team-key name:Team Name] expand:]\n")
+	})
+}

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -1,0 +1,1 @@
+package resources

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -102,7 +102,19 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, p := range op.Params {
-		params[p.Name] = viper.GetString(p.Name)
+		var val interface{}
+		switch p.Type {
+		case "string":
+			val = viper.GetString(p.Name)
+		case "boolean":
+			val = viper.GetBool(p.Name)
+		case "int":
+			val = viper.GetInt(p.Name)
+		}
+
+		if val != nil {
+			params[p.Name] = val
+		}
 	}
 
 	log.Printf("would be making a request to %s here, with args: %s", op.Path, params)

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -27,18 +27,18 @@ func NewResourceCmd(parentCmd *cobra.Command, resourceName, shortDescription, lo
 }
 
 type OperationData struct {
-	Short        string  // summary
-	Long         string  // description
-	Use          string  // method -> use
-	Params       []Param // parameters
-	HTTPMethod   string  // method
-	RequiresBody bool    // requestBody > required
-	Path         string  // path
+	Short        string
+	Long         string
+	Use          string
+	Params       []Param
+	HTTPMethod   string
+	RequiresBody bool
+	Path         string
 }
 
 type Param struct {
 	Name        string
-	In          string // query or path
+	In          string
 	Description string
 	Type        string
 }
@@ -89,7 +89,7 @@ func (op *OperationCmd) initFlags() error {
 }
 
 func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
-	params := map[string]interface{}{}
+	paramVals := map[string]interface{}{}
 
 	if op.RequiresBody {
 		var data interface{}
@@ -98,7 +98,7 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		params[cliflags.DataFlag] = data
+		paramVals[cliflags.DataFlag] = data
 	}
 
 	for _, p := range op.Params {
@@ -113,11 +113,11 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 		}
 
 		if val != nil {
-			params[p.Name] = val
+			paramVals[p.Name] = val
 		}
 	}
 
-	log.Printf("would be making a request to %s here, with args: %s", op.Path, params)
+	log.Printf("would be making a request to %s here, with args: %s", op.Path, paramVals)
 	return nil
 }
 

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/spf13/cobra"
@@ -117,7 +116,8 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	log.Printf("would be making a request to %s here, with args: %s", op.Path, paramVals)
+	fmt.Fprintf(cmd.OutOrStdout(), fmt.Sprintf("would be making a request to %s here, with args: %s\n", op.Path, paramVals))
+
 	return nil
 }
 

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -1,1 +1,133 @@
 package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"ldcli/cmd/cliflags"
+	"ldcli/cmd/validators"
+)
+
+func NewResourceCmd(parentCmd *cobra.Command, resourceName, shortDescription, longDescription string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   resourceName,
+		Short: shortDescription,
+		Long:  longDescription,
+		//TODO: add tracking here
+	}
+
+	parentCmd.AddCommand(cmd)
+
+	return cmd
+}
+
+type OperationData struct {
+	Short        string  // summary
+	Long         string  // description
+	Use          string  // method -> use
+	Params       []Param // parameters
+	HTTPMethod   string  // method
+	RequiresBody bool    // requestBody > required
+	Path         string  // path
+}
+
+type Param struct {
+	Name        string
+	In          string // query or path
+	Description string
+	Type        string
+}
+
+type OperationCmd struct {
+	OperationData
+	client *http.Client
+	cmd    *cobra.Command
+}
+
+func (op *OperationCmd) initFlags() error {
+	if op.RequiresBody {
+		op.cmd.Flags().StringP(cliflags.DataFlag, "d", "", "Input data in JSON")
+		err := op.cmd.MarkFlagRequired(cliflags.DataFlag)
+		if err != nil {
+			return err
+		}
+		err = viper.BindPFlag(cliflags.DataFlag, op.cmd.Flags().Lookup(cliflags.DataFlag))
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, p := range op.Params {
+		shorthand := fmt.Sprintf(p.Name[0:1]) // todo: how do we handle potential dupes
+		switch p.Type {
+		case "string":
+			op.cmd.Flags().StringP(p.Name, shorthand, "", p.Description)
+		case "int":
+			op.cmd.Flags().IntP(p.Name, shorthand, 0, p.Description)
+		case "boolean":
+			op.cmd.Flags().BoolP(p.Name, shorthand, false, p.Description)
+		}
+
+		if p.In == "path" {
+			err := op.cmd.MarkFlagRequired(p.Name)
+			if err != nil {
+				return err
+			}
+		}
+
+		err := viper.BindPFlag(p.Name, op.cmd.Flags().Lookup(p.Name))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
+	params := map[string]interface{}{}
+
+	if op.RequiresBody {
+		var data interface{}
+		// TODO: why does viper.GetString(cliflags.DataFlag) not work?
+		err := json.Unmarshal([]byte(cmd.Flags().Lookup(cliflags.DataFlag).Value.String()), &data)
+		if err != nil {
+			return err
+		}
+		params[cliflags.DataFlag] = data
+	}
+
+	for _, p := range op.Params {
+		params[p.Name] = viper.GetString(p.Name)
+	}
+
+	log.Printf("would be making a request to %s here, with args: %s", op.Path, params)
+	return nil
+}
+
+func NewOperationCmd(parentCmd *cobra.Command, client *http.Client, op OperationData) *cobra.Command {
+	opCmd := OperationCmd{
+		OperationData: op,
+		client:        client,
+	}
+
+	cmd := &cobra.Command{
+		Args:  validators.Validate(), // tbd on this validator
+		Long:  op.Long,
+		RunE:  opCmd.makeRequest,
+		Short: op.Short,
+		Use:   op.Use,
+		//TODO: add tracking here
+	}
+
+	opCmd.cmd = cmd
+	opCmd.initFlags()
+
+	parentCmd.AddCommand(cmd)
+
+	return cmd
+}

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -116,7 +116,7 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), fmt.Sprintf("would be making a request to %s here, with args: %s\n", op.Path, paramVals))
+	fmt.Fprintf(cmd.OutOrStdout(), "would be making a request to %s here, with args: %s\n", op.Path, paramVals)
 
 	return nil
 }
@@ -128,7 +128,7 @@ func NewOperationCmd(parentCmd *cobra.Command, client *http.Client, op Operation
 	}
 
 	cmd := &cobra.Command{
-		Args:  validators.Validate(), // tbd on this validator
+		Args:  validators.Validate(),
 		Long:  op.Long,
 		RunE:  opCmd.makeRequest,
 		Short: op.Short,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,7 @@ func NewRootCommand(
 	version string,
 	useConfigFile bool,
 ) (*cobra.Command, error) {
-	rootCmd := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "ldcli",
 		Short:   "LaunchDarkly CLI",
 		Long:    "LaunchDarkly CLI to control your feature flags",
@@ -75,26 +75,26 @@ func NewRootCommand(
 	viper.SetEnvKeyReplacer(replacer)
 	viper.AutomaticEnv()
 
-	rootCmd.PersistentFlags().String(
+	cmd.PersistentFlags().String(
 		cliflags.AccessTokenFlag,
 		"",
 		"LaunchDarkly API token with write-level access",
 	)
-	err := rootCmd.MarkPersistentFlagRequired(cliflags.AccessTokenFlag)
+	err := cmd.MarkPersistentFlagRequired(cliflags.AccessTokenFlag)
 	if err != nil {
 		return nil, err
 	}
-	err = viper.BindPFlag(cliflags.AccessTokenFlag, rootCmd.PersistentFlags().Lookup(cliflags.AccessTokenFlag))
+	err = viper.BindPFlag(cliflags.AccessTokenFlag, cmd.PersistentFlags().Lookup(cliflags.AccessTokenFlag))
 	if err != nil {
 		return nil, err
 	}
 
-	rootCmd.PersistentFlags().String(
+	cmd.PersistentFlags().String(
 		cliflags.BaseURIFlag,
 		cliflags.BaseURIDefault,
 		"LaunchDarkly base URI",
 	)
-	err = viper.BindPFlag(cliflags.BaseURIFlag, rootCmd.PersistentFlags().Lookup(cliflags.BaseURIFlag))
+	err = viper.BindPFlag(cliflags.BaseURIFlag, cmd.PersistentFlags().Lookup(cliflags.BaseURIFlag))
 	if err != nil {
 		return nil, err
 	}
@@ -116,16 +116,16 @@ func NewRootCommand(
 		return nil, err
 	}
 
-	rootCmd.AddCommand(configcmd.NewConfigCmd(analyticsTracker))
-	rootCmd.AddCommand(environmentsCmd)
-	rootCmd.AddCommand(flagsCmd)
-	rootCmd.AddCommand(membersCmd)
-	rootCmd.AddCommand(projectsCmd)
-	rootCmd.AddCommand(NewQuickStartCmd(clients.EnvironmentsClient, clients.FlagsClient))
+	cmd.AddCommand(configcmd.NewConfigCmd(analyticsTracker))
+	cmd.AddCommand(environmentsCmd)
+	cmd.AddCommand(flagsCmd)
+	cmd.AddCommand(membersCmd)
+	cmd.AddCommand(projectsCmd)
+	cmd.AddCommand(NewQuickStartCmd(clients.EnvironmentsClient, clients.FlagsClient))
 
-	addAllResourceCmds(rootCmd, clients.GenericClient)
+	addAllResourceCmds(cmd, clients.GenericClient)
 
-	return rootCmd, nil
+	return cmd, nil
 }
 
 func Execute(analyticsTracker analytics.Tracker, version string) {


### PR DESCRIPTION
Adds a hardcoded implementation of the `NewResourceCmd` and `NewOperationCmd` functions that we plan to generate in the future. 

Calling help:
```shell
$ go run main.go teams create --help
Create a team. To learn more, read [Creating a team](https://docs.launchdarkly.com/home/teams/creating).

### Expanding the teams response
LaunchDarkly supports four fields for expanding the "Create team" response. By default, these fields are **not** included in the response.

To expand the response, append the `expand` query parameter and add a comma-separated list with any of the following fields:

* `members` includes the total count of members that belong to the team.
* `roles` includes a paginated list of the custom roles that you have assigned to the team.
* `projects` includes a paginated list of the projects that the team has any write access to.
* `maintainers` includes a paginated list of the maintainers that you have assigned to the team.

For example, `expand=members,roles` includes the `members` and `roles` fields in the response.

Usage:
  ldcli teams create [flags]

Flags:
  -d, --data string     Input data in JSON
  -e, --expand string   A comma-separated list of properties that can reveal additional information in the response. Supported fields are explained above.
  -h, --help            help for create

Global Flags:
      --access-token string   LaunchDarkly API token with write-level access
      --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
```

Calling the command w/required flags:
```shell
$ go run main.go teams create --data '{"key": "my-team-key", "name": "My Team Name"}'
would be making a request to /api/v2/teams here, with args: map[data:map[key:my-team-key name:My Team Name] expand:]
```