### PR TITLE
feat: track quick-start events

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -11,25 +11,28 @@ import (
 
 	"ldcli/cmd/cliflags"
 	"ldcli/cmd/validators"
+	"ldcli/internal/analytics"
 	"ldcli/internal/environments"
 	"ldcli/internal/flags"
 	"ldcli/internal/quickstart"
 )
 
 func NewQuickStartCmd(
+	analyticsTracker analytics.Tracker,
 	environmentsClient environments.Client,
 	flagsClient flags.Client,
 ) *cobra.Command {
 	return &cobra.Command{
 		Args:  validators.Validate(),
 		Long:  "",
-		RunE:  runQuickStart(environmentsClient, flagsClient),
+		RunE:  runQuickStart(analyticsTracker, environmentsClient, flagsClient),
 		Short: "Setup guide to create your first feature flag",
 		Use:   "setup",
 	}
 }
 
 func runQuickStart(
+	analyticsTracker analytics.Tracker,
 	environmentsClient environments.Client,
 	flagsClient flags.Client,
 ) func(*cobra.Command, []string) error {
@@ -42,6 +45,7 @@ func runQuickStart(
 		defer f.Close()
 
 		_, err = tea.NewProgram(quickstart.NewContainerModel(
+			analyticsTracker,
 			environmentsClient,
 			flagsClient,
 			viper.GetString(cliflags.AccessTokenFlag),

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -50,7 +50,6 @@ func runQuickStart(
 			flagsClient,
 			viper.GetString(cliflags.AccessTokenFlag),
 			viper.GetString(cliflags.BaseURIFlag),
-			viper.GetBool(cliflags.AnalyticsOptOut),
 		)).Run()
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -50,6 +50,7 @@ func runQuickStart(
 			flagsClient,
 			viper.GetString(cliflags.AccessTokenFlag),
 			viper.GetString(cliflags.BaseURIFlag),
+			viper.GetBool(cliflags.AnalyticsOptOut),
 		)).Run()
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,7 +132,7 @@ func NewRootCommand(
 	cmd.AddCommand(flagsCmd)
 	cmd.AddCommand(membersCmd)
 	cmd.AddCommand(projectsCmd)
-	cmd.AddCommand(NewQuickStartCmd(clients.EnvironmentsClient, clients.FlagsClient))
+	cmd.AddCommand(NewQuickStartCmd(analyticsTracker, clients.EnvironmentsClient, clients.FlagsClient))
 
 	addAllResourceCmds(cmd, clients.GenericClient)
 

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -24,6 +24,23 @@ type Tracker interface {
 		optOut bool,
 		outcome string,
 	)
+	SendSetupStartedEvent(
+		accessToken,
+		baseURI,
+		step string,
+	)
+	SendSetupSDKSelectedEvent(
+		accessToken,
+		baseURI,
+		sdk string,
+	)
+	SendSetupFlagToggledEvent(
+		accessToken,
+		baseURI string,
+		on bool,
+		count int,
+		duration_ms int64,
+	)
 }
 
 type Client struct {
@@ -128,6 +145,58 @@ func (c *Client) SendCommandCompletedEvent(
 	}
 }
 
+func (c *Client) SendSetupStartedEvent(
+	accessToken,
+	baseURI,
+	step string,
+) {
+	c.sendEvent(
+		accessToken,
+		baseURI,
+		false,
+		"CLI Setup Started",
+		map[string]interface{}{
+			"step": step,
+		},
+	)
+}
+
+func (c *Client) SendSetupSDKSelectedEvent(
+	accessToken,
+	baseURI,
+	sdk string,
+) {
+	c.sendEvent(
+		accessToken,
+		baseURI,
+		false,
+		"CLI Setup SDK Selected",
+		map[string]interface{}{
+			"sdk": sdk,
+		},
+	)
+}
+
+func (c *Client) SendSetupFlagToggledEvent(
+	accessToken,
+	baseURI string,
+	on bool,
+	count int,
+	duration_ms int64,
+) {
+	c.sendEvent(
+		accessToken,
+		baseURI,
+		false,
+		"CLI Setup Flag Toggled",
+		map[string]interface{}{
+			"on":          on,
+			"count":       count,
+			"duration_ms": duration_ms,
+		},
+	)
+}
+
 func (a *Client) Wait() {
 	a.wg.Wait()
 }
@@ -147,6 +216,29 @@ func (c *NoopClient) SendCommandCompletedEvent(
 	baseURI string,
 	optOut bool,
 	outcome string,
+) {
+}
+
+func (c *NoopClient) SendSetupStartedEvent(
+	accessToken,
+	baseURI,
+	step string,
+) {
+}
+
+func (c *NoopClient) SendSetupSDKSelectedEvent(
+	accessToken,
+	baseURI,
+	sdk string,
+) {
+}
+
+func (c *NoopClient) SendSetupFlagToggledEvent(
+	accessToken,
+	baseURI string,
+	on bool,
+	count int,
+	duration_ms int64,
 ) {
 }
 
@@ -194,6 +286,58 @@ func (m *MockTracker) SendCommandCompletedEvent(
 		"CLI Command Completed",
 		map[string]interface{}{
 			"outcome": outcome,
+		},
+	)
+}
+
+func (m *MockTracker) SendSetupStartedEvent(
+	accessToken,
+	baseURI,
+	step string,
+) {
+	m.sendEvent(
+		accessToken,
+		baseURI,
+		false,
+		"CLI Setup Started",
+		map[string]interface{}{
+			"step": step,
+		},
+	)
+}
+
+func (m *MockTracker) SendSetupSDKSelectedEvent(
+	accessToken,
+	baseURI,
+	sdk string,
+) {
+	m.sendEvent(
+		accessToken,
+		baseURI,
+		false,
+		"CLI Setup SDK Selected",
+		map[string]interface{}{
+			"sdk": sdk,
+		},
+	)
+}
+
+func (m *MockTracker) SendSetupFlagToggledEvent(
+	accessToken,
+	baseURI string,
+	on bool,
+	count int,
+	duration_ms int64,
+) {
+	m.sendEvent(
+		accessToken,
+		baseURI,
+		false,
+		"CLI Setup Flag Toggled",
+		map[string]interface{}{
+			"on":          on,
+			"count":       count,
+			"duration_ms": duration_ms,
 		},
 	)
 }

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -26,7 +26,8 @@ type Tracker interface {
 	)
 	SendSetupStartedEvent(
 		accessToken,
-		baseURI,
+		baseURI string,
+		optOut bool,
 		step string,
 	)
 	SendSetupSDKSelectedEvent(
@@ -147,7 +148,8 @@ func (c *Client) SendCommandCompletedEvent(
 
 func (c *Client) SendSetupStartedEvent(
 	accessToken,
-	baseURI,
+	baseURI string,
+	optOut bool,
 	step string,
 ) {
 	c.sendEvent(
@@ -221,7 +223,8 @@ func (c *NoopClient) SendCommandCompletedEvent(
 
 func (c *NoopClient) SendSetupStartedEvent(
 	accessToken,
-	baseURI,
+	baseURI string,
+	optOut bool,
 	step string,
 ) {
 }
@@ -292,7 +295,8 @@ func (m *MockTracker) SendCommandCompletedEvent(
 
 func (m *MockTracker) SendSetupStartedEvent(
 	accessToken,
-	baseURI,
+	baseURI string,
+	outOpt bool,
 	step string,
 ) {
 	m.sendEvent(

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -32,12 +32,14 @@ type Tracker interface {
 	)
 	SendSetupSDKSelectedEvent(
 		accessToken,
-		baseURI,
+		baseURI string,
+		optOut bool,
 		sdk string,
 	)
 	SendSetupFlagToggledEvent(
 		accessToken,
 		baseURI string,
+		optOut bool,
 		on bool,
 		count int,
 		duration_ms int64,
@@ -155,7 +157,7 @@ func (c *Client) SendSetupStartedEvent(
 	c.sendEvent(
 		accessToken,
 		baseURI,
-		false,
+		optOut,
 		"CLI Setup Started",
 		map[string]interface{}{
 			"step": step,
@@ -165,13 +167,14 @@ func (c *Client) SendSetupStartedEvent(
 
 func (c *Client) SendSetupSDKSelectedEvent(
 	accessToken,
-	baseURI,
+	baseURI string,
+	optOut bool,
 	sdk string,
 ) {
 	c.sendEvent(
 		accessToken,
 		baseURI,
-		false,
+		optOut,
 		"CLI Setup SDK Selected",
 		map[string]interface{}{
 			"sdk": sdk,
@@ -182,6 +185,7 @@ func (c *Client) SendSetupSDKSelectedEvent(
 func (c *Client) SendSetupFlagToggledEvent(
 	accessToken,
 	baseURI string,
+	optOut bool,
 	on bool,
 	count int,
 	duration_ms int64,
@@ -189,7 +193,7 @@ func (c *Client) SendSetupFlagToggledEvent(
 	c.sendEvent(
 		accessToken,
 		baseURI,
-		false,
+		optOut,
 		"CLI Setup Flag Toggled",
 		map[string]interface{}{
 			"on":          on,
@@ -231,7 +235,8 @@ func (c *NoopClient) SendSetupStartedEvent(
 
 func (c *NoopClient) SendSetupSDKSelectedEvent(
 	accessToken,
-	baseURI,
+	baseURI string,
+	optOut bool,
 	sdk string,
 ) {
 }
@@ -239,6 +244,7 @@ func (c *NoopClient) SendSetupSDKSelectedEvent(
 func (c *NoopClient) SendSetupFlagToggledEvent(
 	accessToken,
 	baseURI string,
+	optOut bool,
 	on bool,
 	count int,
 	duration_ms int64,
@@ -296,13 +302,13 @@ func (m *MockTracker) SendCommandCompletedEvent(
 func (m *MockTracker) SendSetupStartedEvent(
 	accessToken,
 	baseURI string,
-	outOpt bool,
+	optOut bool,
 	step string,
 ) {
 	m.sendEvent(
 		accessToken,
 		baseURI,
-		false,
+		optOut,
 		"CLI Setup Started",
 		map[string]interface{}{
 			"step": step,
@@ -312,13 +318,14 @@ func (m *MockTracker) SendSetupStartedEvent(
 
 func (m *MockTracker) SendSetupSDKSelectedEvent(
 	accessToken,
-	baseURI,
+	baseURI string,
+	optOut bool,
 	sdk string,
 ) {
 	m.sendEvent(
 		accessToken,
 		baseURI,
-		false,
+		optOut,
 		"CLI Setup SDK Selected",
 		map[string]interface{}{
 			"sdk": sdk,
@@ -329,6 +336,7 @@ func (m *MockTracker) SendSetupSDKSelectedEvent(
 func (m *MockTracker) SendSetupFlagToggledEvent(
 	accessToken,
 	baseURI string,
+	optOut bool,
 	on bool,
 	count int,
 	duration_ms int64,
@@ -336,7 +344,7 @@ func (m *MockTracker) SendSetupFlagToggledEvent(
 	m.sendEvent(
 		accessToken,
 		baseURI,
-		false,
+		optOut,
 		"CLI Setup Flag Toggled",
 		map[string]interface{}{
 			"on":          on,

--- a/internal/quickstart/choose_sdk.go
+++ b/internal/quickstart/choose_sdk.go
@@ -3,6 +3,7 @@ package quickstart
 import (
 	"fmt"
 	"io"
+	"ldcli/cmd/cliflags"
 	"ldcli/internal/analytics"
 	"strings"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -71,7 +73,7 @@ func NewChooseSDKModel(analyticsTracker analytics.Tracker, accessToken, baseUri 
 // Init sends commands when the model is created that will:
 // * select an SDK if it's already been selected
 func (m chooseSDKModel) Init() tea.Cmd {
-	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, "2 - sdk selection")
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.OutputFlag), "2 - sdk selection")
 	return selectedSDK(m.selectedIndex)
 }
 

--- a/internal/quickstart/choose_sdk.go
+++ b/internal/quickstart/choose_sdk.go
@@ -71,14 +71,7 @@ func NewChooseSDKModel(analyticsTracker analytics.Tracker, accessToken, baseUri 
 // Init sends commands when the model is created that will:
 // * select an SDK if it's already been selected
 func (m chooseSDKModel) Init() tea.Cmd {
-	m.analyticsTracker.SendEvent(
-		m.accessToken,
-		m.baseUri,
-		"CLI Setup Started",
-		map[string]interface{}{
-			"step": "2 - sdk selection",
-		},
-	)
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, "2 - sdk selection")
 	return selectedSDK(m.selectedIndex)
 }
 

--- a/internal/quickstart/choose_sdk.go
+++ b/internal/quickstart/choose_sdk.go
@@ -73,7 +73,7 @@ func NewChooseSDKModel(analyticsTracker analytics.Tracker, accessToken, baseUri 
 // Init sends commands when the model is created that will:
 // * select an SDK if it's already been selected
 func (m chooseSDKModel) Init() tea.Cmd {
-	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.OutputFlag), "2 - sdk selection")
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.AnalyticsOptOut), "2 - sdk selection")
 	return selectedSDK(m.selectedIndex)
 }
 

--- a/internal/quickstart/choose_sdk.go
+++ b/internal/quickstart/choose_sdk.go
@@ -3,6 +3,7 @@ package quickstart
 import (
 	"fmt"
 	"io"
+	"ldcli/internal/analytics"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/help"
@@ -24,14 +25,17 @@ const (
 )
 
 type chooseSDKModel struct {
-	help          help.Model
-	helpKeys      keyMap
-	list          list.Model
-	selectedIndex int
-	selectedSDK   sdkDetail
+	accessToken      string
+	analyticsTracker analytics.Tracker
+	baseUri          string
+	help             help.Model
+	helpKeys         keyMap
+	list             list.Model
+	selectedIndex    int
+	selectedSDK      sdkDetail
 }
 
-func NewChooseSDKModel(selectedIndex int) tea.Model {
+func NewChooseSDKModel(analyticsTracker analytics.Tracker, accessToken, baseUri string, selectedIndex int) tea.Model {
 	l := list.New(sdksToItems(), sdkDelegate{}, 30, 9)
 	l.Title = "Select your SDK:\n"
 	// reset title styles
@@ -43,7 +47,10 @@ func NewChooseSDKModel(selectedIndex int) tea.Model {
 	l.SetFilteringEnabled(false) // TODO: try to get filtering working
 
 	return chooseSDKModel{
-		help: help.New(),
+		analyticsTracker: analyticsTracker,
+		accessToken:      accessToken,
+		baseUri:          baseUri,
+		help:             help.New(),
 		helpKeys: keyMap{
 			Back:          BindingBack,
 			CursorUp:      BindingCursorUp,
@@ -64,6 +71,14 @@ func NewChooseSDKModel(selectedIndex int) tea.Model {
 // Init sends commands when the model is created that will:
 // * select an SDK if it's already been selected
 func (m chooseSDKModel) Init() tea.Cmd {
+	m.analyticsTracker.SendEvent(
+		m.accessToken,
+		m.baseUri,
+		"CLI Setup Started",
+		map[string]interface{}{
+			"step": "2 - sdk selection",
+		},
+	)
 	return selectedSDK(m.selectedIndex)
 }
 

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -105,6 +105,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case stepToggleFlag:
 				m.currentStep -= 1
 				m.currentModel = NewShowSDKInstructionsModel(
+					m.analyticsTracker,
 					m.environmentsClient,
 					m.accessToken,
 					m.baseUri,

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -155,6 +155,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.err = nil
 	case showToggleFlagMsg:
 		m.currentModel = NewToggleFlagModel(
+			m.analyticsTracker,
 			m.flagsClient,
 			m.accessToken,
 			m.baseUri,

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -3,6 +3,7 @@ package quickstart
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -43,6 +44,7 @@ type ContainerModel struct {
 	gettingStarted     bool
 	quitting           bool
 	sdk                sdkDetail
+	startTime          time.Time
 	totalSteps         int
 	width              int
 }
@@ -63,6 +65,7 @@ func NewContainerModel(
 		environmentsClient: environmentsClient,
 		flagsClient:        flagsClient,
 		gettingStarted:     true,
+		startTime:          time.Now(),
 		totalSteps:         4,
 	}
 }
@@ -157,6 +160,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.baseUri,
 			m.flagKey,
 			m.sdk.kind,
+			m.startTime,
 		)
 		cmd = m.currentModel.Init()
 		m.currentStep += 1

--- a/internal/quickstart/create_flag.go
+++ b/internal/quickstart/create_flag.go
@@ -55,14 +55,7 @@ func NewCreateFlagModel(analyticsTracker analytics.Tracker, client flags.Client,
 }
 
 func (m createFlagModel) Init() tea.Cmd {
-	m.analyticsTracker.SendEvent(
-		m.accessToken,
-		m.baseUri,
-		"CLI Setup Started",
-		map[string]interface{}{
-			"step": "1 - feature flag name",
-		},
-	)
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, "1 - feature flag name")
 
 	return nil
 }

--- a/internal/quickstart/create_flag.go
+++ b/internal/quickstart/create_flag.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"ldcli/internal/analytics"
 	"ldcli/internal/flags"
 )
 
@@ -21,6 +22,7 @@ type flag struct {
 
 type createFlagModel struct {
 	accessToken      string
+	analyticsTracker analytics.Tracker
 	baseUri          string
 	client           flags.Client
 	err              error
@@ -32,7 +34,7 @@ type createFlagModel struct {
 	textInput        textinput.Model
 }
 
-func NewCreateFlagModel(client flags.Client, accessToken, baseUri string) tea.Model {
+func NewCreateFlagModel(analyticsTracker analytics.Tracker, client flags.Client, accessToken, baseUri string) tea.Model {
 	ti := textinput.New()
 	ti.Focus()
 	ti.CharLimit = 156
@@ -40,10 +42,11 @@ func NewCreateFlagModel(client flags.Client, accessToken, baseUri string) tea.Mo
 	ti.Prompt = ""
 
 	return createFlagModel{
-		accessToken: accessToken,
-		baseUri:     baseUri,
-		client:      client,
-		help:        help.New(),
+		analyticsTracker: analyticsTracker,
+		accessToken:      accessToken,
+		baseUri:          baseUri,
+		client:           client,
+		help:             help.New(),
 		helpKeys: keyMap{
 			Quit: BindingQuit,
 		},
@@ -52,6 +55,15 @@ func NewCreateFlagModel(client flags.Client, accessToken, baseUri string) tea.Mo
 }
 
 func (m createFlagModel) Init() tea.Cmd {
+	m.analyticsTracker.SendEvent(
+		m.accessToken,
+		m.baseUri,
+		"CLI Setup Started",
+		map[string]interface{}{
+			"step": "1 - feature flag name",
+		},
+	)
+
 	return nil
 }
 

--- a/internal/quickstart/create_flag.go
+++ b/internal/quickstart/create_flag.go
@@ -57,7 +57,7 @@ func NewCreateFlagModel(analyticsTracker analytics.Tracker, client flags.Client,
 }
 
 func (m createFlagModel) Init() tea.Cmd {
-	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.OutputFlag), "1 - feature flag name")
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.AnalyticsOptOut), "1 - feature flag name")
 
 	return nil
 }

--- a/internal/quickstart/create_flag.go
+++ b/internal/quickstart/create_flag.go
@@ -8,7 +8,9 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/viper"
 
+	"ldcli/cmd/cliflags"
 	"ldcli/internal/analytics"
 	"ldcli/internal/flags"
 )
@@ -55,7 +57,7 @@ func NewCreateFlagModel(analyticsTracker analytics.Tracker, client flags.Client,
 }
 
 func (m createFlagModel) Init() tea.Cmd {
-	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, "1 - feature flag name")
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.OutputFlag), "1 - feature flag name")
 
 	return nil
 }

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
 
+	"ldcli/internal/analytics"
 	"ldcli/internal/environments"
 	"ldcli/internal/sdks"
 )
@@ -41,9 +42,11 @@ type showSDKInstructionsModel struct {
 	spinner            spinner.Model
 	url                string
 	viewport           viewport.Model
+	analyticsTracker   analytics.Tracker
 }
 
 func NewShowSDKInstructionsModel(
+	analyticsTracker analytics.Tracker,
 	environmentsClient environments.Client,
 	accessToken string,
 	baseUri string,
@@ -67,6 +70,7 @@ func NewShowSDKInstructionsModel(
 	h := help.New()
 
 	return showSDKInstructionsModel{
+		analyticsTracker:   analyticsTracker,
 		accessToken:        accessToken,
 		baseUri:            baseUri,
 		canonicalName:      canonicalName,
@@ -92,6 +96,15 @@ func NewShowSDKInstructionsModel(
 // fetch SDK instructions
 // fetch the environment to get values to interpolate into the instructions
 func (m showSDKInstructionsModel) Init() tea.Cmd {
+	m.analyticsTracker.SendEvent(
+		m.accessToken,
+		m.baseUri,
+		"CLI Setup SDK Selected",
+		map[string]interface{}{
+			"sdk": m.canonicalName,
+		},
+	)
+
 	cmds := []tea.Cmd{m.spinner.Tick, readSDKInstructions(m.canonicalName)}
 
 	if m.environment == nil {

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -98,8 +98,8 @@ func NewShowSDKInstructionsModel(
 // fetch SDK instructions
 // fetch the environment to get values to interpolate into the instructions
 func (m showSDKInstructionsModel) Init() tea.Cmd {
-	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.OutputFlag), "3 - sdk installation")
-	m.analyticsTracker.SendSetupSDKSelectedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.OutputFlag), m.canonicalName)
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.AnalyticsOptOut), "3 - sdk installation")
+	m.analyticsTracker.SendSetupSDKSelectedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.AnalyticsOptOut), m.canonicalName)
 
 	cmds := []tea.Cmd{m.spinner.Tick, readSDKInstructions(m.canonicalName)}
 

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -96,22 +96,8 @@ func NewShowSDKInstructionsModel(
 // fetch SDK instructions
 // fetch the environment to get values to interpolate into the instructions
 func (m showSDKInstructionsModel) Init() tea.Cmd {
-	m.analyticsTracker.SendEvent(
-		m.accessToken,
-		m.baseUri,
-		"CLI Setup Started",
-		map[string]interface{}{
-			"step": "3 - sdk installation",
-		},
-	)
-	m.analyticsTracker.SendEvent(
-		m.accessToken,
-		m.baseUri,
-		"CLI Setup SDK Selected",
-		map[string]interface{}{
-			"sdk": m.canonicalName,
-		},
-	)
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, "3 - sdk installation")
+	m.analyticsTracker.SendSetupSDKSelectedEvent(m.accessToken, m.baseUri, m.canonicalName)
 
 	cmds := []tea.Cmd{m.spinner.Tick, readSDKInstructions(m.canonicalName)}
 

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -29,6 +29,7 @@ type environment struct {
 
 type showSDKInstructionsModel struct {
 	accessToken        string
+	analyticsTracker   analytics.Tracker
 	baseUri            string
 	canonicalName      string
 	displayName        string
@@ -42,7 +43,6 @@ type showSDKInstructionsModel struct {
 	spinner            spinner.Model
 	url                string
 	viewport           viewport.Model
-	analyticsTracker   analytics.Tracker
 }
 
 func NewShowSDKInstructionsModel(
@@ -96,6 +96,14 @@ func NewShowSDKInstructionsModel(
 // fetch SDK instructions
 // fetch the environment to get values to interpolate into the instructions
 func (m showSDKInstructionsModel) Init() tea.Cmd {
+	m.analyticsTracker.SendEvent(
+		m.accessToken,
+		m.baseUri,
+		"CLI Setup Started",
+		map[string]interface{}{
+			"step": "3 - sdk installation",
+		},
+	)
 	m.analyticsTracker.SendEvent(
 		m.accessToken,
 		m.baseUri,

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -10,7 +10,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/viper"
 
+	"ldcli/cmd/cliflags"
 	"ldcli/internal/analytics"
 	"ldcli/internal/environments"
 	"ldcli/internal/sdks"
@@ -96,7 +98,7 @@ func NewShowSDKInstructionsModel(
 // fetch SDK instructions
 // fetch the environment to get values to interpolate into the instructions
 func (m showSDKInstructionsModel) Init() tea.Cmd {
-	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, "3 - sdk installation")
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.OutputFlag), "3 - sdk installation")
 	m.analyticsTracker.SendSetupSDKSelectedEvent(m.accessToken, m.baseUri, m.canonicalName)
 
 	cmds := []tea.Cmd{m.spinner.Tick, readSDKInstructions(m.canonicalName)}

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -99,7 +99,7 @@ func NewShowSDKInstructionsModel(
 // fetch the environment to get values to interpolate into the instructions
 func (m showSDKInstructionsModel) Init() tea.Cmd {
 	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.OutputFlag), "3 - sdk installation")
-	m.analyticsTracker.SendSetupSDKSelectedEvent(m.accessToken, m.baseUri, m.canonicalName)
+	m.analyticsTracker.SendSetupSDKSelectedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.OutputFlag), m.canonicalName)
 
 	cmds := []tea.Cmd{m.spinner.Tick, readSDKInstructions(m.canonicalName)}
 

--- a/internal/quickstart/toggle_flag.go
+++ b/internal/quickstart/toggle_flag.go
@@ -94,6 +94,7 @@ func (m toggleFlagModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.analyticsTracker.SendSetupFlagToggledEvent(
 			m.accessToken,
 			m.baseUri,
+			viper.GetBool(cliflags.OutputFlag),
 			m.enabled,
 			m.toggleCount,
 			m.endTime.Sub(m.setupStartTime).Milliseconds(),

--- a/internal/quickstart/toggle_flag.go
+++ b/internal/quickstart/toggle_flag.go
@@ -56,14 +56,7 @@ func NewToggleFlagModel(analyticsTracker analytics.Tracker, client flags.Client,
 }
 
 func (m toggleFlagModel) Init() tea.Cmd {
-	m.analyticsTracker.SendEvent(
-		m.accessToken,
-		m.baseUri,
-		"CLI Setup Started",
-		map[string]interface{}{
-			"step": "4 - flag toggle",
-		},
-	)
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, "4 - flag toggle")
 
 	cmds := []tea.Cmd{
 		m.spinner.Tick,
@@ -96,15 +89,12 @@ func (m toggleFlagModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.flagWasFetched = true
 		m.enabled = msg.enabled
 		m.toggleCount++
-		m.analyticsTracker.SendEvent(
+		m.analyticsTracker.SendSetupFlagToggledEvent(
 			m.accessToken,
 			m.baseUri,
-			"CLI Setup Flag Toggled",
-			map[string]interface{}{
-				"on":          m.enabled,
-				"count":       m.toggleCount,
-				"duration_ms": m.endTime.Sub(m.setupStartTime).Milliseconds(),
-			},
+			m.enabled,
+			m.toggleCount,
+			m.endTime.Sub(m.setupStartTime).Milliseconds(),
 		)
 	case spinner.TickMsg:
 		m.spinner, cmd = m.spinner.Update(msg)

--- a/internal/quickstart/toggle_flag.go
+++ b/internal/quickstart/toggle_flag.go
@@ -9,7 +9,9 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/viper"
 
+	"ldcli/cmd/cliflags"
 	"ldcli/internal/analytics"
 	"ldcli/internal/errors"
 	"ldcli/internal/flags"
@@ -56,7 +58,7 @@ func NewToggleFlagModel(analyticsTracker analytics.Tracker, client flags.Client,
 }
 
 func (m toggleFlagModel) Init() tea.Cmd {
-	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, "4 - flag toggle")
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.OutputFlag), "4 - flag toggle")
 
 	cmds := []tea.Cmd{
 		m.spinner.Tick,

--- a/internal/quickstart/toggle_flag.go
+++ b/internal/quickstart/toggle_flag.go
@@ -58,7 +58,7 @@ func NewToggleFlagModel(analyticsTracker analytics.Tracker, client flags.Client,
 }
 
 func (m toggleFlagModel) Init() tea.Cmd {
-	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.OutputFlag), "4 - flag toggle")
+	m.analyticsTracker.SendSetupStartedEvent(m.accessToken, m.baseUri, viper.GetBool(cliflags.AnalyticsOptOut), "4 - flag toggle")
 
 	cmds := []tea.Cmd{
 		m.spinner.Tick,
@@ -94,7 +94,7 @@ func (m toggleFlagModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.analyticsTracker.SendSetupFlagToggledEvent(
 			m.accessToken,
 			m.baseUri,
-			viper.GetBool(cliflags.OutputFlag),
+			viper.GetBool(cliflags.AnalyticsOptOut),
 			m.enabled,
 			m.toggleCount,
 			m.endTime.Sub(m.setupStartTime).Milliseconds(),


### PR DESCRIPTION
Added three new types of events:
`SendSetupStartedEvent`, `SendSetupSDKSelectedEvent`, `SendSetupFlagToggledEvent`