### PR TITLE
feat: allow users to opt out of analytics tracking

### DIFF
--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -4,6 +4,7 @@ const (
 	BaseURIDefault = "https://app.launchdarkly.com"
 
 	AccessTokenFlag = "access-token"
+	AnalyticsOptOut = "analytics-opt-out"
 	BaseURIFlag     = "base-uri"
 	DataFlag        = "data"
 	EmailsFlag      = "emails"

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -28,6 +28,9 @@ func NewConfigCmd(analyticsTracker analytics.Tracker) *cobra.Command {
 		Short: "View and modify specific configuration values",
 		Use:   "config",
 		PreRun: func(cmd *cobra.Command, args []string) {
+			if viper.GetBool(cliflags.AnalyticsOptOut) {
+				return
+			}
 			analyticsTracker.SendEvent(
 				viper.GetString(cliflags.AccessTokenFlag),
 				viper.GetString(cliflags.BaseURIFlag),

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -28,12 +28,10 @@ func NewConfigCmd(analyticsTracker analytics.Tracker) *cobra.Command {
 		Short: "View and modify specific configuration values",
 		Use:   "config",
 		PreRun: func(cmd *cobra.Command, args []string) {
-			if viper.GetBool(cliflags.AnalyticsOptOut) {
-				return
-			}
 			analyticsTracker.SendEvent(
 				viper.GetString(cliflags.AccessTokenFlag),
 				viper.GetString(cliflags.BaseURIFlag),
+				viper.GetBool(cliflags.AnalyticsOptOut),
 				"CLI Command Run",
 				analytics.CmdRunEventProperties(cmd, "config"),
 			)

--- a/cmd/config/testdata/help.golden
+++ b/cmd/config/testdata/help.golden
@@ -11,5 +11,6 @@ Flags:
 
 Global Flags:
       --access-token string   LaunchDarkly API token with write-level access
+      --analytics-opt-out     Opt out of analytics tracking
       --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
   -o, --output string         Command response output format in either JSON or plain text (default "plaintext")

--- a/cmd/environments/environments.go
+++ b/cmd/environments/environments.go
@@ -18,12 +18,10 @@ func NewEnvironmentsCmd(
 		Short: "Make requests (list, create, etc.) on environments",
 		Long:  "Make requests (list, create, etc.) on environments",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if viper.GetBool(cliflags.AnalyticsOptOut) {
-				return
-			}
 			analyticsTracker.SendEvent(
 				viper.GetString(cliflags.AccessTokenFlag),
 				viper.GetString(cliflags.BaseURIFlag),
+				viper.GetBool(cliflags.AnalyticsOptOut),
 				"CLI Command Run",
 				analytics.CmdRunEventProperties(cmd, "environments"),
 			)

--- a/cmd/environments/environments.go
+++ b/cmd/environments/environments.go
@@ -18,6 +18,9 @@ func NewEnvironmentsCmd(
 		Short: "Make requests (list, create, etc.) on environments",
 		Long:  "Make requests (list, create, etc.) on environments",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if viper.GetBool(cliflags.AnalyticsOptOut) {
+				return
+			}
 			analyticsTracker.SendEvent(
 				viper.GetString(cliflags.AccessTokenFlag),
 				viper.GetString(cliflags.BaseURIFlag),

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -15,12 +15,10 @@ func NewFlagsCmd(analyticsTracker analytics.Tracker, client flags.Client) (*cobr
 		Short: "Make requests (list, create, etc.) on flags",
 		Long:  "Make requests (list, create, etc.) on flags",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if viper.GetBool(cliflags.AnalyticsOptOut) {
-				return
-			}
 			analyticsTracker.SendEvent(
 				viper.GetString(cliflags.AccessTokenFlag),
 				viper.GetString(cliflags.BaseURIFlag),
+				viper.GetBool(cliflags.AnalyticsOptOut),
 				"CLI Command Run",
 				analytics.CmdRunEventProperties(cmd, "flags"),
 			)

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -15,6 +15,9 @@ func NewFlagsCmd(analyticsTracker analytics.Tracker, client flags.Client) (*cobr
 		Short: "Make requests (list, create, etc.) on flags",
 		Long:  "Make requests (list, create, etc.) on flags",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if viper.GetBool(cliflags.AnalyticsOptOut) {
+				return
+			}
 			analyticsTracker.SendEvent(
 				viper.GetString(cliflags.AccessTokenFlag),
 				viper.GetString(cliflags.BaseURIFlag),

--- a/cmd/members/members.go
+++ b/cmd/members/members.go
@@ -15,12 +15,10 @@ func NewMembersCmd(analyticsTracker analytics.Tracker, client members.Client) (*
 		Short: "Make requests (list, create, etc.) on members",
 		Long:  "Make requests (list, create, etc.) on members",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if viper.GetBool(cliflags.AnalyticsOptOut) {
-				return
-			}
 			analyticsTracker.SendEvent(
 				viper.GetString(cliflags.AccessTokenFlag),
 				viper.GetString(cliflags.BaseURIFlag),
+				viper.GetBool(cliflags.AnalyticsOptOut),
 				"CLI Command Run",
 				analytics.CmdRunEventProperties(cmd, "members"),
 			)

--- a/cmd/members/members.go
+++ b/cmd/members/members.go
@@ -15,6 +15,9 @@ func NewMembersCmd(analyticsTracker analytics.Tracker, client members.Client) (*
 		Short: "Make requests (list, create, etc.) on members",
 		Long:  "Make requests (list, create, etc.) on members",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if viper.GetBool(cliflags.AnalyticsOptOut) {
+				return
+			}
 			analyticsTracker.SendEvent(
 				viper.GetString(cliflags.AccessTokenFlag),
 				viper.GetString(cliflags.BaseURIFlag),

--- a/cmd/projects/projects.go
+++ b/cmd/projects/projects.go
@@ -15,12 +15,10 @@ func NewProjectsCmd(analyticsTracker analytics.Tracker, client projects.Client) 
 		Short: "Make requests (list, create, etc.) on projects",
 		Long:  "Make requests (list, create, etc.) on projects",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if viper.GetBool(cliflags.AnalyticsOptOut) {
-				return
-			}
 			analyticsTracker.SendEvent(
 				viper.GetString(cliflags.AccessTokenFlag),
 				viper.GetString(cliflags.BaseURIFlag),
+				viper.GetBool(cliflags.AnalyticsOptOut),
 				"CLI Command Run",
 				analytics.CmdRunEventProperties(cmd, "projects"),
 			)

--- a/cmd/projects/projects.go
+++ b/cmd/projects/projects.go
@@ -15,6 +15,9 @@ func NewProjectsCmd(analyticsTracker analytics.Tracker, client projects.Client) 
 		Short: "Make requests (list, create, etc.) on projects",
 		Long:  "Make requests (list, create, etc.) on projects",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if viper.GetBool(cliflags.AnalyticsOptOut) {
+				return
+			}
 			analyticsTracker.SendEvent(
 				viper.GetString(cliflags.AccessTokenFlag),
 				viper.GetString(cliflags.BaseURIFlag),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,6 +99,16 @@ func NewRootCommand(
 		return nil, err
 	}
 
+	cmd.PersistentFlags().Bool(
+		cliflags.AnalyticsOptOut,
+		false,
+		"Opt out of analytics tracking",
+	)
+	err = viper.BindPFlag(cliflags.AnalyticsOptOut, cmd.PersistentFlags().Lookup(cliflags.AnalyticsOptOut))
+	if err != nil {
+		return nil, err
+	}
+
 	cmd.PersistentFlags().StringP(
 		cliflags.OutputFlag,
 		"o",

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -15,6 +15,7 @@ type Tracker interface {
 	SendEvent(
 		accessToken string,
 		baseURI string,
+		optOut bool,
 		eventName string,
 		properties map[string]interface{},
 	)
@@ -29,9 +30,13 @@ type Client struct {
 func (c *Client) SendEvent(
 	accessToken string,
 	baseURI string,
+	optOut bool,
 	eventName string,
 	properties map[string]interface{},
 ) {
+	if optOut {
+		return
+	}
 	input := struct {
 		Event      string                 `json:"event"`
 		Properties map[string]interface{} `json:"properties"`
@@ -87,6 +92,7 @@ type NoopClient struct{}
 func (c *NoopClient) SendEvent(
 	accessToken string,
 	baseURI string,
+	optOut bool,
 	eventName string,
 	properties map[string]interface{},
 ) {
@@ -100,6 +106,7 @@ type MockTracker struct {
 func (m *MockTracker) SendEvent(
 	accessToken string,
 	baseURI string,
+	optOut bool,
 	eventName string,
 	properties map[string]interface{},
 ) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/mitchellh/go-homedir"
 
@@ -12,8 +13,9 @@ const Filename = ".ldcli-config.yml"
 
 // ConfigFile represents the data stored in the config file.
 type ConfigFile struct {
-	AccessToken string `json:"access-token,omitempty" yaml:"access-token,omitempty"`
-	BaseURI     string `json:"base-uri,omitempty" yaml:"base-uri,omitempty"`
+	AccessToken     string `json:"access-token,omitempty" yaml:"access-token,omitempty"`
+	AnalyticsOptOut bool   `json:"analytics-opt-out,omitempty" yaml:"analytics-opt-out,omitempty"`
+	BaseURI         string `json:"base-uri,omitempty" yaml:"base-uri,omitempty"`
 }
 
 func NewConfig(rawConfig map[string]interface{}) ConfigFile {
@@ -21,14 +23,20 @@ func NewConfig(rawConfig map[string]interface{}) ConfigFile {
 	if rawConfig[cliflags.AccessTokenFlag] != nil {
 		accessToken = rawConfig[cliflags.AccessTokenFlag].(string)
 	}
+	var analyticsOptOut bool
+	if rawConfig[cliflags.AnalyticsOptOut] != nil {
+		stringValue := rawConfig[cliflags.AnalyticsOptOut].(string)
+		analyticsOptOut, _ = strconv.ParseBool(stringValue)
+	}
 	var baseURI string
 	if rawConfig[cliflags.BaseURIFlag] != nil {
 		baseURI = rawConfig[cliflags.BaseURIFlag].(string)
 	}
 
 	return ConfigFile{
-		AccessToken: accessToken,
-		BaseURI:     baseURI,
+		AccessToken:     accessToken,
+		AnalyticsOptOut: analyticsOptOut,
+		BaseURI:         baseURI,
 	}
 }
 


### PR DESCRIPTION
1. adds a new `analytics-opt-out` flag
a. this value can be set as an environment variable (`LD_ANALYTICS_OPT_OUT`), config value, or passed as a flag
b. this value can be set as `0` or `false` for false, `1` or `true` for true

2. will not send a tracking event if this value is set to true

Manually tested, was unsure how to update tests for this 🤔 