### PR TITLE
feat: add hardcoded operation command with no body

### DIFF
--- a/cmd/resource_cmds.go
+++ b/cmd/resource_cmds.go
@@ -23,7 +23,7 @@ func addAllResourceCmds(rootCmd *cobra.Command, client *http.Client) {
 	resources.NewOperationCmd(gen_TeamsResourceCmd, client, resources.OperationData{
 		Short: "Create team",
 		Long:  "Create a team. To learn more, read [Creating a team](https://docs.launchdarkly.com/home/teams/creating).\n\n### Expanding the teams response\nLaunchDarkly supports four fields for expanding the \"Create team\" response. By default, these fields are **not** included in the response.\n\nTo expand the response, append the `expand` query parameter and add a comma-separated list with any of the following fields:\n\n* `members` includes the total count of members that belong to the team.\n* `roles` includes a paginated list of the custom roles that you have assigned to the team.\n* `projects` includes a paginated list of the projects that the team has any write access to.\n* `maintainers` includes a paginated list of the maintainers that you have assigned to the team.\n\nFor example, `expand=members,roles` includes the `members` and `roles` fields in the response.\n",
-		Use:   "create",
+		Use:   "create", // TODO: translate post -> create
 		Params: []resources.Param{
 			{
 				Name:        "expand",
@@ -35,5 +35,28 @@ func addAllResourceCmds(rootCmd *cobra.Command, client *http.Client) {
 		HTTPMethod:   "post",
 		RequiresBody: true,
 		Path:         "/api/v2/teams",
+	})
+
+	resources.NewOperationCmd(gen_TeamsResourceCmd, client, resources.OperationData{
+		Short: "Get team",
+		Long:  "Fetch a team by key.\n\n### Expanding the teams response\nLaunchDarkly supports four fields for expanding the \"Get team\" response. By default, these fields are **not** included in the response.\n\nTo expand the response, append the `expand` query parameter and add a comma-separated list with any of the following fields:\n\n* `members` includes the total count of members that belong to the team.\n* `roles` includes a paginated list of the custom roles that you have assigned to the team.\n* `projects` includes a paginated list of the projects that the team has any write access to.\n* `maintainers` includes a paginated list of the maintainers that you have assigned to the team.\n\nFor example, `expand=members,roles` includes the `members` and `roles` fields in the response.\n",
+		Use:   "get",
+		Params: []resources.Param{
+			{
+				Name:        "teamKey", // TODO: kebab case/trim key? to be consistent with our existing flags (e.g. projectKey = project)
+				In:          "path",
+				Description: "The team key.",
+				Type:        "string",
+				Required:    true,
+			},
+			{
+				Name:        "expand",
+				In:          "query",
+				Description: "A comma-separated list of properties that can reveal additional information in the response.",
+				Type:        "string",
+			},
+		},
+		HTTPMethod: "get",
+		Path:       "/api/v2/teams/{teamKey}",
 	})
 }

--- a/cmd/resource_cmds.go
+++ b/cmd/resource_cmds.go
@@ -8,12 +8,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"ldcli/cmd/resources"
+	"ldcli/internal/analytics"
 )
 
-func addAllResourceCmds(rootCmd *cobra.Command, client *http.Client) {
+func addAllResourceCmds(rootCmd *cobra.Command, client *http.Client, analyticsTracker analytics.Tracker) {
 	// Resource commands
 	gen_TeamsResourceCmd := resources.NewResourceCmd(
 		rootCmd,
+		analyticsTracker,
 		"teams",
 		"A team is a group of members in your LaunchDarkly account.",
 		"A team can have maintainers who are able to add and remove team members. It also can have custom roles assigned to it that allows shared access to those roles for all team members. To learn more, read [Teams](https://docs.launchdarkly.com/home/teams).\n\nThe Teams API allows you to create, read, update, and delete a team.\n\nSeveral of the endpoints in the Teams API require one or more member IDs. The member ID is returned as part of the [List account members](/tag/Account-members#operation/getMembers) response. It is the `_id` field of each element in the `items` array.",

--- a/cmd/resource_cmds_test.go
+++ b/cmd/resource_cmds_test.go
@@ -37,6 +37,6 @@ func TestCreateTeam(t *testing.T) {
 
 		require.NoError(t, err)
 		s := string(output)
-		assert.Contains(t, s, "would be making a request to /api/v2/teams here, with args: map[data:map[key:team-key name:Team Name] expand:]\n")
+		assert.Contains(t, s, "would be making a post request to /api/v2/teams here, with args: map[data:map[key:team-key name:Team Name] expand:]\n")
 	})
 }

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -17,7 +17,6 @@ func NewResourceCmd(parentCmd *cobra.Command, resourceName, shortDescription, lo
 		Use:   resourceName,
 		Short: shortDescription,
 		Long:  longDescription,
-		//TODO: add tracking here
 	}
 
 	parentCmd.AddCommand(cmd)
@@ -40,6 +39,7 @@ type Param struct {
 	In          string
 	Description string
 	Type        string
+	Required    bool
 }
 
 type OperationCmd struct {
@@ -116,7 +116,7 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "would be making a request to %s here, with args: %s\n", op.Path, paramVals)
+	fmt.Fprintf(cmd.OutOrStdout(), "would be making a %s request to %s here, with args: %s\n", op.HTTPMethod, op.Path, paramVals)
 
 	return nil
 }

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -8,15 +8,25 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	cmdAnalytics "ldcli/cmd/analytics"
 	"ldcli/cmd/cliflags"
 	"ldcli/cmd/validators"
+	"ldcli/internal/analytics"
 )
 
-func NewResourceCmd(parentCmd *cobra.Command, resourceName, shortDescription, longDescription string) *cobra.Command {
+func NewResourceCmd(parentCmd *cobra.Command, analyticsTracker analytics.Tracker, resourceName, shortDescription, longDescription string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   resourceName,
 		Short: shortDescription,
 		Long:  longDescription,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			analyticsTracker.SendCommandRunEvent(
+				viper.GetString(cliflags.AccessTokenFlag),
+				viper.GetString(cliflags.BaseURIFlag),
+				viper.GetBool(cliflags.AnalyticsOptOut),
+				cmdAnalytics.CmdRunEventProperties(cmd, resourceName),
+			)
+		},
 	}
 
 	parentCmd.AddCommand(cmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,7 +144,7 @@ func NewRootCommand(
 	cmd.AddCommand(projectsCmd)
 	cmd.AddCommand(NewQuickStartCmd(clients.EnvironmentsClient, clients.FlagsClient))
 
-	addAllResourceCmds(cmd, clients.GenericClient)
+	addAllResourceCmds(cmd, clients.GenericClient, analyticsTracker)
 
 	return cmd, nil
 }


### PR DESCRIPTION
admittedly this probably didn't need to be its own PR, but we've added logging!

adds `teams get --teamKey {team key}`

note that the flag is camelcase, but that's how it comes from the openapi spec. we'll update this once we do the generation of OperationDate from the OpenAPI spec (comment left)