### PR TITLE
fix: Fix data flag JSON error handling

### DIFF
--- a/cmd/environments/get.go
+++ b/cmd/environments/get.go
@@ -64,16 +64,7 @@ func runGet(
 			viper.GetString(cliflags.ProjectFlag),
 		)
 		if err != nil {
-			output, err := output.CmdOutputSingular(
-				viper.GetString(cliflags.OutputFlag),
-				[]byte(err.Error()),
-				output.ErrorPlaintextOutputFn,
-			)
-			if err != nil {
-				return errors.NewError(err.Error())
-			}
-
-			return errors.NewError(output)
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 		}
 
 		output, err := output.CmdOutput("get", viper.GetString(cliflags.OutputFlag), response)

--- a/cmd/flags/create.go
+++ b/cmd/flags/create.go
@@ -57,7 +57,7 @@ func runCreate(client flags.Client) func(*cobra.Command, []string) error {
 		var data inputData
 		err := json.Unmarshal([]byte(viper.GetString(cliflags.DataFlag)), &data)
 		if err != nil {
-			return err
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 		}
 
 		response, err := client.Create(
@@ -69,16 +69,7 @@ func runCreate(client flags.Client) func(*cobra.Command, []string) error {
 			viper.GetString(cliflags.ProjectFlag),
 		)
 		if err != nil {
-			output, err := output.CmdOutputSingular(
-				viper.GetString(cliflags.OutputFlag),
-				[]byte(err.Error()),
-				output.ErrorPlaintextOutputFn,
-			)
-			if err != nil {
-				return errors.NewError(err.Error())
-			}
-
-			return errors.NewError(output)
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 		}
 
 		output, err := output.CmdOutput("create", viper.GetString(cliflags.OutputFlag), response)

--- a/cmd/flags/get.go
+++ b/cmd/flags/get.go
@@ -67,16 +67,7 @@ func runGet(client flags.Client) func(*cobra.Command, []string) error {
 			viper.GetString(cliflags.EnvironmentFlag),
 		)
 		if err != nil {
-			output, err := output.CmdOutputSingular(
-				viper.GetString(cliflags.OutputFlag),
-				[]byte(err.Error()),
-				output.ErrorPlaintextOutputFn,
-			)
-			if err != nil {
-				return errors.NewError(err.Error())
-			}
-
-			return errors.NewError(output)
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 		}
 
 		output, err := output.CmdOutput("get", viper.GetString(cliflags.OutputFlag), response)

--- a/cmd/flags/update.go
+++ b/cmd/flags/update.go
@@ -125,7 +125,7 @@ func runUpdate(client flags.Client) func(*cobra.Command, []string) error {
 		} else {
 			err := json.Unmarshal([]byte(viper.GetString(cliflags.DataFlag)), &patch)
 			if err != nil {
-				return err
+				return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 			}
 		}
 
@@ -138,16 +138,7 @@ func runUpdate(client flags.Client) func(*cobra.Command, []string) error {
 			patch,
 		)
 		if err != nil {
-			output, err := output.CmdOutputSingular(
-				viper.GetString(cliflags.OutputFlag),
-				[]byte(err.Error()),
-				output.ErrorPlaintextOutputFn,
-			)
-			if err != nil {
-				return errors.NewError(err.Error())
-			}
-
-			return errors.NewError(output)
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 		}
 
 		output, err := output.CmdOutput("update", viper.GetString(cliflags.OutputFlag), response)

--- a/cmd/members/create.go
+++ b/cmd/members/create.go
@@ -40,10 +40,9 @@ func NewCreateCmd(client members.Client) (*cobra.Command, error) {
 func runCreate(client members.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		var data []members.MemberInput
-		// TODO: why does viper.GetString(cliflags.DataFlag) not work?
-		err := json.Unmarshal([]byte(cmd.Flags().Lookup(cliflags.DataFlag).Value.String()), &data)
+		err := json.Unmarshal([]byte(viper.GetString(cliflags.DataFlag)), &data)
 		if err != nil {
-			return errors.NewError(err.Error())
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 		}
 
 		response, err := client.Create(
@@ -53,16 +52,7 @@ func runCreate(client members.Client) func(*cobra.Command, []string) error {
 			data,
 		)
 		if err != nil {
-			output, err := output.CmdOutputSingular(
-				viper.GetString(cliflags.OutputFlag),
-				[]byte(err.Error()),
-				output.ErrorPlaintextOutputFn,
-			)
-			if err != nil {
-				return errors.NewError(err.Error())
-			}
-
-			return errors.NewError(output)
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 		}
 
 		output, err := output.CmdOutput("create", viper.GetString(cliflags.OutputFlag), response)

--- a/cmd/members/invite.go
+++ b/cmd/members/invite.go
@@ -62,16 +62,7 @@ func runInvite(client members.Client) func(*cobra.Command, []string) error {
 			memberInputs,
 		)
 		if err != nil {
-			output, err := output.CmdOutputSingular(
-				viper.GetString(cliflags.OutputFlag),
-				[]byte(err.Error()),
-				output.ErrorPlaintextOutputFn,
-			)
-			if err != nil {
-				return errors.NewError(err.Error())
-			}
-
-			return errors.NewError(output)
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 		}
 
 		output, err := output.CmdOutput("create", viper.GetString(cliflags.OutputFlag), response)

--- a/cmd/projects/create.go
+++ b/cmd/projects/create.go
@@ -48,7 +48,7 @@ func runCreate(client projects.Client) func(*cobra.Command, []string) error {
 		// TODO: why does viper.GetString(cliflags.DataFlag) not work?
 		err := json.Unmarshal([]byte(cmd.Flags().Lookup(cliflags.DataFlag).Value.String()), &data)
 		if err != nil {
-			return err
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 		}
 
 		response, err := client.Create(
@@ -59,16 +59,7 @@ func runCreate(client projects.Client) func(*cobra.Command, []string) error {
 			data.Key,
 		)
 		if err != nil {
-			output, err := output.CmdOutputSingular(
-				viper.GetString(cliflags.OutputFlag),
-				[]byte(err.Error()),
-				output.ErrorPlaintextOutputFn,
-			)
-			if err != nil {
-				return errors.NewError(err.Error())
-			}
-
-			return errors.NewError(output)
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 		}
 
 		output, err := output.CmdOutput("create", viper.GetString(cliflags.OutputFlag), response)

--- a/cmd/projects/list.go
+++ b/cmd/projects/list.go
@@ -34,16 +34,7 @@ func runList(client projects.Client) func(*cobra.Command, []string) error {
 			viper.GetString(cliflags.BaseURIFlag),
 		)
 		if err != nil {
-			output, err := output.CmdOutputSingular(
-				viper.GetString(cliflags.OutputFlag),
-				[]byte(err.Error()),
-				output.ErrorPlaintextOutputFn,
-			)
-			if err != nil {
-				return errors.NewError(err.Error())
-			}
-
-			return errors.NewError(output)
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
 		}
 
 		output, err := output.CmdOutput("list", viper.GetString(cliflags.OutputFlag), response)

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -16,7 +16,7 @@ func TestAPIError(t *testing.T) {
 	t.Run("with a 400 error has a JSON response", func(t *testing.T) {
 		underlying := errs.NewAPIError(
 			[]byte(`{"code":"conflict","message":"an error"}`),
-			errors.New("409 Conflict"),
+			errors.New("400 an error"),
 			[]string{},
 		)
 
@@ -45,7 +45,7 @@ func TestAPIError(t *testing.T) {
 	t.Run("with a 403 error has a JSON response", func(t *testing.T) {
 		underlying := errs.NewAPIError(
 			[]byte(`{"code": "forbidden", "message": "an error"}`),
-			errors.New("409 Conflict"),
+			errors.New("403 Forbidden"),
 			[]string{},
 		)
 

--- a/internal/output/resource_output_test.go
+++ b/internal/output/resource_output_test.go
@@ -1,11 +1,14 @@
 package output_test
 
 import (
-	"ldcli/internal/output"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"ldcli/internal/errors"
+	"ldcli/internal/output"
 )
 
 func TestCmdOutput(t *testing.T) {
@@ -16,7 +19,7 @@ func TestCmdOutput(t *testing.T) {
 			"other": "other-value"
 		}`
 
-		t.Run("with json output", func(t *testing.T) {
+		t.Run("with JSON output", func(t *testing.T) {
 			t.Run("returns the JSON", func(t *testing.T) {
 				result, err := output.CmdOutput("create", "json", []byte(input))
 
@@ -48,7 +51,7 @@ func TestCmdOutput(t *testing.T) {
 			]
 		}`
 
-		t.Run("with json output", func(t *testing.T) {
+		t.Run("with JSON output", func(t *testing.T) {
 			t.Run("returns the JSON", func(t *testing.T) {
 				result, err := output.CmdOutput("create", "json", []byte(input))
 
@@ -80,7 +83,7 @@ func TestCmdOutput(t *testing.T) {
 			]
 		}`
 
-		t.Run("with json output", func(t *testing.T) {
+		t.Run("with JSON output", func(t *testing.T) {
 			t.Run("returns the JSON", func(t *testing.T) {
 				result, err := output.CmdOutput("create", "json", []byte(input))
 
@@ -107,7 +110,7 @@ func TestCmdOutput(t *testing.T) {
 			"name": "test-name"
 		}`
 
-		t.Run("with json output", func(t *testing.T) {
+		t.Run("with JSON output", func(t *testing.T) {
 			t.Run("does not return anything", func(t *testing.T) {
 				result, err := output.CmdOutput("delete", "json", []byte(""))
 
@@ -149,7 +152,7 @@ func TestCmdOutput(t *testing.T) {
 			"other": "other-value"
 		}`
 
-		t.Run("with json output", func(t *testing.T) {
+		t.Run("with JSON output", func(t *testing.T) {
 			t.Run("returns the JSON", func(t *testing.T) {
 				result, err := output.CmdOutput("update", "json", []byte(input))
 
@@ -167,6 +170,31 @@ func TestCmdOutput(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, expected, result)
 			})
+		})
+	})
+}
+
+func TestCmdOutputError(t *testing.T) {
+	t.Run("with an API error", func(t *testing.T) {
+		t.Run("with JSON output", func(t *testing.T) {
+			expected := `{"code":"conflict", "message":"an error"}`
+			err := errors.NewError(`{"code":"conflict", "message":"an error"}`)
+
+			result := output.CmdOutputError("json", err)
+
+			assert.JSONEq(t, expected, result)
+		})
+
+		t.Run("with plaintext output", func(t *testing.T) {
+			expected := "invalid JSON"
+			type testType any
+			invalid := []byte(`{"invalid": true}`)
+			err := json.Unmarshal(invalid, &[]testType{})
+			require.Error(t, err)
+
+			result := output.CmdOutputError("plaintext", err)
+
+			assert.Equal(t, expected, result)
 		})
 	})
 }


### PR DESCRIPTION
Running the `members create` command with invalid JSON would show a bad error:
```
json: cannot unmarshal object into Go value of type []members.MemberInput
```
Now it shows a nicer one:
```
$ ldcli members create --data '{"email": "friend+11@launchdarkly.com", "role": "writer"}'
invalid JSON
$ ldcli members create --data '{"email": "friend+11@launchdarkly.com", "role": "writer"}' --output json
{"message":"invalid JSON"}
```

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
