### PR TITLE
feat: track cli setup started event

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -11,25 +11,28 @@ import (
 
 	"ldcli/cmd/cliflags"
 	"ldcli/cmd/validators"
+	"ldcli/internal/analytics"
 	"ldcli/internal/environments"
 	"ldcli/internal/flags"
 	"ldcli/internal/quickstart"
 )
 
 func NewQuickStartCmd(
+	analyticsTracker analytics.Tracker,
 	environmentsClient environments.Client,
 	flagsClient flags.Client,
 ) *cobra.Command {
 	return &cobra.Command{
 		Args:  validators.Validate(),
 		Long:  "",
-		RunE:  runQuickStart(environmentsClient, flagsClient),
+		RunE:  runQuickStart(analyticsTracker, environmentsClient, flagsClient),
 		Short: "Setup guide to create your first feature flag",
 		Use:   "setup",
 	}
 }
 
 func runQuickStart(
+	analyticsTracker analytics.Tracker,
 	environmentsClient environments.Client,
 	flagsClient flags.Client,
 ) func(*cobra.Command, []string) error {
@@ -42,6 +45,7 @@ func runQuickStart(
 		defer f.Close()
 
 		_, err = tea.NewProgram(quickstart.NewContainerModel(
+			analyticsTracker,
 			environmentsClient,
 			flagsClient,
 			viper.GetString(cliflags.AccessTokenFlag),

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -45,6 +45,7 @@ func runQuickStart(
 		defer f.Close()
 
 		_, err = tea.NewProgram(quickstart.NewContainerModel(
+			viper.GetBool(cliflags.AnalyticsOptOut),
 			analyticsTracker,
 			environmentsClient,
 			flagsClient,

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -45,11 +45,11 @@ func runQuickStart(
 		defer f.Close()
 
 		_, err = tea.NewProgram(quickstart.NewContainerModel(
-			viper.GetBool(cliflags.AnalyticsOptOut),
 			analyticsTracker,
 			environmentsClient,
 			flagsClient,
 			viper.GetString(cliflags.AccessTokenFlag),
+			viper.GetBool(cliflags.AnalyticsOptOut),
 			viper.GetString(cliflags.BaseURIFlag),
 		)).Run()
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,7 +142,7 @@ func NewRootCommand(
 	cmd.AddCommand(flagsCmd)
 	cmd.AddCommand(membersCmd)
 	cmd.AddCommand(projectsCmd)
-	cmd.AddCommand(NewQuickStartCmd(clients.EnvironmentsClient, clients.FlagsClient))
+	cmd.AddCommand(NewQuickStartCmd(analyticsTracker, clients.EnvironmentsClient, clients.FlagsClient))
 
 	addAllResourceCmds(cmd, clients.GenericClient, analyticsTracker)
 

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -24,7 +24,7 @@ type Tracker interface {
 		optOut bool,
 		outcome string,
 	)
-	SendSetupStartedEvent(
+	SendSetupStepStartedEvent(
 		accessToken,
 		baseURI string,
 		optOut bool,
@@ -134,7 +134,7 @@ func (c *Client) SendCommandCompletedEvent(
 	}
 }
 
-func (c *Client) SendSetupStartedEvent(
+func (c *Client) SendSetupStepStartedEvent(
 	accessToken,
 	baseURI string,
 	optOut bool,
@@ -173,7 +173,7 @@ func (c *NoopClient) SendCommandCompletedEvent(
 ) {
 }
 
-func (c *NoopClient) SendSetupStartedEvent(
+func (c *NoopClient) SendSetupStepStartedEvent(
 	accessToken,
 	baseURI string,
 	optOut bool,
@@ -229,7 +229,7 @@ func (m *MockTracker) SendCommandCompletedEvent(
 	)
 }
 
-func (m *MockTracker) SendSetupStartedEvent(
+func (m *MockTracker) SendSetupStepStartedEvent(
 	accessToken,
 	baseURI string,
 	optOut bool,

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -24,6 +24,12 @@ type Tracker interface {
 		optOut bool,
 		outcome string,
 	)
+	SendSetupStartedEvent(
+		accessToken,
+		baseURI string,
+		optOut bool,
+		step string,
+	)
 }
 
 type Client struct {
@@ -128,6 +134,23 @@ func (c *Client) SendCommandCompletedEvent(
 	}
 }
 
+func (c *Client) SendSetupStartedEvent(
+	accessToken,
+	baseURI string,
+	optOut bool,
+	step string,
+) {
+	c.sendEvent(
+		accessToken,
+		baseURI,
+		optOut,
+		"CLI Setup Started",
+		map[string]interface{}{
+			"step": step,
+		},
+	)
+}
+
 func (a *Client) Wait() {
 	a.wg.Wait()
 }
@@ -147,6 +170,14 @@ func (c *NoopClient) SendCommandCompletedEvent(
 	baseURI string,
 	optOut bool,
 	outcome string,
+) {
+}
+
+func (c *NoopClient) SendSetupStartedEvent(
+	accessToken,
+	baseURI string,
+	optOut bool,
+	step string,
 ) {
 }
 
@@ -194,6 +225,23 @@ func (m *MockTracker) SendCommandCompletedEvent(
 		"CLI Command Completed",
 		map[string]interface{}{
 			"outcome": outcome,
+		},
+	)
+}
+
+func (m *MockTracker) SendSetupStartedEvent(
+	accessToken,
+	baseURI string,
+	optOut bool,
+	step string,
+) {
+	m.sendEvent(
+		accessToken,
+		baseURI,
+		optOut,
+		"CLI Setup Started",
+		map[string]interface{}{
+			"step": step,
 		},
 	)
 }

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -144,7 +144,7 @@ func (c *Client) SendSetupStartedEvent(
 		accessToken,
 		baseURI,
 		optOut,
-		"CLI Setup Started",
+		"CLI Setup Step Started",
 		map[string]interface{}{
 			"step": step,
 		},
@@ -239,7 +239,7 @@ func (m *MockTracker) SendSetupStartedEvent(
 		accessToken,
 		baseURI,
 		optOut,
-		"CLI Setup Started",
+		"CLI Setup Step Started",
 		map[string]interface{}{
 			"step": step,
 		},

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -8,7 +8,10 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/muesli/reflow/wordwrap"
+	"github.com/spf13/viper"
 
+	"ldcli/cmd/cliflags"
+	"ldcli/internal/analytics"
 	"ldcli/internal/environments"
 	"ldcli/internal/flags"
 )
@@ -30,6 +33,7 @@ const (
 // represents a step in the quick-start flow.
 type ContainerModel struct {
 	accessToken        string
+	analyticsTracker   analytics.Tracker
 	baseUri            string
 	currentModel       tea.Model
 	currentStep        int
@@ -46,6 +50,7 @@ type ContainerModel struct {
 }
 
 func NewContainerModel(
+	analyticsTracker analytics.Tracker,
 	environmentsClient environments.Client,
 	flagsClient flags.Client,
 	accessToken string,
@@ -64,7 +69,13 @@ func NewContainerModel(
 }
 
 func (m ContainerModel) Init() tea.Cmd {
-	return nil
+	return trackSetupStartedEvent(
+		m.analyticsTracker,
+		m.accessToken,
+		m.baseUri,
+		viper.GetBool(cliflags.AnalyticsOptOut),
+		"1 - feature flag name",
+	)
 }
 
 func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -43,8 +43,8 @@ func (s step) String() string {
 // represents a step in the quick-start flow.
 type ContainerModel struct {
 	accessToken        string
-	analyticsTracker   analytics.Tracker
 	analyticsOptOut    bool
+	analyticsTracker   analytics.Tracker
 	baseUri            string
 	currentModel       tea.Model
 	currentStep        step
@@ -61,11 +61,11 @@ type ContainerModel struct {
 }
 
 func NewContainerModel(
-	analyticsOptOut bool,
 	analyticsTracker analytics.Tracker,
 	environmentsClient environments.Client,
 	flagsClient flags.Client,
 	accessToken string,
+	analyticsOptOut bool,
 	baseUri string,
 ) tea.Model {
 	return ContainerModel{

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -83,7 +83,7 @@ func NewContainerModel(
 }
 
 func (m ContainerModel) Init() tea.Cmd {
-	return trackSetupStartedEvent(
+	return trackSetupStepStartedEvent(
 		m.analyticsTracker,
 		m.accessToken,
 		m.baseUri,
@@ -185,7 +185,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if sendEvent {
-		cmd = tea.Batch(cmd, trackSetupStartedEvent(
+		cmd = tea.Batch(cmd, trackSetupStepStartedEvent(
 			m.analyticsTracker,
 			m.accessToken,
 			m.baseUri,

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -30,7 +30,13 @@ const (
 )
 
 func (s step) String() string {
-	return [...]string{"_", "1 - feature flag name", "2 - sdk selection", "3 - sdk installation", "4 - flag toggle"}[s]
+	return []string{
+		"_",
+		"1 - feature flag name",
+		"2 - sdk selection",
+		"3 - sdk installation",
+		"4 - flag toggle",
+	}[s]
 }
 
 // ContainerModel is a high level container model that controls the nested models where each

--- a/internal/quickstart/container.go
+++ b/internal/quickstart/container.go
@@ -8,9 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/muesli/reflow/wordwrap"
-	"github.com/spf13/viper"
 
-	"ldcli/cmd/cliflags"
 	"ldcli/internal/analytics"
 	"ldcli/internal/environments"
 	"ldcli/internal/flags"
@@ -40,6 +38,7 @@ func (s step) String() string {
 type ContainerModel struct {
 	accessToken        string
 	analyticsTracker   analytics.Tracker
+	analyticsOptOut    bool
 	baseUri            string
 	currentModel       tea.Model
 	currentStep        step
@@ -56,6 +55,7 @@ type ContainerModel struct {
 }
 
 func NewContainerModel(
+	analyticsOptOut bool,
 	analyticsTracker analytics.Tracker,
 	environmentsClient environments.Client,
 	flagsClient flags.Client,
@@ -64,6 +64,8 @@ func NewContainerModel(
 ) tea.Model {
 	return ContainerModel{
 		accessToken:        accessToken,
+		analyticsOptOut:    analyticsOptOut,
+		analyticsTracker:   analyticsTracker,
 		baseUri:            baseUri,
 		currentModel:       NewCreateFlagModel(flagsClient, accessToken, baseUri),
 		currentStep:        1,
@@ -79,7 +81,7 @@ func (m ContainerModel) Init() tea.Cmd {
 		m.analyticsTracker,
 		m.accessToken,
 		m.baseUri,
-		viper.GetBool(cliflags.AnalyticsOptOut),
+		m.analyticsOptOut,
 		m.currentStep.String(),
 	)
 }
@@ -181,7 +183,7 @@ func (m ContainerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.analyticsTracker,
 			m.accessToken,
 			m.baseUri,
-			viper.GetBool(cliflags.AnalyticsOptOut),
+			m.analyticsOptOut,
 			m.currentStep.String(),
 		))
 	}

--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -244,9 +244,9 @@ func selectedSDK(index int) tea.Cmd {
 
 type eventTrackedMsg struct{}
 
-func trackSetupStartedEvent(tracker analytics.Tracker, accessToken, baseURI string, optOut bool, step string) tea.Cmd {
+func trackSetupStepStartedEvent(tracker analytics.Tracker, accessToken, baseURI string, optOut bool, step string) tea.Cmd {
 	return func() tea.Msg {
-		tracker.SendSetupStartedEvent(accessToken, baseURI, optOut, step)
+		tracker.SendSetupStepStartedEvent(accessToken, baseURI, optOut, step)
 
 		return eventTrackedMsg{}
 	}

--- a/internal/quickstart/messages.go
+++ b/internal/quickstart/messages.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"ldcli/internal/analytics"
 	"ldcli/internal/environments"
 	"ldcli/internal/errors"
 	"ldcli/internal/flags"
@@ -238,5 +239,15 @@ type selectedSDKMsg struct {
 func selectedSDK(index int) tea.Cmd {
 	return func() tea.Msg {
 		return selectedSDKMsg{index: index}
+	}
+}
+
+type eventTrackedMsg struct{}
+
+func trackSetupStartedEvent(tracker analytics.Tracker, accessToken, baseURI string, optOut bool, step string) tea.Cmd {
+	return func() tea.Msg {
+		tracker.SendSetupStartedEvent(accessToken, baseURI, optOut, step)
+
+		return eventTrackedMsg{}
 	}
 }


### PR DESCRIPTION
Added the `cli setup started` event specifically.
- Created a eventTrackedMsg and trackSetupStartedEvent function to send cmd. 
- All trackSetupStartedEvent function calls happen within container

gif:
![CleanShot 2024-04-30 at 11 42 25](https://github.com/launchdarkly/ldcli/assets/58448919/307916a0-e8eb-4d24-b4a0-03929b3d6db2)


**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
