### PR TITLE
feat: Add valid config fields to its help

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The LaunchDarkly CLI allows you to save preferred settings, either within a conf
 Supported settings:
 
 * `access-token` A LaunchDarkly access token with write-level access
-* `analytics-optout` Opt out of analytics tracking (default false)
+* `analytics-opt-out` Opt out of analytics tracking (default false)
 * `base-uri` LaunchDarkly base URI (default "https://app.launchdarkly.com")
 * `output` Command response output format in either JSON or plain text
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ ldcli --help
 
 The LaunchDarkly CLI allows you to save preferred settings, either within a config file using the `config` commands, or set as environment variables.
 
-Current respected settings:
+Current settings:
 
-* `access-token` A LaunchDarkly API token with write-level access
+* `access-token` A LaunchDarkly access token with write-level access
 * `analytics-optout` Opt out of analytics tracking (default false)
 * `base-uri` LaunchDarkly base URI (default "https://app.launchdarkly.com")
+* `output` Command response output format in either JSON or plain text
 
 To set a value as an environment variable, prepend the variable name with `LD`. For example:
 ```shell

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ldcli --help
 
 The LaunchDarkly CLI allows you to save preferred settings, either within a config file using the `config` commands, or set as environment variables.
 
-Current settings:
+Supported settings:
 
 * `access-token` A LaunchDarkly access token with write-level access
 * `analytics-optout` Opt out of analytics tracking (default false)

--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -13,4 +13,18 @@ const (
 	OutputFlag      = "output"
 	ProjectFlag     = "project"
 	RoleFlag        = "role"
+
+	AccessTokenFlagDescription = "LaunchDarkly access token with write-level access"
+	AnalyticsOptOutDescription = "Opt out of analytics tracking"
+	BaseURIFlagDescription     = "LaunchDarkly base URI"
+	OutputFlagDescription      = "Command response output format in either JSON or plain text"
 )
+
+func AllFlagsHelp() map[string]string {
+	return map[string]string{
+		AccessTokenFlag: AccessTokenFlagDescription,
+		AnalyticsOptOut: AnalyticsOptOutDescription,
+		BaseURIFlag:     BaseURIFlagDescription,
+		OutputFlag:      OutputFlagDescription,
+	}
+}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -38,6 +39,22 @@ func NewConfigCmd(analyticsTracker analytics.Tracker) *cobra.Command {
 			)
 		},
 	}
+
+	helpFun := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		var sb strings.Builder
+		sb.WriteString("\n\nCurrent settings:\n")
+		for _, s := range []string{
+			cliflags.AccessTokenFlag,
+			cliflags.AnalyticsOptOut,
+			cliflags.BaseURIFlag,
+			cliflags.OutputFlag,
+		} {
+			sb.WriteString(fmt.Sprintf("- `%s`: %s\n", s, cliflags.AllFlagsHelp()[s]))
+		}
+		cmd.Long += sb.String()
+		helpFun(cmd, args)
+	})
 
 	cmd.Flags().Bool(ListFlag, false, "List configs")
 	_ = viper.BindPFlag(ListFlag, cmd.Flags().Lookup(ListFlag))

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -43,7 +43,7 @@ func NewConfigCmd(analyticsTracker analytics.Tracker) *cobra.Command {
 	helpFun := cmd.HelpFunc()
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		var sb strings.Builder
-		sb.WriteString("\n\nCurrent settings:\n")
+		sb.WriteString("\n\nSupported settings:\n")
 		for _, s := range []string{
 			cliflags.AccessTokenFlag,
 			cliflags.AnalyticsOptOut,

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,13 +1,14 @@
 package config_test
 
 import (
-	"ldcli/cmd"
-	"ldcli/internal/analytics"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"ldcli/cmd"
+	"ldcli/internal/analytics"
 )
 
 func TestNoFlag(t *testing.T) {

--- a/cmd/config/testdata/help.golden
+++ b/cmd/config/testdata/help.golden
@@ -1,5 +1,11 @@
 View and modify specific configuration values
 
+Current settings:
+- `access-token`: LaunchDarkly access token with write-level access
+- `analytics-opt-out`: Opt out of analytics tracking
+- `base-uri`: LaunchDarkly base URI
+- `output`: Command response output format in either JSON or plain text
+
 Usage:
   ldcli config [flags]
 
@@ -10,7 +16,7 @@ Flags:
       --unset string   Unset a config field
 
 Global Flags:
-      --access-token string   LaunchDarkly API token with write-level access
+      --access-token string   LaunchDarkly access token with write-level access
       --analytics-opt-out     Opt out of analytics tracking
       --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
   -o, --output string         Command response output format in either JSON or plain text (default "plaintext")

--- a/cmd/config/testdata/help.golden
+++ b/cmd/config/testdata/help.golden
@@ -1,6 +1,6 @@
 View and modify specific configuration values
 
-Current settings:
+Supported settings:
 - `access-token`: LaunchDarkly access token with write-level access
 - `analytics-opt-out`: Opt out of analytics tracking
 - `base-uri`: LaunchDarkly base URI

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,7 +78,7 @@ func NewRootCommand(
 	cmd.PersistentFlags().String(
 		cliflags.AccessTokenFlag,
 		"",
-		"LaunchDarkly API token with write-level access",
+		cliflags.AccessTokenFlagDescription,
 	)
 	err := cmd.MarkPersistentFlagRequired(cliflags.AccessTokenFlag)
 	if err != nil {
@@ -92,7 +92,7 @@ func NewRootCommand(
 	cmd.PersistentFlags().String(
 		cliflags.BaseURIFlag,
 		cliflags.BaseURIDefault,
-		"LaunchDarkly base URI",
+		cliflags.BaseURIFlagDescription,
 	)
 	err = viper.BindPFlag(cliflags.BaseURIFlag, cmd.PersistentFlags().Lookup(cliflags.BaseURIFlag))
 	if err != nil {
@@ -102,7 +102,7 @@ func NewRootCommand(
 	cmd.PersistentFlags().Bool(
 		cliflags.AnalyticsOptOut,
 		false,
-		"Opt out of analytics tracking",
+		cliflags.AnalyticsOptOutDescription,
 	)
 	err = viper.BindPFlag(cliflags.AnalyticsOptOut, cmd.PersistentFlags().Lookup(cliflags.AnalyticsOptOut))
 	if err != nil {
@@ -113,7 +113,7 @@ func NewRootCommand(
 		cliflags.OutputFlag,
 		"o",
 		"plaintext",
-		"Command response output format in either JSON or plain text",
+		cliflags.OutputFlagDescription,
 	)
 	err = viper.BindPFlag(cliflags.OutputFlag, cmd.PersistentFlags().Lookup(cliflags.OutputFlag))
 	if err != nil {


### PR DESCRIPTION
Running `ldcli config --help` shows
```
View and modify specific configuration values

Current settings:
- `access-token`: LaunchDarkly access token with write-level access
- `analytics-opt-out`: Opt out of analytics tracking
- `base-uri`: LaunchDarkly base URI
- `output`: Command response output format in either JSON or plain text

Usage:
  ldcli config [flags]

Flags:
  -h, --help           help for config
      --list           List configs
      --set            Set a config field to a value
      --unset string   Unset a config field

Global Flags:
      --access-token string   LaunchDarkly access token with write-level access
      --analytics-opt-out     Opt out of analytics tracking
      --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
  -o, --output string         Command response output format in either JSON or plain text (default "plaintext")`
```

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
