### PR TITLE
fix: config action output

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -122,6 +122,28 @@ func run() func(*cobra.Command, []string) error {
 
 			return writeConfig(configFile, v, setKeyFn)
 		case viper.IsSet(UnsetFlag):
+			isValid := false
+			for _, s := range []string{
+				cliflags.AccessTokenFlag,
+				cliflags.AnalyticsOptOut,
+				cliflags.BaseURIFlag,
+				cliflags.OutputFlag,
+			} {
+				if s == viper.GetString(UnsetFlag) {
+					isValid = true
+				}
+			}
+			if !isValid {
+				err := errors.NewError(
+					fmt.Sprintf(`{
+							"message": "%s is not a valid configuration option"
+						}`,
+						viper.GetString(UnsetFlag),
+					),
+				)
+				return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
+			}
+
 			config, v, err := getConfig()
 			if err != nil {
 				return err

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -96,6 +96,13 @@ func run() func(*cobra.Command, []string) error {
 				return errors.NewError("flag needs an argument: --set")
 			}
 
+			for i := 0; i < len(args)-1; i += 2 {
+				_, ok := cliflags.AllFlagsHelp()[args[i]]
+				if !ok {
+					return newErr(args[i])
+				}
+			}
+
 			rawConfig, v, err := getRawConfig()
 			if err != nil {
 				return err
@@ -122,26 +129,9 @@ func run() func(*cobra.Command, []string) error {
 
 			return writeConfig(configFile, v, setKeyFn)
 		case viper.IsSet(UnsetFlag):
-			isValid := false
-			for _, s := range []string{
-				cliflags.AccessTokenFlag,
-				cliflags.AnalyticsOptOut,
-				cliflags.BaseURIFlag,
-				cliflags.OutputFlag,
-			} {
-				if s == viper.GetString(UnsetFlag) {
-					isValid = true
-				}
-			}
-			if !isValid {
-				err := errors.NewError(
-					fmt.Sprintf(`{
-							"message": "%s is not a valid configuration option"
-						}`,
-						viper.GetString(UnsetFlag),
-					),
-				)
-				return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
+			_, ok := cliflags.AllFlagsHelp()[viper.GetString(UnsetFlag)]
+			if !ok {
+				return newErr(viper.GetString(UnsetFlag))
 			}
 
 			config, v, err := getConfig()
@@ -155,7 +145,12 @@ func run() func(*cobra.Command, []string) error {
 				}
 			}
 
-			return writeConfig(config, v, unsetKeyFn)
+			// TODO: show successful output
+
+			err = writeConfig(config, v, unsetKeyFn)
+			if err != nil {
+				return err
+			}
 		default:
 			return cmd.Help()
 		}
@@ -255,4 +250,17 @@ func writeConfig(
 	}
 
 	return nil
+}
+
+func newErr(flag string) error {
+	err := errors.NewError(
+		fmt.Sprintf(
+			`{
+				"message": "%s is not a valid configuration option"
+			}`,
+			flag,
+		),
+	)
+
+	return errors.NewError(output.CmdOutputError(flag, err))
 }


### PR DESCRIPTION
Show an error message for `ldcli config --unset {key}` and `ldcli config --set {key} {val}` when key is invalid.

```
$ ldcli config --set analytics-opt-out true foo bar
foo is not a valid configuration option

$ ldcli config --unset foo
foo is not a valid configuration option
```

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
