### PR TITLE
fix: Pass in values to analytics tracker for command completed event

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -174,10 +175,12 @@ func Execute(analyticsTracker analytics.Tracker, version string) {
 		fmt.Fprintln(os.Stderr, err.Error())
 	}
 
+	optOutStr := rootCmd.PersistentFlags().Lookup(cliflags.AnalyticsOptOut).Value.String()
+	optOut, _ := strconv.ParseBool(optOutStr)
 	analyticsTracker.SendCommandCompletedEvent(
-		viper.GetString(cliflags.AccessTokenFlag),
-		viper.GetString(cliflags.BaseURIDefault),
-		viper.GetBool(cliflags.AnalyticsOptOut),
+		rootCmd.PersistentFlags().Lookup(cliflags.AccessTokenFlag).Value.String(),
+		rootCmd.PersistentFlags().Lookup(cliflags.BaseURIFlag).Value.String(),
+		optOut,
 		outcome,
 	)
 }


### PR DESCRIPTION
The values in viper haven't been set at the time we read them for this call, so we need to check the root command's flags for the current values.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
