### PR TITLE
fix: Return regular error for generated resource error response

### DIFF
--- a/internal/resources/client.go
+++ b/internal/resources/client.go
@@ -46,7 +46,7 @@ func (c ResourcesClient) MakeRequest(accessToken, method, path, contentType stri
 	defer res.Body.Close()
 
 	if res.StatusCode >= 400 {
-		return body, errors.NewAPIError(body, nil, nil)
+		return body, errors.NewError(string(body))
 	}
 
 	return body, nil


### PR DESCRIPTION
The generated resources use an HTTP client instead of the LD go client, so an error response will be a regular JSON string and not have all the methods for an `APIError`.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
