### PR TITLE
fix: Fix delete message output with only a key

### DIFF
--- a/internal/output/plaintext_fns.go
+++ b/internal/output/plaintext_fns.go
@@ -52,5 +52,12 @@ var MultiplePlaintextOutputFn = func(r resource) string {
 
 // SingularPlaintextOutputFn converts the resource to plain text based on its name and key.
 var SingularPlaintextOutputFn = func(r resource) string {
+	if r["name"] == nil {
+		return r["key"].(string)
+	}
+	if r["key"] == nil {
+		return r["name"].(string)
+	}
+
 	return fmt.Sprintf("%s (%s)", r["name"], r["key"])
 }

--- a/internal/output/resource_output_test.go
+++ b/internal/output/resource_output_test.go
@@ -132,9 +132,11 @@ func TestCmdOutput(t *testing.T) {
 			})
 
 			t.Run("with a key", func(t *testing.T) {
-				t.Skip()
 				t.Run("returns a success message", func(t *testing.T) {
 					expected := "Successfully deleted test-key"
+					input := `{
+						"key": "test-key"
+					}`
 
 					result, err := output.CmdOutput("delete", "plaintext", []byte(input))
 


### PR DESCRIPTION
A delete response won't have a body, so we'll only have the resource's key to show in a success response.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
