### PR TITLE
docs: add link to docs.launchdarkly

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ ldcli flags create --access-token <access-token> --project default --data '{"nam
 
 ## Documentation
 
-_(coming soon!)_
+Additional documentation is available at https://docs.launchdarkly.com/home/getting-started/ldcli.
 
 ## Contributing
 


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

[SC-243155](https://app.shortcut.com/launchdarkly/story/243155/ldcli-readme-add-link-back-to-product-docs)

**Describe the solution you've provided**

Ben [suggested](https://launchdarkly.slack.com/archives/C06KW03D8F7/p1715027472514309?thread_ts=1715026459.004739&cid=C06KW03D8F7) that we link to the product docs from here. Those docs don't currently have additional info, but eventually they will, and they help you discover more info about LaunchDarkly generally.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
