### PR TITLE
fix: Handle output for multiple resources with _id and name

### DIFF
--- a/internal/output/plaintext_fns.go
+++ b/internal/output/plaintext_fns.go
@@ -45,6 +45,11 @@ var MultipleEmailPlaintextOutputFn = func(r resource) string {
 	return fmt.Sprintf("* %s (%s)", r["email"], r["_id"])
 }
 
+// MultipleIDPlaintextOutputFn converts the resource to plain text for data without a key.
+var MultipleIDPlaintextOutputFn = func(r resource) string {
+	return fmt.Sprintf("* %s (%s)", r["name"], r["_id"])
+}
+
 // MultiplePlaintextOutputFn converts the resource to plain text based on its name and key in a list.
 var MultiplePlaintextOutputFn = func(r resource) string {
 	return fmt.Sprintf("* %s (%s)", r["name"], r["key"])

--- a/internal/output/resource_output.go
+++ b/internal/output/resource_output.go
@@ -49,10 +49,15 @@ func CmdOutput(action string, outputKind string, input []byte) (string, error) {
 		if len(maybeResources.Items) == 0 {
 			return "No items found", nil
 		}
+
 		// the response could have various properties we want to show
+		keyExists := func(key string) bool { _, ok := maybeResources.Items[0][key]; return ok }
 		outputFn := MultiplePlaintextOutputFn
-		if _, ok := maybeResources.Items[0]["email"]; ok {
+		switch {
+		case keyExists("email"):
 			outputFn = MultipleEmailPlaintextOutputFn
+		case keyExists("_id"):
+			outputFn = MultipleIDPlaintextOutputFn
 		}
 
 		items := make([]string, 0, len(maybeResources.Items))

--- a/internal/output/resource_output_test.go
+++ b/internal/output/resource_output_test.go
@@ -12,6 +12,28 @@ import (
 )
 
 func TestCmdOutput(t *testing.T) {
+	t.Run("with multiple resources with an ID and name", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"_id": "test-id",
+					"name": "test-name"
+				}
+			]
+		}`
+
+		t.Run("with plaintext output", func(t *testing.T) {
+			t.Run("returns a success message", func(t *testing.T) {
+				expected := "\n* test-name (test-id)"
+
+				result, err := output.CmdOutput("list", "plaintext", []byte(input))
+
+				require.NoError(t, err)
+				assert.Equal(t, expected, result)
+			})
+		})
+	})
+
 	t.Run("when creating a resource", func(t *testing.T) {
 		input := `{
 			"key": "test-key",


### PR DESCRIPTION
When a response looks like this:
```
{
    "items": [
        {
            "_id": "test-id",
            "name": "test-name"
        }
    ]
}
```
Plain text output should look like
```
* test-name (test-id)
```
instead of
```
* test-name (%!!(MISSING)s(<nil>))
```


**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
