### PR TITLE
fix: remove http client timeout for resources

### DIFF
--- a/internal/resources/client.go
+++ b/internal/resources/client.go
@@ -4,11 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"ldcli/internal/errors"
 	"net/http"
 	"net/url"
-	"time"
-
-	"ldcli/internal/errors"
 )
 
 type Client interface {
@@ -26,7 +24,7 @@ func NewClient(cliVersion string) ResourcesClient {
 }
 
 func (c ResourcesClient) MakeRequest(accessToken, method, path, contentType string, query url.Values, data []byte) ([]byte, error) {
-	client := http.Client{Timeout: 3 * time.Second}
+	client := http.Client{}
 
 	req, _ := http.NewRequest(method, path, bytes.NewReader(data))
 	req.Header.Add("Authorization", accessToken)

--- a/internal/resources/client.go
+++ b/internal/resources/client.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"ldcli/internal/errors"
 	"net/http"
 	"net/url"
+
+	"ldcli/internal/errors"
 )
 
 type Client interface {


### PR DESCRIPTION
our 3 second timeout was resulting in some errors - instead we'll rely on gonfalon's timeout. 

```
Get "https://app.launchdarkly.com/api/v2/approval-requests": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```