### PR TITLE
fix: set resource cmd usage template

### DIFF
--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -210,6 +210,7 @@ func NewResourceCmd(
 		},
 	}
 
+	cmd.SetUsageTemplate(getResourceUsageTemplate())
 	parentCmd.AddCommand(cmd)
 	parentCmd.Annotations[resourceName] = "resource"
 
@@ -363,6 +364,38 @@ func NewOperationCmd(parentCmd *cobra.Command, client resources.Client, op Opera
 	parentCmd.AddCommand(cmd)
 
 	return cmd
+}
+
+func getResourceUsageTemplate() string {
+	return `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}`
 }
 
 func operationUsageTemplate() string {


### PR DESCRIPTION
somehow the help/usage on the root command seems to have taken precedence over the subcommands help templates. setting it manually seems to fix this (which we do already for operation commands). 

ideally we'd have some kind of shared template between the resource and operation cmds since they are very similar, but I couldn't quite figure out how to hide the required/optional flags because technically the resource commands all do have a flag (`help`) so that section isn't properly hiding. i'm trying to play with more template functions but couldn't quite get them to work, and I really want to fix this for people to test. 

before:
![image](https://github.com/launchdarkly/ldcli/assets/55991524/f9662f6d-fa05-40a0-b7b1-879507853b53)


after:
![image](https://github.com/launchdarkly/ldcli/assets/55991524/179ea5e8-26a2-4230-8015-9411826e8766)
