### PR TITLE
fix: update usage template to only show flags when present

### DIFF
--- a/cmd/flags/toggle.go
+++ b/cmd/flags/toggle.go
@@ -23,7 +23,7 @@ func NewToggleOnCmd(client resources.Client) *cobra.Command {
 		Use:   "toggle-on",
 	}
 
-	cmd.SetUsageTemplate(resourcescmd.OperationUsageTemplate())
+	cmd.SetUsageTemplate(resourcescmd.SubcommandUsageTemplate())
 	initFlags(cmd)
 
 	return cmd

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -210,7 +210,7 @@ func NewResourceCmd(
 		},
 	}
 
-	cmd.SetUsageTemplate(getResourceUsageTemplate())
+	cmd.SetUsageTemplate(OperationUsageTemplate())
 	parentCmd.AddCommand(cmd)
 	parentCmd.Annotations[resourceName] = "resource"
 
@@ -366,39 +366,6 @@ func NewOperationCmd(parentCmd *cobra.Command, client resources.Client, op Opera
 	return cmd
 }
 
-func getResourceUsageTemplate() string {
-	return `Usage:{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
-
-Aliases:
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
-
-Examples:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
-
-Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
-
-{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
-
-Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-
-Flags:
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
-
-Global Flags:
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
-
-Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
-`
-}
-
 func OperationUsageTemplate() string {
 	return `Usage:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
@@ -417,16 +384,16 @@ Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help")
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
 
 Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}{{if HasRequiredFlags .}}
 
 Required flags:
-{{WrappedRequiredFlagUsages . | trimTrailingWhitespaces}}
+{{WrappedRequiredFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if HasOptionalFlags .}}
 
 Optional flags:
-{{WrappedOptionalFlagUsages . | trimTrailingWhitespaces}}
+{{WrappedOptionalFlagUsages . | trimTrailingWhitespaces}}{{end}}
 
 Global Flags:
-{{rpad "  -h, --help" 29}} Help for this command
+{{rpad "  -h, --help" 29}} Get help about any command
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -210,7 +210,7 @@ func NewResourceCmd(
 		},
 	}
 
-	cmd.SetUsageTemplate(OperationUsageTemplate())
+	cmd.SetUsageTemplate(SubcommandUsageTemplate())
 	parentCmd.AddCommand(cmd)
 	parentCmd.Annotations[resourceName] = "resource"
 
@@ -356,7 +356,7 @@ func NewOperationCmd(parentCmd *cobra.Command, client resources.Client, op Opera
 		Use:   op.Use,
 	}
 
-	cmd.SetUsageTemplate(OperationUsageTemplate())
+	cmd.SetUsageTemplate(SubcommandUsageTemplate())
 
 	opCmd.cmd = cmd
 	_ = opCmd.initFlags()
@@ -366,7 +366,7 @@ func NewOperationCmd(parentCmd *cobra.Command, client resources.Client, op Opera
 	return cmd
 }
 
-func OperationUsageTemplate() string {
+func SubcommandUsageTemplate() string {
 	return `Usage:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
@@ -384,7 +384,7 @@ Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help")
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
 
 Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}{{if HasRequiredFlags .}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}{{if gt (len WrappedRequiredFlagUsages .) 0}}
 
 Required flags:
 {{WrappedRequiredFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if HasOptionalFlags .}}
@@ -392,7 +392,7 @@ Required flags:
 Optional flags:
 {{WrappedOptionalFlagUsages . | trimTrailingWhitespaces}}{{end}}
 
-Global Flags:
+Global flags:
 {{rpad "  -h, --help" 29}} Get help about any command
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -232,6 +232,8 @@ See each command's help for details on how to use the generated script.`, rootCm
 
 	cobra.AddTemplateFunc("WrappedRequiredFlagUsages", WrappedRequiredFlagUsages)
 	cobra.AddTemplateFunc("WrappedOptionalFlagUsages", WrappedOptionalFlagUsages)
+	cobra.AddTemplateFunc("HasRequiredFlags", HasRequiredFlags)
+	cobra.AddTemplateFunc("HasOptionalFlags", HasOptionalFlags)
 	rootCmd.cmd.SetUsageTemplate(getUsageTemplate())
 
 	err = rootCmd.Execute()

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -28,29 +28,53 @@ Flags:
 `
 }
 
-func WrappedRequiredFlagUsages(cmd *cobra.Command) string {
-	nonRequestParamsFlags := pflag.NewFlagSet("request", pflag.ExitOnError)
-
+func HasRequiredFlags(cmd *cobra.Command) bool {
+	var numFlags int
 	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
-		if _, ok := flag.Annotations["required"]; ok {
-			nonRequestParamsFlags.AddFlag(flag)
+		_, ok := flag.Annotations["required"]
+		if ok {
+			numFlags += 1
 		}
 	})
 
-	return nonRequestParamsFlags.FlagUsagesWrapped(getTerminalWidth())
+	return numFlags > 0
+}
+
+func HasOptionalFlags(cmd *cobra.Command) bool {
+	var numFlags int
+	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+		_, ok := flag.Annotations["required"]
+		if !ok && flag.Name != "help" {
+			numFlags += 1
+		}
+	})
+
+	return numFlags > 0
+}
+
+func WrappedRequiredFlagUsages(cmd *cobra.Command) string {
+	flagSet := pflag.NewFlagSet("request", pflag.ExitOnError)
+
+	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+		if _, ok := flag.Annotations["required"]; ok {
+			flagSet.AddFlag(flag)
+		}
+	})
+
+	return flagSet.FlagUsagesWrapped(getTerminalWidth())
 }
 
 func WrappedOptionalFlagUsages(cmd *cobra.Command) string {
-	nonRequestParamsFlags := pflag.NewFlagSet("request", pflag.ExitOnError)
+	flagSet := pflag.NewFlagSet("request", pflag.ExitOnError)
 
 	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
 		_, ok := flag.Annotations["required"]
 		if !ok && flag.Name != "help" {
-			nonRequestParamsFlags.AddFlag(flag)
+			flagSet.AddFlag(flag)
 		}
 	})
 
-	return nonRequestParamsFlags.FlagUsagesWrapped(getTerminalWidth())
+	return flagSet.FlagUsagesWrapped(getTerminalWidth())
 }
 
 func getTerminalWidth() int {


### PR DESCRIPTION
updates the operation usage template to only show a header for required/optional flags if they're actually there. also removes the template for resources in favor of this singular template now. 

truly don't know if this is the Best Way to handle this as I'm not familiar with templates, but it works!

before:
![image](https://github.com/launchdarkly/ldcli/assets/55991524/244988c7-6034-47b3-ae28-713a71a877b1)

after:
![image](https://github.com/launchdarkly/ldcli/assets/55991524/575f2d91-d4e5-419a-83bd-89abde67babc)

and also resources work now too, though to be honest I don't know how `Flags:` is showing up there 🤔 
![image](https://github.com/launchdarkly/ldcli/assets/55991524/3b1834db-8a80-4c90-8c9f-5119c5dbf929)


