### PR TITLE
fix: Show plaintext list of tags

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -50,8 +50,8 @@ type OutputterFn interface {
 type PlaintextOutputFn func(resource) string
 
 // resource is the subset of data we need to display a command's plain text response for a single
-// resource.
-// We're trading off type safety for easy of use instead of defining a type for each expected resource.
+// resource. We're trading off type safety for easy of use instead of defining a type for each
+// expected resource.
 type resource map[string]interface{}
 
 type link map[string]string
@@ -64,6 +64,13 @@ type resources struct {
 	Items      []resource `json:"items"`
 	Links      links      `json:"_links"`
 	TotalCount int        `json:"totalCount"`
+}
+
+// resourcesList is a response that has a list of scalar values instead of JSON objects.
+type resourcesList struct {
+	Items      []interface{} `json:"items"`
+	Links      links         `json:"_links"`
+	TotalCount int           `json:"totalCount"`
 }
 
 // CmdOutputSingular builds a command response based on the flag the user provided and the shape of

--- a/internal/output/resource_output_test.go
+++ b/internal/output/resource_output_test.go
@@ -108,6 +108,33 @@ func TestCmdOutput(t *testing.T) {
 		})
 	})
 
+	t.Run("with a list of tags", func(t *testing.T) {
+		input := `{
+			"items": [
+				"tag1",
+				"tag2"
+			],
+			"_links": {
+				"self": {
+					"href": "/api/v2/tags",
+					"type": "application/json"
+				}
+			},
+			"totalCount": 2
+		}`
+
+		t.Run("with plaintext output", func(t *testing.T) {
+			t.Run("returns the list", func(t *testing.T) {
+				expected := "* tag1\n* tag2\nShowing results 1 - 2 of 2."
+
+				result, err := output.CmdOutput("list", "plaintext", []byte(input))
+
+				require.NoError(t, err)
+				assert.Equal(t, expected, result)
+			})
+		})
+	})
+
 	t.Run("when creating a resource", func(t *testing.T) {
 		input := `{
 			"key": "test-key",


### PR DESCRIPTION
The tags endpoint returns data like this:
```
{
  "items": [
    "tag1"
  ],
  "_links": {
    "self": {
      "href": "/api/v2/tags",
      "type": "application/json"
    }
  },
  "totalCount": 1
}
```
so we need to handle a response that has a list of scalar values for items instead of JSON objects.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
