### PR TITLE
fix: add back member invite alias

### DIFF
--- a/cmd/members/invite.go
+++ b/cmd/members/invite.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	
+
 	"ldcli/cmd/cliflags"
 	resourcescmd "ldcli/cmd/resources"
 	"ldcli/cmd/validators"

--- a/cmd/members/invite_test.go
+++ b/cmd/members/invite_test.go
@@ -1,0 +1,49 @@
+package members_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"ldcli/cmd"
+	"ldcli/internal/analytics"
+	"ldcli/internal/resources"
+)
+
+func TestInvite(t *testing.T) {
+	mockClient := &resources.MockClient{
+		Response: []byte(`{
+		   "items":[
+			  {
+				 "_id":"000000000000000000000001",
+				 "role":"writer",
+				 "email":"test1@test.com"
+			  },
+			  {
+				 "_id":"000000000000000000000002",
+				 "role":"writer",
+				 "email":"test2@test.com"
+			  }
+		   ]
+		}`),
+	}
+	args := []string{
+		"members", "invite",
+		"--access-token", "abcd1234",
+		"--emails", "test1@test.com,test2@test.com",
+		"--role", "writer",
+	}
+	output, err := cmd.CallCmd(
+		t,
+		cmd.APIClients{
+			ResourcesClient: mockClient,
+		},
+		analytics.NoopClientFn{}.Tracker(),
+		args,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, `[{"email":"test1@test.com","role":"writer"},{"email":"test2@test.com","role":"writer"}]`, string(mockClient.Input))
+	assert.Equal(t, "Successfully updated\n* test1@test.com (000000000000000000000001)\n* test2@test.com (000000000000000000000002)\n", string(output))
+}

--- a/cmd/members/members.go
+++ b/cmd/members/members.go
@@ -1,0 +1,88 @@
+package members
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	
+	"ldcli/cmd/cliflags"
+	resourcescmd "ldcli/cmd/resources"
+	"ldcli/cmd/validators"
+	"ldcli/internal/errors"
+	"ldcli/internal/members"
+	"ldcli/internal/output"
+	"ldcli/internal/resources"
+)
+
+func NewMembersInviteCmd(client resources.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Args:  validators.Validate(),
+		Long:  "Create new members and send them an invitation email",
+		RunE:  runE(client),
+		Short: "Invite new members",
+		Use:   "invite",
+	}
+
+	cmd.SetUsageTemplate(resourcescmd.SubcommandUsageTemplate())
+	initFlags(cmd)
+
+	return cmd
+}
+
+func runE(client resources.Client) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		emails := viper.GetStringSlice(cliflags.EmailsFlag)
+		memberInputs := make([]members.MemberInput, 0, len(emails))
+		for _, e := range emails {
+			role := viper.GetString(cliflags.RoleFlag)
+			memberInputs = append(memberInputs, members.MemberInput{Email: e, Role: role})
+		}
+
+		membersJson, err := json.Marshal(memberInputs)
+		if err != nil {
+			return errors.NewError(err.Error())
+		}
+
+		path := fmt.Sprintf(
+			"%s/api/v2/members",
+			viper.GetString(cliflags.BaseURIFlag),
+		)
+		res, err := client.MakeRequest(
+			viper.GetString(cliflags.AccessTokenFlag),
+			"POST",
+			path,
+			"application/json",
+			nil,
+			membersJson,
+		)
+		if err != nil {
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
+		}
+
+		output, err := output.CmdOutput("update", viper.GetString(cliflags.OutputFlag), res)
+		if err != nil {
+			return errors.NewError(err.Error())
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), output+"\n")
+
+		return nil
+	}
+}
+
+func initFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSliceP(cliflags.EmailsFlag, "e", []string{}, "A comma separated list of emails")
+	_ = cmd.MarkFlagRequired(cliflags.EmailsFlag)
+	_ = cmd.Flags().SetAnnotation(cliflags.EnvironmentFlag, "required", []string{"true"})
+	_ = viper.BindPFlag(cliflags.EmailsFlag, cmd.Flags().Lookup(cliflags.EmailsFlag))
+
+	cmd.Flags().StringP(
+		cliflags.RoleFlag,
+		"r",
+		"reader",
+		"Built-in role for the member - one of reader, writer, or admin",
+	)
+	_ = viper.BindPFlag(cliflags.RoleFlag, cmd.Flags().Lookup(cliflags.RoleFlag))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	"log"
 	"os"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 	"ldcli/cmd/cliflags"
 	configcmd "ldcli/cmd/config"
 	flagscmd "ldcli/cmd/flags"
+	memberscmd "ldcli/cmd/members"
 	resourcecmd "ldcli/cmd/resources"
 	"ldcli/internal/analytics"
 	"ldcli/internal/config"
@@ -192,6 +194,9 @@ func NewRootCommand(
 		if c.Name() == "flags" {
 			c.AddCommand(flagscmd.NewToggleOnCmd(clients.ResourcesClient))
 			c.AddCommand(flagscmd.NewToggleOffCmd(clients.ResourcesClient))
+		}
+		if c.Name() == "members" {
+			c.AddCommand(memberscmd.NewMembersInviteCmd(clients.ResourcesClient))
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-
 	"log"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
This was accidentally removed when we generated the remaining resources from the openapi spec

Running `ldcli members --help` shows the new command:
```
Usage:
  ldcli members [command]

Available Commands:
  create       Invite new members
  create-teams Add a member to teams
  delete       Delete account member
  get          Get account member
  invite       Invite new members
  list         List account members
  update       Modify an account member

Global flags:
  -h, --help                  Get help about any command
      --access-token string   LaunchDarkly access token with write-level access
      --analytics-opt-out     Opt out of analytics tracking
      --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
  -o, --output string         Command response output format in either JSON or plain text (default "plaintext")

Use "ldcli members [command] --help" for more information about a command.
```

Note that the short description is the same as what we have for `create`, which comes straight from the openapi spec. Not sure what else we might want to put here instead. 