### PR TITLE
fix: add required flags for member invite cmd

### DIFF
--- a/cmd/members/invite.go
+++ b/cmd/members/invite.go
@@ -75,7 +75,7 @@ func runE(client resources.Client) func(*cobra.Command, []string) error {
 func initFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceP(cliflags.EmailsFlag, "e", []string{}, "A comma separated list of emails")
 	_ = cmd.MarkFlagRequired(cliflags.EmailsFlag)
-	_ = cmd.Flags().SetAnnotation(cliflags.EnvironmentFlag, "required", []string{"true"})
+	_ = cmd.Flags().SetAnnotation(cliflags.EmailsFlag, "required", []string{"true"})
 	_ = viper.BindPFlag(cliflags.EmailsFlag, cmd.Flags().Lookup(cliflags.EmailsFlag))
 
 	cmd.Flags().StringP(


### PR DESCRIPTION
```Create new members and send them an invitation email

Usage:
  ldcli members invite [flags]

Required flags:
  -e, --emails strings   A comma separated list of emails

Optional flags:
  -r, --role string   Built-in role for the member - one of reader, writer, or admin (default "reader")

Global flags:
  -h, --help                  Get help about any command
      --access-token string   LaunchDarkly access token with write-level access
      --analytics-opt-out     Opt out of analytics tracking
      --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
  -o, --output string         Command response output format in either JSON or plain text (default "plaintext")```