### PR TITLE
docs: update output error msg

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -90,6 +90,6 @@ func TestNewConfig(t *testing.T) {
 
 		_, err := config.NewConfig(rawConfig)
 
-		assert.EqualError(t, err, "output is invalid")
+		assert.EqualError(t, err, "output is invalid, use 'json' or 'plaintext'")
 	})
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -6,7 +6,7 @@ import (
 	"ldcli/internal/errors"
 )
 
-var ErrInvalidOutputKind = errors.NewError("output is invalid")
+var ErrInvalidOutputKind = errors.NewError("output is invalid, use 'json' or 'plaintext'")
 
 type OutputKind string
 


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

PR feedback in https://github.com/launchdarkly/ld-docs-private/pull/4370 recommended we tell folks how to set their `output` preference using the `config` command. In testing that out, I wanted `ldcli` to tell me what the available options were. Instead, I had to search this repo to figure it out. 

**Describe the solution you've provided**

This PR adds the available options to the error msg.

**Describe alternatives you've considered**

Definitely open to other ideas on where to surface this.

**Additional context**

