### PR TITLE
fix: completion cmd usage & short description

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -231,6 +231,7 @@ func Execute(version string) {
 	if err == nil {
 		completionCmd.Long = fmt.Sprintf(`Generate the autocompletion script for %[1]s for the specified shell.
 See each command's help for details on how to use the generated script.`, rootCmd.Cmd().Name())
+		completionCmd.SetUsageTemplate(resourcecmd.SubcommandUsageTemplate())
 		rootCmd.Cmd().AddCommand(completionCmd)
 	}
 

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -13,7 +13,7 @@ func getUsageTemplate() string {
 Commands:
   {{rpad "setup" 29}} Create your first feature flag using a step-by-step guide
   {{rpad "config" 29}} View and modify specific configuration values
-  {{rpad "completion" 29}} Generate the autocompletion script for the specified shell
+  {{rpad "completion" 29}} Enable command autocompletion within supported shells
 
 Common resource commands:
   {{rpad "flags" 29}} List, create, and modify feature flags and their targeting

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -21,7 +21,7 @@ Common resource commands:
   {{rpad "projects" 29}} List, create, and manage projects
   {{rpad "members" 29}} Invite new members to an account
   {{rpad "segments" 29}} List, create, modify, and delete segments
-  {{rpad "..." 29}} To see more resource commands, run 'ldcli resources help'
+  {{rpad "..." 29}} To see more resource commands, run 'ldcli resources'
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}


### PR DESCRIPTION
running `ldcli completion`
```
Generate the autocompletion script for ldcli for the specified shell.
See each command's help for details on how to use the generated script.

Usage:
  ldcli completion [command]

Available Commands:
  bash        Generate the autocompletion script for bash
  fish        Generate the autocompletion script for fish
  powershell  Generate the autocompletion script for powershell
  zsh         Generate the autocompletion script for zsh

Global flags:
  -h, --help                  Get help about any command
      --access-token string   LaunchDarkly access token with write-level access
      --analytics-opt-out     Opt out of analytics tracking
      --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
  -o, --output string         Command response output format in either JSON or plain text (default "plaintext")

Use "ldcli completion [command] --help" for more information about a command.
```

and running `ldcli`:
```
LaunchDarkly CLI to control your feature flags

Usage:
  ldcli [command]

Commands:
  setup                         Create your first feature flag using a step-by-step guide
  config                        View and modify specific configuration values
  completion                    Enable command autocompletion within supported shells

Common resource commands:
  flags                         List, create, and modify feature flags and their targeting
  environments                  List, create, and manage environments
  projects                      List, create, and manage projects
  members                       Invite new members to an account
  segments                      List, create, modify, and delete segments
  ...                           To see more resource commands, run 'ldcli resources help'

Flags:
      --access-token string   LaunchDarkly access token with write-level access
      --analytics-opt-out     Opt out of analytics tracking
      --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
  -h, --help                  help for ldcli
  -o, --output string         Command response output format in either JSON or plain text (default "plaintext")
  -v, --version               version for ldcli
```

running `ldcli completion bash --help`
```
Generate the autocompletion script for the bash shell.

This script depends on the 'bash-completion' package.
If it is not installed already, you can install it via your OS's package manager.

To load completions in your current shell session:

	source <(ldcli completion bash)

To load completions for every new session, execute once:

#### Linux:

	ldcli completion bash > /etc/bash_completion.d/ldcli

#### macOS:

	ldcli completion bash > $(brew --prefix)/etc/bash_completion.d/ldcli

You will need to start a new shell for this setup to take effect.

Usage:
  ldcli completion bash

Optional flags:
      --no-descriptions   disable completion descriptions

Global flags:
  -h, --help                  Get help about any command
      --access-token string   LaunchDarkly access token with write-level access
      --analytics-opt-out     Opt out of analytics tracking
      --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
  -o, --output string         Command response output format in either JSON or plain text (default "plaintext")
```