### PR TITLE
feat: support default resources in config

### DIFF
--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -18,6 +18,7 @@ const (
 	AnalyticsOptOutDescription = "Opt out of analytics tracking"
 	BaseURIFlagDescription     = "LaunchDarkly base URI"
 	OutputFlagDescription      = "Command response output format in either JSON or plain text"
+	ProjectFlagDescription     = "Default project key"
 )
 
 func AllFlagsHelp() map[string]string {
@@ -26,5 +27,6 @@ func AllFlagsHelp() map[string]string {
 		AnalyticsOptOut: AnalyticsOptOutDescription,
 		BaseURIFlag:     BaseURIFlagDescription,
 		OutputFlag:      OutputFlagDescription,
+		ProjectFlag:     ProjectFlagDescription,
 	}
 }

--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -17,6 +17,8 @@ const (
 	AccessTokenFlagDescription = "LaunchDarkly access token with write-level access"
 	AnalyticsOptOutDescription = "Opt out of analytics tracking"
 	BaseURIFlagDescription     = "LaunchDarkly base URI"
+	EnvironmentFlagDescription = "Default environment key"
+	FlagFlagDescription        = "Default feature flag key"
 	OutputFlagDescription      = "Command response output format in either JSON or plain text"
 	ProjectFlagDescription     = "Default project key"
 )
@@ -26,6 +28,8 @@ func AllFlagsHelp() map[string]string {
 		AccessTokenFlag: AccessTokenFlagDescription,
 		AnalyticsOptOut: AnalyticsOptOutDescription,
 		BaseURIFlag:     BaseURIFlagDescription,
+		EnvironmentFlag: EnvironmentFlagDescription,
+		FlagFlag:        FlagFlagDescription,
 		OutputFlag:      OutputFlagDescription,
 		ProjectFlag:     ProjectFlagDescription,
 	}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -68,6 +68,8 @@ func NewConfigCmd(analyticsTrackerFn analytics.TrackerFn) *ConfigCmd {
 			cliflags.AccessTokenFlag,
 			cliflags.AnalyticsOptOut,
 			cliflags.BaseURIFlag,
+			cliflags.EnvironmentFlag,
+			cliflags.FlagFlag,
 			cliflags.OutputFlag,
 			cliflags.ProjectFlag,
 		} {

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -69,6 +69,7 @@ func NewConfigCmd(analyticsTrackerFn analytics.TrackerFn) *ConfigCmd {
 			cliflags.AnalyticsOptOut,
 			cliflags.BaseURIFlag,
 			cliflags.OutputFlag,
+			cliflags.ProjectFlag,
 		} {
 			sb.WriteString(fmt.Sprintf("- `%s`: %s\n", s, cliflags.AllFlagsHelp()[s]))
 		}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -64,16 +64,9 @@ func NewConfigCmd(analyticsTrackerFn analytics.TrackerFn) *ConfigCmd {
 
 		var sb strings.Builder
 		sb.WriteString("\n\nSupported settings:\n")
-		for _, s := range []string{
-			cliflags.AccessTokenFlag,
-			cliflags.AnalyticsOptOut,
-			cliflags.BaseURIFlag,
-			cliflags.EnvironmentFlag,
-			cliflags.FlagFlag,
-			cliflags.OutputFlag,
-			cliflags.ProjectFlag,
-		} {
-			sb.WriteString(fmt.Sprintf("- `%s`: %s\n", s, cliflags.AllFlagsHelp()[s]))
+
+		for flag, description := range cliflags.AllFlagsHelp() {
+			sb.WriteString(fmt.Sprintf("- `%s`: %s\n", flag, description))
 		}
 		cmd.Long += sb.String()
 

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -64,10 +65,7 @@ func NewConfigCmd(analyticsTrackerFn analytics.TrackerFn) *ConfigCmd {
 
 		var sb strings.Builder
 		sb.WriteString("\n\nSupported settings:\n")
-
-		for flag, description := range cliflags.AllFlagsHelp() {
-			sb.WriteString(fmt.Sprintf("- `%s`: %s\n", flag, description))
-		}
+		writeAlphabetizedFlags(&sb)
 		cmd.Long += sb.String()
 
 		analyticsTrackerFn(
@@ -295,4 +293,15 @@ func newErr(flag string) error {
 	)
 
 	return errors.NewError(output.CmdOutputError(flag, err))
+}
+
+func writeAlphabetizedFlags(sb *strings.Builder) {
+	flags := make([]string, 0, len(cliflags.AllFlagsHelp()))
+	for f := range cliflags.AllFlagsHelp() {
+		flags = append(flags, f)
+	}
+	sort.Strings(flags)
+	for _, flag := range flags {
+		sb.WriteString(fmt.Sprintf("- `%s`: %s\n", flag, cliflags.AllFlagsHelp()[flag]))
+	}
 }

--- a/cmd/config/testdata/help.golden
+++ b/cmd/config/testdata/help.golden
@@ -4,6 +4,8 @@ Supported settings:
 - `access-token`: LaunchDarkly access token with write-level access
 - `analytics-opt-out`: Opt out of analytics tracking
 - `base-uri`: LaunchDarkly base URI
+- `environment`: Default environment key
+- `flag`: Default feature flag key
 - `output`: Command response output format in either JSON or plain text
 - `project`: Default project key
 

--- a/cmd/config/testdata/help.golden
+++ b/cmd/config/testdata/help.golden
@@ -5,6 +5,7 @@ Supported settings:
 - `analytics-opt-out`: Opt out of analytics tracking
 - `base-uri`: LaunchDarkly base URI
 - `output`: Command response output format in either JSON or plain text
+- `project`: Default project key
 
 Usage:
   ldcli config [flags]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type ConfigFile struct {
 	AnalyticsOptOut *bool  `json:"analytics-opt-out,omitempty" yaml:"analytics-opt-out,omitempty"`
 	BaseURI         string `json:"base-uri,omitempty" yaml:"base-uri,omitempty"`
 	Output          string `json:"output,omitempty" yaml:"output,omitempty"`
+	Project         string `json:"project,omitempty" yaml:"project,omitempty"`
 }
 
 func NewConfig(rawConfig map[string]interface{}) (ConfigFile, error) {
@@ -30,6 +31,7 @@ func NewConfig(rawConfig map[string]interface{}) (ConfigFile, error) {
 		baseURI         string
 		err             error
 		outputKind      output.OutputKind
+		project         string
 	)
 	if rawConfig[cliflags.AccessTokenFlag] != nil {
 		accessToken = rawConfig[cliflags.AccessTokenFlag].(string)
@@ -50,12 +52,16 @@ func NewConfig(rawConfig map[string]interface{}) (ConfigFile, error) {
 			return ConfigFile{}, err
 		}
 	}
+	if rawConfig[cliflags.ProjectFlag] != nil {
+		project = rawConfig[cliflags.ProjectFlag].(string)
+	}
 
 	return ConfigFile{
 		AccessToken:     accessToken,
 		AnalyticsOptOut: &analyticsOptOut,
 		BaseURI:         baseURI,
 		Output:          outputKind.String(),
+		Project:         project,
 	}, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,8 @@ type ConfigFile struct {
 	AccessToken     string `json:"access-token,omitempty" yaml:"access-token,omitempty"`
 	AnalyticsOptOut *bool  `json:"analytics-opt-out,omitempty" yaml:"analytics-opt-out,omitempty"`
 	BaseURI         string `json:"base-uri,omitempty" yaml:"base-uri,omitempty"`
+	Flag            string `json:"flag,omitempty" yaml:"flag,omitempty"`
+	Environment     string `json:"environment,omitempty" yaml:"environment,omitempty"`
 	Output          string `json:"output,omitempty" yaml:"output,omitempty"`
 	Project         string `json:"project,omitempty" yaml:"project,omitempty"`
 }
@@ -29,7 +31,9 @@ func NewConfig(rawConfig map[string]interface{}) (ConfigFile, error) {
 		accessToken     string
 		analyticsOptOut bool
 		baseURI         string
+		environment     string
 		err             error
+		flag            string
 		outputKind      output.OutputKind
 		project         string
 	)
@@ -46,6 +50,12 @@ func NewConfig(rawConfig map[string]interface{}) (ConfigFile, error) {
 	if rawConfig[cliflags.BaseURIFlag] != nil {
 		baseURI = rawConfig[cliflags.BaseURIFlag].(string)
 	}
+	if rawConfig[cliflags.EnvironmentFlag] != nil {
+		environment = rawConfig[cliflags.EnvironmentFlag].(string)
+	}
+	if rawConfig[cliflags.FlagFlag] != nil {
+		flag = rawConfig[cliflags.FlagFlag].(string)
+	}
 	if rawConfig[cliflags.OutputFlag] != nil {
 		outputKind, err = output.NewOutputKind(rawConfig[cliflags.OutputFlag].(string))
 		if err != nil {
@@ -60,6 +70,8 @@ func NewConfig(rawConfig map[string]interface{}) (ConfigFile, error) {
 		AccessToken:     accessToken,
 		AnalyticsOptOut: &analyticsOptOut,
 		BaseURI:         baseURI,
+		Environment:     environment,
+		Flag:            flag,
 		Output:          outputKind.String(),
 		Project:         project,
 	}, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -93,16 +93,42 @@ func TestNewConfig(t *testing.T) {
 		assert.EqualError(t, err, "output is invalid, use 'json' or 'plaintext'")
 	})
 
-	t.Run("project", func(t *testing.T) {
+	t.Run("environment", func(t *testing.T) {
 		t.Run("sets the given value", func(t *testing.T) {
 			rawConfig := map[string]interface{}{
-				"project": "test-project-key",
+				"environment": "test-key",
 			}
 
 			configFile, err := config.NewConfig(rawConfig)
 
 			require.NoError(t, err)
-			assert.Equal(t, "test-project-key", configFile.Project)
+			assert.Equal(t, "test-key", configFile.Environment)
+		})
+	})
+
+	t.Run("flag", func(t *testing.T) {
+		t.Run("sets the given value", func(t *testing.T) {
+			rawConfig := map[string]interface{}{
+				"flag": "test-key",
+			}
+
+			configFile, err := config.NewConfig(rawConfig)
+
+			require.NoError(t, err)
+			assert.Equal(t, "test-key", configFile.Flag)
+		})
+	})
+
+	t.Run("project", func(t *testing.T) {
+		t.Run("sets the given value", func(t *testing.T) {
+			rawConfig := map[string]interface{}{
+				"project": "test-key",
+			}
+
+			configFile, err := config.NewConfig(rawConfig)
+
+			require.NoError(t, err)
+			assert.Equal(t, "test-key", configFile.Project)
 		})
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -92,4 +92,17 @@ func TestNewConfig(t *testing.T) {
 
 		assert.EqualError(t, err, "output is invalid, use 'json' or 'plaintext'")
 	})
+
+	t.Run("project", func(t *testing.T) {
+		t.Run("sets the given value", func(t *testing.T) {
+			rawConfig := map[string]interface{}{
+				"project": "test-project-key",
+			}
+
+			configFile, err := config.NewConfig(rawConfig)
+
+			require.NoError(t, err)
+			assert.Equal(t, "test-project-key", configFile.Project)
+		})
+	})
 }


### PR DESCRIPTION
Config file supports new keys.
```
ldcli config --set environment production
ldcli config --set flag my-flag
ldcli config --set project default
```
Running `ldcli config --list` returns
```
environment: production
flag: my-new-flag
project: default
```
Now commands that require these flags can use the values in the config file:
```
ldcli flags get # uses --project and --flag
ldcli environments get # uses --environment
```


**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
