### PR TITLE
feat: add archive flag cmd

### DIFF
--- a/cmd/flags/archive.go
+++ b/cmd/flags/archive.go
@@ -1,0 +1,74 @@
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"ldcli/cmd/cliflags"
+	resourcescmd "ldcli/cmd/resources"
+	"ldcli/cmd/validators"
+	"ldcli/internal/errors"
+	"ldcli/internal/output"
+	"ldcli/internal/resources"
+)
+
+func NewArchiveCmd(client resources.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Args:  validators.Validate(),
+		Long:  "Archive a feature flag on",
+		RunE:  makeArchiveRequest(client),
+		Short: "Archive a feature flag on",
+		Use:   "archive",
+	}
+
+	cmd.SetUsageTemplate(resourcescmd.SubcommandUsageTemplate())
+	initArchiveFlags(cmd)
+
+	return cmd
+}
+
+func makeArchiveRequest(client resources.Client) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+
+		path := fmt.Sprintf(
+			"%s/api/v2/flags/%s/%s",
+			viper.GetString(cliflags.BaseURIFlag),
+			viper.GetString(cliflags.ProjectFlag),
+			viper.GetString(cliflags.FlagFlag),
+		)
+		res, err := client.MakeRequest(
+			viper.GetString(cliflags.AccessTokenFlag),
+			"PATCH",
+			path,
+			"application/json",
+			nil,
+			[]byte(`[{"op": "replace", "path": "/archived", "value": true}]`),
+		)
+		if err != nil {
+			return errors.NewError(output.CmdOutputError(viper.GetString(cliflags.OutputFlag), err))
+		}
+
+		output, err := output.CmdOutput("update", viper.GetString(cliflags.OutputFlag), res)
+		if err != nil {
+			return errors.NewError(err.Error())
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), output+"\n")
+
+		return nil
+	}
+}
+
+func initArchiveFlags(cmd *cobra.Command) {
+	cmd.Flags().String(cliflags.FlagFlag, "", "The feature flag key. The key identifies the flag in your code.")
+	_ = cmd.MarkFlagRequired(cliflags.FlagFlag)
+	_ = cmd.Flags().SetAnnotation(cliflags.FlagFlag, "required", []string{"true"})
+	_ = viper.BindPFlag(cliflags.FlagFlag, cmd.Flags().Lookup(cliflags.FlagFlag))
+
+	cmd.Flags().String(cliflags.ProjectFlag, "", "The project key")
+	_ = cmd.MarkFlagRequired(cliflags.ProjectFlag)
+	_ = cmd.Flags().SetAnnotation(cliflags.ProjectFlag, "required", []string{"true"})
+	_ = viper.BindPFlag(cliflags.ProjectFlag, cmd.Flags().Lookup(cliflags.ProjectFlag))
+}

--- a/cmd/flags/archive.go
+++ b/cmd/flags/archive.go
@@ -17,9 +17,9 @@ import (
 func NewArchiveCmd(client resources.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  validators.Validate(),
-		Long:  "Archive a feature flag on",
+		Long:  "Archive a flag across all environments. It will only appear in your list when filtered for.",
 		RunE:  makeArchiveRequest(client),
-		Short: "Archive a feature flag on",
+		Short: "Archive a feature flag",
 		Use:   "archive",
 	}
 

--- a/cmd/flags/archive_test.go
+++ b/cmd/flags/archive_test.go
@@ -1,0 +1,60 @@
+package flags_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"ldcli/cmd"
+	"ldcli/internal/analytics"
+	"ldcli/internal/resources"
+)
+
+func TestArchive(t *testing.T) {
+	mockClient := &resources.MockClient{
+		Response: []byte(`{
+			"key": "test-flag",
+			"name": "test flag"
+		}`),
+	}
+
+	t.Run("succeeds with valid inputs", func(t *testing.T) {
+		args := []string{
+			"flags", "archive",
+			"--access-token", "abcd1234",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, `[{"op": "replace", "path": "/archived", "value": true}]`, string(mockClient.Input))
+		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+	})
+	t.Run("returns error with missing flags", func(t *testing.T) {
+		args := []string{
+			"flags", "archive",
+			"--access-token", "abcd1234",
+			"--flag", "test-flag",
+		}
+		_, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		assert.Error(t, err)
+		assert.Equal(t, "required flag(s) \"project\" not set. See `ldcli flags archive --help` for supported flags and usage.", err.Error())
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -193,6 +193,7 @@ func NewRootCommand(
 		if c.Name() == "flags" {
 			c.AddCommand(flagscmd.NewToggleOnCmd(clients.ResourcesClient))
 			c.AddCommand(flagscmd.NewToggleOffCmd(clients.ResourcesClient))
+			c.AddCommand(flagscmd.NewArchiveCmd(clients.ResourcesClient))
 		}
 		if c.Name() == "members" {
 			c.AddCommand(memberscmd.NewMembersInviteCmd(clients.ResourcesClient))


### PR DESCRIPTION
`ldcli flags --help`
```
Usage:
  ldcli flags [command]

Available Commands:
  archive                        Archive a feature flag
  copy                           Copy feature flag
  create                         Create a feature flag
  create-migration-safety-issues Get migration safety issues
  delete                         Delete feature flag
  get                            Get feature flag
  get-status                     Get feature flag status
  get-status-across-environments Get flag status across environments
  list                           List feature flags
  list-expiring-context-targets  Get expiring context targets for feature flag
  list-expiring-user-targets     Get expiring user targets for feature flag
  list-statuses                  List feature flag statuses
  toggle-off                     Turn a feature flag off
  toggle-on                      Turn a feature flag on
  update                         Update feature flag
  update-expiring-targets        Update expiring context targets on feature flag
  update-expiring-user-targets   Update expiring user targets on feature flag
```

`ldcli flags archive --help`
```
Archive a flag across all environments. It will only appear in your list when filtered for.

Usage:
  ldcli flags archive [flags]

Required flags:
      --flag string      The feature flag key. The key identifies the flag in your code.
      --project string   The project key

Global flags:
  -h, --help                  Get help about any command
      --access-token string   LaunchDarkly access token with write-level access
      --analytics-opt-out     Opt out of analytics tracking
      --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
  -o, --output string         Command response output format in either JSON or plain text (default "plaintext")
```