### PR TITLE
ci: enforce formatting, go mod tidy

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,22 +21,9 @@ jobs:
       with:
         go-version: '1.20'
 
-    - name: Enforce gofmt
+    - name: Enforce formatting / go mod tidy
       run: |
-        test -z $(gofmt -l cmd)
-        test -z $(gofmt -l internal)
-        test -z $(gofmt -l *.go)
-
-    - name: Enforce go mod tidy
-      run: |
-        set -e
-        go mod tidy
-        STATUS=$(git status --porcelain go.mod go.sum)
-        if [ ! -z "$STATUS" ]; then
-          echo "go.mod/go.sum is not tidy!"
-          exit 1
-        fi
-        exit 0
+        ./git/hooks/pre-commit
 
     - name: Build
       run: go build -o ldcli

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,23 @@ jobs:
       with:
         go-version: '1.20'
 
+    - name: Enforce gofmt
+      run: |
+        test -z $(gofmt -l cmd)
+        test -z $(gofmt -l internal)
+        test -z $(gofmt -l *.go)
+
+    - name: Enforce go mod tidy
+      run: |
+        set -e
+        go mod tidy
+        STATUS=$(git status --porcelain go.mod go.sum)
+        if [ ! -z "$STATUS" ]; then
+          echo "go.mod/go.sum is not tidy!"
+          exit 1
+        fi
+        exit 0
+
     - name: Build
       run: go build -o ldcli
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,12 @@ The LaunchDarkly team monitors the [issue tracker](https://github.com/launchdark
 ## Submitting pull requests
 
 We encourage pull requests and other contributions from the community. Before submitting pull requests, ensure that all temporary or unintended code is removed. Don't worry about adding reviewers to the pull request; the LaunchDarkly team will add themselves.
+
+## Git Hooks
+
+To install the repo's git hooks, run `make install-hooks`.
+
+**pre-commit**
+
+The pre-commit hook checks that relevant project files are formatted with `go fmt`, and that
+the `go.mod/go.sum` files are tidy.

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ test:
 
 vendor:
 	go mod tidy && go mod vendor
+
+install-hooks:
+	cp -r git/hooks/* .git/hooks/

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -22,4 +22,3 @@ if [ -n "$(git status --porcelain go.mod go.sum)" ]; then
 	echo "go.mod/go.sum is not tidy; run go mod tidy"
 	exit 1
 fi
-fi

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -2,10 +2,6 @@
 
 set -eo pipefail
 
-
-# REwrite the test lines above so that the script exits with a non-zero exit code, and emits
-# a emssage if any of them fail.
-
 if [ -n "$(gofmt -l cmd)"  ]; then
   echo "cmd/* is not formatted; run gofmt -w -s cmd"
   exit 1
@@ -21,12 +17,9 @@ if [ -n "$(gofmt -l ./*.go)"  ]; then
   exit 1
 fi
 
-
-
 go mod tidy
-status=$(git status --porcelain go.mod go.sum)
-if [ ! -z "$status" ]; then
+if [ -n "$(git status --porcelain go.mod go.sum)" ]; then
 	echo "go.mod/go.sum is not tidy; run go mod tidy"
 	exit 1
 fi
-exit 0
+fi

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eo pipefail
+
+
+# REwrite the test lines above so that the script exits with a non-zero exit code, and emits
+# a emssage if any of them fail.
+
+if [ -n "$(gofmt -l cmd)"  ]; then
+  echo "cmd/* is not formatted; run gofmt -w -s cmd"
+  exit 1
+fi
+
+if [ -n "$(gofmt -l internal)"  ]; then
+  echo "internal/* is not formatted; run gofmt -w -s internal"
+  exit 1
+fi
+
+if [ -n "$(gofmt -l ./*.go)"  ]; then
+  echo "*.go is not formatted; run gofmt -w -s *.go"
+  exit 1
+fi
+
+
+
+go mod tidy
+status=$(git status --porcelain go.mod go.sum)
+if [ ! -z "$status" ]; then
+	echo "go.mod/go.sum is not tidy; run go mod tidy"
+	exit 1
+fi
+exit 0

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/term v0.18.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -72,7 +73,6 @@ require (
 	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
-	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/term v0.18.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -73,6 +72,7 @@ require (
 	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect


### PR DESCRIPTION
Adds CI checks for:
- `gofmt`: important to ensure code is always formatted in the repo
- `go mod tidy`: important to ensure deterministic dependencies

It does this via `git/hooks/pre-commit`, which can also be installed via `make install-hooks`.