### PR TITLE
chore: remove "prerelease" from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ With the CLI, you can:
 - Onboard your whole team by inviting new members.
 - Interact with the [LaunchDarkly API](https://apidocs.launchdarkly.com/) using resource- and CRUD-based commands.
 
-> [!CAUTION]
-> This package is prerelease and experimental. It should not be used in production and is not yet supported.
-
 ## Installation
 
 The LaunchDarkly CLI will soon be available for macOS, Windows, and Linux.


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

**Describe the solution you've provided**

Remove the "Caution" section of the README just before we release v1.0. Please advise on when this should be merged.

**Describe alternatives you've considered**

**Additional context**
