### PR TITLE
fix: add required annotation to data flags

### DIFF
--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -232,6 +232,10 @@ func (op *OperationCmd) initFlags() error {
 			if err != nil {
 				return err
 			}
+			err = op.cmd.Flags().SetAnnotation(cliflags.DataFlag, "required", []string{"true"})
+			if err != nil {
+				return err
+			}
 		}
 		err := viper.BindPFlag(cliflags.DataFlag, op.cmd.Flags().Lookup(cliflags.DataFlag))
 		if err != nil {


### PR DESCRIPTION
While the data flags *were* required when actually running the commands, they weren't showing up as a required flag in the help template because we hadn't added the proper annotations. Fixed now!