### PR TITLE
fix: Build windows binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,10 @@ builds:
       - darwin
       - linux
       - windows
+    goarch:
+      - 386
+      - amd64
+      - arm64
     env:
       - CGO_ENABLED=0
 dockers:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,11 +2,9 @@ builds:
   - id: ldcli
     binary: ldcli
     goos:
-      - linux
       - darwin
-    goarch:
-      - amd64
-      - arm64
+      - linux
+      - windows
     env:
       - CGO_ENABLED=0
 dockers:


### PR DESCRIPTION
Realized too late that we need to specify building a windows binary in the goreleaser config. The [latest release](https://github.com/launchdarkly/ldcli/releases/tag/v1.1.0) doesn't have a windows binary.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
