### PR TITLE
feat: Can fetch a token based on the device code

### DIFF
--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -20,6 +20,10 @@ type DeviceAuthorization struct {
 	VerificationURI string `json:"verificationUri"`
 }
 
+type DeviceAuthorizationToken struct {
+	AccessToken string `json:"accessToken"`
+}
+
 type UnauthenticatedClient interface {
 	MakeRequest(
 		method string,
@@ -94,6 +98,32 @@ func FetchDeviceAuthorization(
 	}
 
 	return deviceAuthorization, nil
+}
+
+func FetchToken(
+	client UnauthenticatedClient,
+	deviceCode string,
+	baseURI string,
+) (DeviceAuthorizationToken, error) {
+	path := fmt.Sprintf("%s/internal/device-authorization/token", baseURI)
+	body := fmt.Sprintf(
+		`{
+			"deviceCode": %q
+		}`,
+		deviceCode,
+	)
+	res, err := client.MakeRequest("POST", path, []byte(body))
+	if err != nil {
+		return DeviceAuthorizationToken{}, err
+	}
+
+	var deviceAuthorizationToken DeviceAuthorizationToken
+	err = json.Unmarshal(res, &deviceAuthorizationToken)
+	if err != nil {
+		return DeviceAuthorizationToken{}, err
+	}
+
+	return deviceAuthorizationToken, nil
 }
 
 func GetDeviceName() string {


### PR DESCRIPTION
During login, after receiving a verification URL, we can make a request to it and, after the user has allowed access, it returns an access token.

Additional PRs will poll the endpoint and handle the various errors it can return.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
