### PR TITLE
feat: sc-240965/check current access token

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -228,7 +228,7 @@ func getConfig() (config.ConfigFile, *viper.Viper, error) {
 		return config.ConfigFile{}, nil, err
 	}
 
-	c, err := config.NewConfigFromFile(v.ConfigFileUsed())
+	c, err := config.NewConfigFromFile(v.ConfigFileUsed(), os.ReadFile)
 	if err != nil {
 		return config.ConfigFile{}, nil, err
 	}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -228,13 +228,7 @@ func getConfig() (config.ConfigFile, *viper.Viper, error) {
 		return config.ConfigFile{}, nil, err
 	}
 
-	data, err := os.ReadFile(v.ConfigFileUsed())
-	if err != nil {
-		return config.ConfigFile{}, nil, err
-	}
-
-	var c config.ConfigFile
-	err = yaml.Unmarshal([]byte(data), &c)
+	c, err := config.NewConfigFromFile(v.ConfigFileUsed())
 	if err != nil {
 		return config.ConfigFile{}, nil, err
 	}

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -2,7 +2,6 @@ package login
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -12,7 +11,6 @@ import (
 	"github.com/launchdarkly/ldcli/cmd/cliflags"
 	"github.com/launchdarkly/ldcli/internal/analytics"
 	"github.com/launchdarkly/ldcli/internal/config"
-	"github.com/launchdarkly/ldcli/internal/errors"
 	"github.com/launchdarkly/ldcli/internal/login"
 	"github.com/launchdarkly/ldcli/internal/output"
 )
@@ -57,12 +55,8 @@ func NewLoginCmd(
 
 func run(client login.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		config, err := config.NewConfigFromFile(viper.GetViper().ConfigFileUsed(), os.ReadFile)
-		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
-		}
-		if config.AccessToken != "" {
-			return errors.NewError("Your access token is already set. Remove it from the config if you wish to reset it.")
+		if ok, err := config.AccessTokenIsSet(viper.GetViper().ConfigFileUsed()); !ok {
+			return err
 		}
 
 		deviceAuthorization, err := login.FetchDeviceAuthorization(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,3 +109,15 @@ func GetConfigFile() string {
 
 	return filepath.Join(configFilePath, "config.yml")
 }
+
+func AccessTokenIsSet(filename string) (bool, error) {
+	config, err := NewConfigFromFile(filename, os.ReadFile)
+	if err != nil {
+		return false, err
+	}
+	if config.AccessToken != "" {
+		return false, errors.NewError("Your access token is already set. Remove it from the config if you wish to reset it.")
+	}
+
+	return true, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,16 +27,18 @@ type ConfigFile struct {
 	Project         string `json:"project,omitempty" yaml:"project,omitempty"`
 }
 
-func NewConfigFromFile(f string) (ConfigFile, error) {
-	data, err := os.ReadFile(f)
+type ReadFile func(name string) ([]byte, error)
+
+func NewConfigFromFile(f string, readFile ReadFile) (ConfigFile, error) {
+	data, err := readFile(f)
 	if err != nil {
-		return ConfigFile{}, err
+		return ConfigFile{}, errors.NewError("could not read config file")
 	}
 
 	var c ConfigFile
 	err = yaml.Unmarshal([]byte(data), &c)
 	if err != nil {
-		return ConfigFile{}, err
+		return ConfigFile{}, errors.NewError("config file is invalid yaml")
 	}
 
 	return c, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/mitchellh/go-homedir"
+	"gopkg.in/yaml.v3"
 
 	"github.com/launchdarkly/ldcli/cmd/cliflags"
 	"github.com/launchdarkly/ldcli/internal/errors"
@@ -24,6 +25,21 @@ type ConfigFile struct {
 	Environment     string `json:"environment,omitempty" yaml:"environment,omitempty"`
 	Output          string `json:"output,omitempty" yaml:"output,omitempty"`
 	Project         string `json:"project,omitempty" yaml:"project,omitempty"`
+}
+
+func NewConfigFromFile(f string) (ConfigFile, error) {
+	data, err := os.ReadFile(f)
+	if err != nil {
+		return ConfigFile{}, err
+	}
+
+	var c ConfigFile
+	err = yaml.Unmarshal([]byte(data), &c)
+	if err != nil {
+		return ConfigFile{}, err
+	}
+
+	return c, nil
 }
 
 func NewConfig(rawConfig map[string]interface{}) (ConfigFile, error) {


### PR DESCRIPTION
If the user already has an access token, don't let them log in again.

Since access tokens count against an account's limit, we don't want to let the user create endless access tokens by running the login command over and over. This prevents them from creating a new one but gives them a way to do it if they really want to.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
