### PR TITLE
Add overrides to projects

### DIFF
--- a/internal/dev_server/api/api.yaml
+++ b/internal/dev_server/api/api.yaml
@@ -28,6 +28,15 @@ paths:
       summary: get the specified project and its configuration for syncing from the LaunchDarkly Service
       parameters:
         - $ref: "#/components/parameters/projectKey"
+        - name: expand
+          description: Available expand options for this endpoint.
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - overrides
       responses:
         200:
           $ref: "#/components/responses/Project"
@@ -139,6 +148,42 @@ components:
       x-go-type: ldvalue.Value
       x-go-type-import:
         path: github.com/launchdarkly/go-sdk-common/v3/ldvalue
+    Project:
+      description: Project
+      type: object
+      required:
+        - sourceEnvironmentKey
+        - context
+        - _lastSyncedFromSource
+      properties:
+        sourceEnvironmentKey:
+          type: string
+          description: environment to copy flag values from
+        context:
+          type: object
+          description: context object to use when evaluating flags in source environment
+          default:
+            key: "local-dev"
+            kind: user
+          x-go-type: ldcontext.Context
+          x-go-type-import:
+            path: github.com/launchdarkly/go-sdk-common/v3/ldcontext
+        flagsState:
+          type: object
+          description: flags and their values and version for a given project in the source environment
+          x-go-type: model.FlagsState
+          x-go-type-import:
+            path: github.com/launchdarkly/ldcli/internal/dev_server/model
+        overrides:
+          type: object
+          description: flags and their values and version for a given project in the source environment
+          x-go-type: model.FlagsState
+          x-go-type-import:
+            path: github.com/launchdarkly/ldcli/internal/dev_server/model
+        _lastSyncedFromSource:
+          type: integer
+          x-go-type: int64
+          description: unix timestamp for the lat time the flag values were synced from the source environment
   responses:
     FlagOverride:
       description: Flag override
@@ -160,31 +205,4 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - sourceEnvironmentKey
-              - context
-              - _lastSyncedFromSource
-            properties:
-              sourceEnvironmentKey:
-                type: string
-                description: environment to copy flag values from
-              context:
-                type: object
-                description: context object to use when evaluating flags in source environment
-                default:
-                  key: "local-dev"
-                  kind: user
-                x-go-type: ldcontext.Context
-                x-go-type-import:
-                  path: github.com/launchdarkly/go-sdk-common/v3/ldcontext
-              flagsState:
-                type: object
-                description: flags and their values and version for a given project in the source environment
-                x-go-type: model.FlagsState
-                x-go-type-import:
-                  path: github.com/launchdarkly/ldcli/internal/dev_server/model
-              _lastSyncedFromSource:
-                type: integer
-                x-go-type: int64
-                description: unix timestamp for the lat time the flag values were synced from the source environment
+            $ref: "#/components/schemas/Project"

--- a/internal/dev_server/api/server.go
+++ b/internal/dev_server/api/server.go
@@ -60,7 +60,11 @@ func (s Server) GetDevProjectsProjectKey(ctx context.Context, request GetDevProj
 		for _, item := range *request.Params.Expand {
 			if item == "overrides" {
 				//TODO: fetch overrides from db and put here
-				response.Overrides = &model.FlagsState{}
+				overrides, err := store.GetOverridesForProject(ctx, request.ProjectKey)
+				if err != nil {
+					return nil, err
+				}
+				response.Overrides = &overrides
 			}
 		}
 

--- a/internal/dev_server/api/server.go
+++ b/internal/dev_server/api/server.go
@@ -49,13 +49,25 @@ func (s Server) GetDevProjectsProjectKey(ctx context.Context, request GetDevProj
 		return GetDevProjectsProjectKey404Response{}, nil
 	}
 
+	response := ProjectJSONResponse{
+		LastSyncedFromSource: project.LastSyncTime.Unix(),
+		Context:              project.Context,
+		SourceEnvironmentKey: project.SourceEnvironmentKey,
+		FlagsState:           &project.FlagState,
+	}
+
+	if request.Params.Expand != nil {
+		for _, item := range *request.Params.Expand {
+			if item == "overrides" {
+				//TODO: fetch overrides from db and put here
+				response.Overrides = &model.FlagsState{}
+			}
+		}
+
+	}
+
 	return GetDevProjectsProjectKey200JSONResponse{
-		ProjectJSONResponse{
-			LastSyncedFromSource: project.LastSyncTime.Unix(),
-			Context:              project.Context,
-			SourceEnvironmentKey: project.SourceEnvironmentKey,
-			FlagsState:           &project.FlagState,
-		},
+		response,
 	}, nil
 }
 

--- a/internal/dev_server/api/server.go
+++ b/internal/dev_server/api/server.go
@@ -59,7 +59,6 @@ func (s Server) GetDevProjectsProjectKey(ctx context.Context, request GetDevProj
 	if request.Params.Expand != nil {
 		for _, item := range *request.Params.Expand {
 			if item == "overrides" {
-				//TODO: fetch overrides from db and put here
 				overrides, err := store.GetOverridesForProject(ctx, request.ProjectKey)
 				if err != nil {
 					return nil, err

--- a/internal/dev_server/model/store.go
+++ b/internal/dev_server/model/store.go
@@ -18,6 +18,7 @@ type Store interface {
 	DeleteDevProject(ctx context.Context, projectKey string) (bool, error)
 	InsertProject(ctx context.Context, project Project) error
 	UpsertOverride(ctx context.Context, override Override) error
+	GetOverridesForProject(ctx context.Context, projectKey string) (FlagsState, error)
 }
 
 func ContextWithStore(ctx context.Context, store Store) context.Context {


### PR DESCRIPTION
I hid the overrides behind an expand flag so that we wouldn't return this by default in the cli.  The project response is already very long since I'm now returning the flag state so I preemptively put the overrides behind the expand flag.  

To test:

`GET localhost:8765/dev/projects/default?expand=overrides`

will add something like this to the response

```
    "overrides": {
        "enable-flag-code-references": {
            "value": false,
            "version": 1
        }
    },
```