### PR TITLE
fix: Overrides weren't being loaded when SDKs were initialized

### DIFF
--- a/internal/dev_server/api/server.go
+++ b/internal/dev_server/api/server.go
@@ -63,7 +63,16 @@ func (s Server) GetDevProjectsProjectKey(ctx context.Context, request GetDevProj
 				if err != nil {
 					return nil, err
 				}
-				response.Overrides = &overrides
+				respOverrides := make(model.FlagsState)
+				for _, override := range overrides {
+					if !override.Active {
+						continue
+					}
+					respOverrides[override.FlagKey] = model.FlagState{
+						Value:   override.Value,
+						Version: override.Version,
+					}
+				}
 			}
 		}
 

--- a/internal/dev_server/model/store.go
+++ b/internal/dev_server/model/store.go
@@ -18,7 +18,7 @@ type Store interface {
 	DeleteDevProject(ctx context.Context, projectKey string) (bool, error)
 	InsertProject(ctx context.Context, project Project) error
 	UpsertOverride(ctx context.Context, override Override) (Override, error)
-	GetOverridesForProject(ctx context.Context, projectKey string) (FlagsState, error)
+	GetOverridesForProject(ctx context.Context, projectKey string) (Overrides, error)
 }
 
 func ContextWithStore(ctx context.Context, store Store) context.Context {

--- a/internal/dev_server/sdk/get_client_flags.go
+++ b/internal/dev_server/sdk/get_client_flags.go
@@ -16,7 +16,10 @@ func GetClientFlags(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		panic(errors.Wrap(err, "unable to get dev project"))
 	}
-	allFlags := project.GetFlagStateWithOverridesForProject(ctx, nil) // TODO fetch overrides
+	allFlags, err := project.GetFlagStateWithOverridesForProject(ctx)
+	if err != nil {
+		panic(errors.Wrap(err, "failed to get flag state"))
+	}
 	jsonBody, err := json.Marshal(allFlags)
 	if err != nil {
 		panic(errors.Wrap(err, "failed to marshal flag state"))

--- a/internal/dev_server/sdk/stream_client_flags.go
+++ b/internal/dev_server/sdk/stream_client_flags.go
@@ -18,7 +18,10 @@ func StreamClientFlags(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		panic(errors.Wrap(err, "unable to get dev project"))
 	}
-	allFlags := project.GetFlagStateWithOverridesForProject(ctx, nil) // TODO fetch overrides
+	allFlags, err := project.GetFlagStateWithOverridesForProject(ctx)
+	if err != nil {
+		panic(errors.Wrap(err, "failed to get flag state"))
+	}
 	jsonBody, err := json.Marshal(allFlags)
 	if err != nil {
 		panic(errors.Wrap(err, "failed to marshal flag state"))

--- a/internal/dev_server/sdk/stream_server_flags.go
+++ b/internal/dev_server/sdk/stream_server_flags.go
@@ -18,7 +18,10 @@ func StreamServerAllPayload(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		panic(errors.Wrap(err, "unable to get dev project"))
 	}
-	allFlags := project.GetFlagStateWithOverridesForProject(ctx, nil) // TODO fetch overrides
+	allFlags, err := project.GetFlagStateWithOverridesForProject(ctx)
+	if err != nil {
+		panic(errors.Wrap(err, "failed to get flag state"))
+	}
 	serverFlags := ServerAllPayloadFromFlagsState(allFlags)
 	jsonBody, err := json.Marshal(serverFlags)
 	if err != nil {


### PR DESCRIPTION
Load overrides when the SDKs load. Made the store less efficient but easier to reuse in the two scenarios we have.