### PR TITLE
Adds a sync api

### DIFF
--- a/cmd/dev_server/projects.go
+++ b/cmd/dev_server/projects.go
@@ -111,9 +111,9 @@ func NewSyncProjectCmd(client dev_server.LocalClient) *cobra.Command {
 func syncProject(client dev_server.LocalClient) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 
-		path := DEV_SERVER + "/dev/projects/" + viper.GetString(cliflags.ProjectFlag) + "sync"
+		path := DEV_SERVER + "/dev/projects/" + viper.GetString(cliflags.ProjectFlag) + "/sync"
 		res, err := client.MakeRequest(
-			"PUT",
+			"PATCH",
 			path,
 			nil,
 		)

--- a/internal/dev_server/api/api.yaml
+++ b/internal/dev_server/api/api.yaml
@@ -75,6 +75,15 @@ paths:
       summary: Add the project to the dev server
       parameters:
         - $ref: "#/components/parameters/projectKey"
+        - name: expand
+          description: Available expand options for this endpoint.
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - overrides
       requestBody:
         content:
           application/json:

--- a/internal/dev_server/api/api.yaml
+++ b/internal/dev_server/api/api.yaml
@@ -23,6 +23,25 @@ paths:
                 items:
                   type: string
                 uniqueItems: true
+  /dev/projects/{projectKey}/sync:
+    patch:
+      summary: updates the flag state for the given project and source environment
+      parameters:
+        - $ref: "#/components/parameters/projectKey"
+        - name: expand
+          description: Available expand options for this endpoint.
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - overrides
+      responses:
+        200:
+          $ref: "#/components/responses/Project"
+        404:
+          description: No project found
   /dev/projects/{projectKey}:
     get:
       summary: get the specified project and its configuration for syncing from the LaunchDarkly Service

--- a/internal/dev_server/api/api.yaml
+++ b/internal/dev_server/api/api.yaml
@@ -205,7 +205,7 @@ components:
         overrides:
           type: object
           description: flags and their values and version for a given project in the source environment
-          x-go-type: model.FlagsState
+          x-go-type: model.Overrides
           x-go-type-import:
             path: github.com/launchdarkly/ldcli/internal/dev_server/model
         _lastSyncedFromSource:

--- a/internal/dev_server/api/server.gen.go
+++ b/internal/dev_server/api/server.gen.go
@@ -47,7 +47,7 @@ type Project struct {
 	FlagsState *model.FlagsState `json:"flagsState,omitempty"`
 
 	// Overrides flags and their values and version for a given project in the source environment
-	Overrides *model.FlagsState `json:"overrides,omitempty"`
+	Overrides *model.Overrides `json:"overrides,omitempty"`
 
 	// SourceEnvironmentKey environment to copy flag values from
 	SourceEnvironmentKey string `json:"sourceEnvironmentKey"`

--- a/internal/dev_server/api/server.go
+++ b/internal/dev_server/api/server.go
@@ -84,17 +84,34 @@ func (s Server) GetDevProjectsProjectKey(ctx context.Context, request GetDevProj
 }
 
 func (s Server) PostDevProjectsProjectKey(ctx context.Context, request PostDevProjectsProjectKeyRequestObject) (PostDevProjectsProjectKeyResponseObject, error) {
+	store := model.StoreFromContext(ctx)
 	project, err := model.CreateProject(ctx, request.ProjectKey, request.Body.SourceEnvironmentKey, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	response := ProjectJSONResponse{
+		LastSyncedFromSource: project.LastSyncTime.Unix(),
+		Context:              project.Context,
+		SourceEnvironmentKey: project.SourceEnvironmentKey,
+		FlagsState:           &project.FlagState,
+	}
+
+	if request.Params.Expand != nil {
+		for _, item := range *request.Params.Expand {
+			if item == "overrides" {
+				overrides, err := store.GetOverridesForProject(ctx, request.ProjectKey)
+				if err != nil {
+					return nil, err
+				}
+				response.Overrides = &overrides
+			}
+		}
+
+	}
+
 	return PostDevProjectsProjectKey201JSONResponse{
-		ProjectJSONResponse{
-			LastSyncedFromSource: project.LastSyncTime.Unix(),
-			Context:              project.Context,
-			SourceEnvironmentKey: project.SourceEnvironmentKey,
-			FlagsState:           &project.FlagState,
-		},
+		response,
 	}, nil
 }
 

--- a/internal/dev_server/model/project.go
+++ b/internal/dev_server/model/project.go
@@ -19,6 +19,7 @@ type Project struct {
 
 // CreateProject creates a project and adds it to the database.
 func CreateProject(ctx context.Context, projectKey, sourceEnvironmentKey string, ldCtx *ldcontext.Context) (Project, error) {
+	store := StoreFromContext(ctx)
 	project := Project{}
 	project.Key = projectKey
 	project.SourceEnvironmentKey = sourceEnvironmentKey
@@ -27,19 +28,12 @@ func CreateProject(ctx context.Context, projectKey, sourceEnvironmentKey string,
 	} else {
 		project.Context = *ldCtx
 	}
+	flagsState, err := project.FetchFlagState(ctx)
+	if err != nil {
+		return Project{}, err
+	}
 
-	sdkAdapter := adapters.GetSdk(ctx)
-	apiAdapter := adapters.GetApi(ctx)
-	store := StoreFromContext(ctx)
-	sdkKey, err := apiAdapter.GetSdkKey(ctx, projectKey, sourceEnvironmentKey)
-	if err != nil {
-		return Project{}, err
-	}
-	sdkFlags, err := sdkAdapter.GetAllFlagsState(ctx, project.Context, sdkKey)
-	if err != nil {
-		return Project{}, err
-	}
-	project.FlagState = FromAllFlags(sdkFlags)
+	project.FlagState = flagsState
 	project.LastSyncTime = time.Now()
 
 	err = store.InsertProject(ctx, project)
@@ -47,6 +41,29 @@ func CreateProject(ctx context.Context, projectKey, sourceEnvironmentKey string,
 		return Project{}, err
 	}
 	return project, nil
+}
+
+func SyncProject(ctx context.Context, projectKey string) (Project, error) {
+	store := StoreFromContext(ctx)
+	project, err := store.GetDevProject(ctx, projectKey)
+	if err != nil {
+		return Project{}, err
+	}
+	flagsState, err := project.FetchFlagState(ctx)
+	if err != nil {
+		return Project{}, err
+	}
+
+	project.FlagState = flagsState
+	project.LastSyncTime = time.Now()
+	updated, err := store.UpdateProject(ctx, *project)
+	if err != nil {
+		return Project{}, err
+	}
+	if !updated {
+		return Project{}, err
+	}
+	return *project, nil
 }
 
 func (p Project) GetFlagStateWithOverridesForProject(ctx context.Context) (FlagsState, error) {
@@ -65,30 +82,18 @@ func (p Project) GetFlagStateWithOverridesForProject(ctx context.Context) (Flags
 	return withOverrides, nil
 }
 
-func SyncProject(ctx context.Context, projectKey string) (Project, error) {
-	store := StoreFromContext(ctx)
-	project, err := store.GetDevProject(ctx, projectKey)
-	if err != nil {
-		return Project{}, err
-	}
+func (p Project) FetchFlagState(ctx context.Context) (FlagsState, error) {
 	sdkAdapter := adapters.GetSdk(ctx)
 	apiAdapter := adapters.GetApi(ctx)
-	sdkKey, err := apiAdapter.GetSdkKey(ctx, projectKey, project.SourceEnvironmentKey)
+	sdkKey, err := apiAdapter.GetSdkKey(ctx, p.Key, p.SourceEnvironmentKey)
+	flagsState := make(FlagsState)
 	if err != nil {
-		return Project{}, err
+		return flagsState, err
 	}
-	sdkFlags, err := sdkAdapter.GetAllFlagsState(ctx, project.Context, sdkKey)
+	sdkFlags, err := sdkAdapter.GetAllFlagsState(ctx, p.Context, sdkKey)
 	if err != nil {
-		return Project{}, err
+		return flagsState, err
 	}
-	project.FlagState = FromAllFlags(sdkFlags)
-	project.LastSyncTime = time.Now()
-	updated, err := store.UpdateProject(ctx, *project)
-	if err != nil {
-		return Project{}, err
-	}
-	if !updated {
-		return Project{}, err
-	}
-	return *project, nil
+	flagsState = FromAllFlags(sdkFlags)
+	return flagsState, nil
 }

--- a/internal/dev_server/model/store.go
+++ b/internal/dev_server/model/store.go
@@ -15,6 +15,7 @@ type Store interface {
 	DeleteOverride(ctx context.Context, projectKey, flagKey string) error
 	GetDevProjects(ctx context.Context) ([]string, error)
 	GetDevProject(ctx context.Context, projectKey string) (*Project, error)
+	UpdateProject(ctx context.Context, project Project) (bool, error)
 	DeleteDevProject(ctx context.Context, projectKey string) (bool, error)
 	InsertProject(ctx context.Context, project Project) error
 	UpsertOverride(ctx context.Context, override Override) (Override, error)


### PR DESCRIPTION
I've added a sync api for the project that refetches the flag state.

The api looks like this 

`PATCH localhost:8765/dev/projects/default/sync?expand=overrides`

I've updated it so that the expand param is in both the patch and post apis since we'll want that data for the ui.  


In the next pr, I'll add another endpoint to patch the context and source environment for the project.  I should also do a bit of refactoring.  😬 