### PR TITLE
add dev stream uri to config file

### DIFF
--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -1,12 +1,14 @@
 package cliflags
 
 const (
-	BaseURIDefault = "https://app.launchdarkly.com"
+	BaseURIDefault      = "https://app.launchdarkly.com"
+	DevStreamURIDefault = "https://stream.launchdarkly.com"
 
 	AccessTokenFlag = "access-token"
 	AnalyticsOptOut = "analytics-opt-out"
 	BaseURIFlag     = "base-uri"
 	DataFlag        = "data"
+	DevStreamURI    = "dev-stream-uri"
 	EmailsFlag      = "emails"
 	EnvironmentFlag = "environment"
 	FlagFlag        = "flag"
@@ -17,6 +19,7 @@ const (
 	AccessTokenFlagDescription = "LaunchDarkly access token with write-level access"
 	AnalyticsOptOutDescription = "Opt out of analytics tracking"
 	BaseURIFlagDescription     = "LaunchDarkly base URI"
+	DevStreamURIDescription    = "URI from which the dev server will stream flag configurations"
 	EnvironmentFlagDescription = "Default environment key"
 	FlagFlagDescription        = "Default feature flag key"
 	OutputFlagDescription      = "Command response output format in either JSON or plain text"
@@ -28,6 +31,7 @@ func AllFlagsHelp() map[string]string {
 		AccessTokenFlag: AccessTokenFlagDescription,
 		AnalyticsOptOut: AnalyticsOptOutDescription,
 		BaseURIFlag:     BaseURIFlagDescription,
+		DevStreamURI:    DevStreamURIDescription,
 		EnvironmentFlag: EnvironmentFlagDescription,
 		FlagFlag:        FlagFlagDescription,
 		OutputFlag:      OutputFlagDescription,

--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -4,17 +4,17 @@ const (
 	BaseURIDefault      = "https://app.launchdarkly.com"
 	DevStreamURIDefault = "https://stream.launchdarkly.com"
 
-	AccessTokenFlag = "access-token"
-	AnalyticsOptOut = "analytics-opt-out"
-	BaseURIFlag     = "base-uri"
-	DataFlag        = "data"
-	DevStreamURI    = "dev-stream-uri"
-	EmailsFlag      = "emails"
-	EnvironmentFlag = "environment"
-	FlagFlag        = "flag"
-	OutputFlag      = "output"
-	ProjectFlag     = "project"
-	RoleFlag        = "role"
+	AccessTokenFlag  = "access-token"
+	AnalyticsOptOut  = "analytics-opt-out"
+	BaseURIFlag      = "base-uri"
+	DataFlag         = "data"
+	DevStreamURIFlag = "dev-stream-uri"
+	EmailsFlag       = "emails"
+	EnvironmentFlag  = "environment"
+	FlagFlag         = "flag"
+	OutputFlag       = "output"
+	ProjectFlag      = "project"
+	RoleFlag         = "role"
 
 	AccessTokenFlagDescription = "LaunchDarkly access token with write-level access"
 	AnalyticsOptOutDescription = "Opt out of analytics tracking"
@@ -28,13 +28,13 @@ const (
 
 func AllFlagsHelp() map[string]string {
 	return map[string]string{
-		AccessTokenFlag: AccessTokenFlagDescription,
-		AnalyticsOptOut: AnalyticsOptOutDescription,
-		BaseURIFlag:     BaseURIFlagDescription,
-		DevStreamURI:    DevStreamURIDescription,
-		EnvironmentFlag: EnvironmentFlagDescription,
-		FlagFlag:        FlagFlagDescription,
-		OutputFlag:      OutputFlagDescription,
-		ProjectFlag:     ProjectFlagDescription,
+		AccessTokenFlag:  AccessTokenFlagDescription,
+		AnalyticsOptOut:  AnalyticsOptOutDescription,
+		BaseURIFlag:      BaseURIFlagDescription,
+		DevStreamURIFlag: DevStreamURIDescription,
+		EnvironmentFlag:  EnvironmentFlagDescription,
+		FlagFlag:         FlagFlagDescription,
+		OutputFlag:       OutputFlagDescription,
+		ProjectFlag:      ProjectFlagDescription,
 	}
 }

--- a/cmd/config/testdata/help.golden
+++ b/cmd/config/testdata/help.golden
@@ -4,6 +4,7 @@ Supported settings:
 - `access-token`: LaunchDarkly access token with write-level access
 - `analytics-opt-out`: Opt out of analytics tracking
 - `base-uri`: LaunchDarkly base URI
+- `dev-stream-uri`: URI from which the dev server will stream flag configurations
 - `environment`: Default environment key
 - `flag`: Default feature flag key
 - `output`: Command response output format in either JSON or plain text

--- a/cmd/dev_server/dev_server.go
+++ b/cmd/dev_server/dev_server.go
@@ -2,7 +2,9 @@ package dev_server
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
+	"github.com/launchdarkly/ldcli/cmd/cliflags"
 	resourcecmd "github.com/launchdarkly/ldcli/cmd/resources"
 	"github.com/launchdarkly/ldcli/internal/dev_server"
 )
@@ -14,6 +16,13 @@ func NewDevServerCmd(localClient dev_server.LocalClient, ldClient dev_server.Cli
 		Long:  "Start and use a local development server for overriding flag values.",
 	}
 
+	cmd.PersistentFlags().String(
+		cliflags.DevStreamURI,
+		cliflags.DevStreamURIDefault,
+		cliflags.DevStreamURIDescription,
+	)
+	_ = viper.BindPFlag(cliflags.DevStreamURI, cmd.PersistentFlags().Lookup(cliflags.DevStreamURI))
+
 	// Add subcommands here
 	cmd.AddGroup(&cobra.Group{ID: "projects", Title: "Project commands:"})
 	cmd.AddCommand(NewListProjectsCmd(localClient))
@@ -21,10 +30,12 @@ func NewDevServerCmd(localClient dev_server.LocalClient, ldClient dev_server.Cli
 	cmd.AddCommand(NewSyncProjectCmd(localClient))
 	cmd.AddCommand(NewRemoveProjectCmd(localClient))
 	cmd.AddCommand(NewAddProjectCmd(localClient))
+
 	cmd.AddGroup(&cobra.Group{ID: "overrides", Title: "Override commands:"})
 	cmd.AddCommand(NewAddOverrideCmd(localClient))
 	cmd.AddCommand(NewRemoveOverrideCmd(localClient))
 	cmd.AddGroup(&cobra.Group{ID: "server", Title: "Server commands:"})
+
 	cmd.AddCommand(NewStartServerCmd(ldClient))
 
 	cmd.SetUsageTemplate(resourcecmd.SubcommandUsageTemplate())

--- a/cmd/dev_server/dev_server.go
+++ b/cmd/dev_server/dev_server.go
@@ -17,11 +17,11 @@ func NewDevServerCmd(localClient dev_server.LocalClient, ldClient dev_server.Cli
 	}
 
 	cmd.PersistentFlags().String(
-		cliflags.DevStreamURI,
+		cliflags.DevStreamURIFlag,
 		cliflags.DevStreamURIDefault,
 		cliflags.DevStreamURIDescription,
 	)
-	_ = viper.BindPFlag(cliflags.DevStreamURI, cmd.PersistentFlags().Lookup(cliflags.DevStreamURI))
+	_ = viper.BindPFlag(cliflags.DevStreamURIFlag, cmd.PersistentFlags().Lookup(cliflags.DevStreamURIFlag))
 
 	// Add subcommands here
 	cmd.AddGroup(&cobra.Group{ID: "projects", Title: "Project commands:"})

--- a/cmd/dev_server/start_server.go
+++ b/cmd/dev_server/start_server.go
@@ -31,7 +31,12 @@ func startServer(client dev_server.Client) func(*cobra.Command, []string) error 
 	return func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
-		client.RunServer(ctx, viper.GetString(cliflags.AccessTokenFlag), viper.GetString(cliflags.BaseURIFlag))
+		client.RunServer(
+			ctx,
+			viper.GetString(cliflags.AccessTokenFlag),
+			viper.GetString(cliflags.BaseURIFlag),
+			viper.GetString(cliflags.DevStreamURI),
+		)
 
 		return nil
 	}

--- a/cmd/dev_server/start_server.go
+++ b/cmd/dev_server/start_server.go
@@ -35,7 +35,7 @@ func startServer(client dev_server.Client) func(*cobra.Command, []string) error 
 			ctx,
 			viper.GetString(cliflags.AccessTokenFlag),
 			viper.GetString(cliflags.BaseURIFlag),
-			viper.GetString(cliflags.DevStreamURI),
+			viper.GetString(cliflags.DevStreamURIFlag),
 		)
 
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,8 +85,8 @@ func NewConfig(rawConfig map[string]interface{}) (ConfigFile, error) {
 	if rawConfig[cliflags.ProjectFlag] != nil {
 		project = rawConfig[cliflags.ProjectFlag].(string)
 	}
-	if rawConfig[cliflags.DevStreamURI] != nil {
-		devStreamURI = rawConfig[cliflags.DevStreamURI].(string)
+	if rawConfig[cliflags.DevStreamURIFlag] != nil {
+		devStreamURI = rawConfig[cliflags.DevStreamURIFlag].(string)
 	}
 
 	return ConfigFile{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type ConfigFile struct {
 	AnalyticsOptOut *bool  `json:"analytics-opt-out,omitempty" yaml:"analytics-opt-out,omitempty"`
 	BaseURI         string `json:"base-uri,omitempty" yaml:"base-uri,omitempty"`
 	Flag            string `json:"flag,omitempty" yaml:"flag,omitempty"`
+	DevStreamURI    string `json:"dev-stream-uri,omitempty" yaml:"dev-stream-uri,omitempty"`
 	Environment     string `json:"environment,omitempty" yaml:"environment,omitempty"`
 	Output          string `json:"output,omitempty" yaml:"output,omitempty"`
 	Project         string `json:"project,omitempty" yaml:"project,omitempty"`
@@ -49,6 +50,7 @@ func NewConfig(rawConfig map[string]interface{}) (ConfigFile, error) {
 		accessToken     string
 		analyticsOptOut bool
 		baseURI         string
+		devStreamURI    string
 		environment     string
 		err             error
 		flag            string
@@ -83,11 +85,15 @@ func NewConfig(rawConfig map[string]interface{}) (ConfigFile, error) {
 	if rawConfig[cliflags.ProjectFlag] != nil {
 		project = rawConfig[cliflags.ProjectFlag].(string)
 	}
+	if rawConfig[cliflags.DevStreamURI] != nil {
+		devStreamURI = rawConfig[cliflags.DevStreamURI].(string)
+	}
 
 	return ConfigFile{
 		AccessToken:     accessToken,
 		AnalyticsOptOut: &analyticsOptOut,
 		BaseURI:         baseURI,
+		DevStreamURI:    devStreamURI,
 		Environment:     environment,
 		Flag:            flag,
 		Output:          outputKind.String(),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -189,6 +189,19 @@ func TestNewConfig(t *testing.T) {
 			assert.Equal(t, "test-key", configFile.Project)
 		})
 	})
+
+	t.Run("dev-stream-uri", func(t *testing.T) {
+		t.Run("sets the given value", func(t *testing.T) {
+			rawConfig := map[string]interface{}{
+				"dev-stream-uri": "http://relay.com",
+			}
+
+			configFile, err := config.NewConfig(rawConfig)
+
+			require.NoError(t, err)
+			assert.Equal(t, "http://relay.com", configFile.DevStreamURI)
+		})
+	})
 }
 
 func TestService_VerifyAccessToken(t *testing.T) {

--- a/internal/dev_server/dev_server.go
+++ b/internal/dev_server/dev_server.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Client interface {
-	RunServer(ctx context.Context, accessToken, baseURI string)
+	RunServer(ctx context.Context, accessToken, baseURI, devStreamURI string)
 }
 
 type LDClient struct {
@@ -32,7 +32,7 @@ func NewClient(cliVersion string) LDClient {
 	return LDClient{cliVersion: cliVersion}
 }
 
-func (c LDClient) RunServer(ctx context.Context, accessToken, baseURI string) {
+func (c LDClient) RunServer(ctx context.Context, accessToken, baseURI, devStreamURI string) {
 	ldClient := client.New(accessToken, baseURI, c.cliVersion)
 	sqlStore, err := db.NewSqlite(ctx, "devserver.db")
 	if err != nil {

--- a/internal/dev_server/dev_server.go
+++ b/internal/dev_server/dev_server.go
@@ -44,7 +44,7 @@ func (c LDClient) RunServer(ctx context.Context, accessToken, baseURI, devStream
 		ResponseErrorHandlerFunc: ResponseErrorHandler,
 	})
 	r := mux.NewRouter()
-	r.Use(adapters.Middleware(*ldClient, "https://relay-stg.ld.catamorphic.com")) // TODO add to config
+	r.Use(adapters.Middleware(*ldClient, devStreamURI))
 	r.Use(model.StoreMiddleware(sqlStore))
 	r.Use(model.ObserversMiddleware(model.NewObservers()))
 	sdk.BindRoutes(r)


### PR DESCRIPTION
To set the value in the config file:
`go run . config --set dev-stream-uri https://relay-stg.ld.catamorphic.com`

This can also be set as an environment variable:
`export LD_DEV_STREAM_URI=https://relay-stg.ld.catamorphic.com`

Value defaults to prod: `https://stream.launchdarkly.com`

```
$ go run . config help
View and modify specific configuration values

Supported settings:
- `access-token`: LaunchDarkly access token with write-level access
- `analytics-opt-out`: Opt out of analytics tracking
- `base-uri`: LaunchDarkly base URI
- `dev-stream-uri`: URI from which the dev server will stream flag configurations
- `environment`: Default environment key
- `flag`: Default feature flag key
- `output`: Command response output format in either JSON or plain text
- `project`: Default project key

Usage:
  ldcli config [command]
```