### PR TITLE
feat: add ui routes

### DIFF
--- a/internal/dev_server/api/Makefile
+++ b/internal/dev_server/api/Makefile
@@ -1,2 +1,0 @@
-server.gen.go: api.yaml oapi-codegen-cfg.yaml
-	oapi-codegen -config oapi-codegen-cfg.yaml api.yaml

--- a/internal/dev_server/api/server.go
+++ b/internal/dev_server/api/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/launchdarkly/ldcli/internal/dev_server/model"
 )
 
+//go:generate oapi-codegen -config oapi-codegen-cfg.yaml api.yaml
 type Server struct {
 }
 

--- a/internal/dev_server/dev_server.go
+++ b/internal/dev_server/dev_server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/launchdarkly/ldcli/internal/dev_server/db"
 	"github.com/launchdarkly/ldcli/internal/dev_server/model"
 	"github.com/launchdarkly/ldcli/internal/dev_server/sdk"
+	"github.com/launchdarkly/ldcli/internal/dev_server/ui"
 )
 
 type Client interface {
@@ -49,6 +50,8 @@ func (c LDClient) RunServer(ctx context.Context, accessToken, baseURI string) {
 	r.Use(adapters.Middleware(*ldClient, "https://relay-stg.ld.catamorphic.com")) // TODO add to config
 	r.Use(model.StoreMiddleware(sqlStore))
 	r.Use(model.ObserversMiddleware(model.NewObservers()))
+	r.Handle("/ui", http.RedirectHandler("/ui/", http.StatusMovedPermanently))
+	r.PathPrefix("/ui/").Handler(http.StripPrefix("/ui/", ui.AssetHandler))
 	sdk.BindRoutes(r)
 	handler := api.HandlerFromMux(apiServer, r)
 	handler = handlers.CombinedLoggingHandler(os.Stdout, handler)

--- a/internal/dev_server/ui/asset_handler.go
+++ b/internal/dev_server/ui/asset_handler.go
@@ -1,0 +1,11 @@
+package ui
+
+import (
+	"embed"
+	"net/http"
+)
+
+//go:embed index.html
+var content embed.FS
+
+var AssetHandler = http.FileServerFS(content)


### PR DESCRIPTION
Adds UI routes & uses go generate instead of make for regenerating the server code.