### PR TITLE
add UI cmd

### DIFF
--- a/cmd/dev_server/dev_server.go
+++ b/cmd/dev_server/dev_server.go
@@ -37,6 +37,7 @@ func NewDevServerCmd(localClient dev_server.LocalClient, ldClient dev_server.Cli
 	cmd.AddGroup(&cobra.Group{ID: "server", Title: "Server commands:"})
 
 	cmd.AddCommand(NewStartServerCmd(ldClient))
+	cmd.AddCommand(NewUICmd())
 
 	cmd.SetUsageTemplate(resourcecmd.SubcommandUsageTemplate())
 

--- a/cmd/dev_server/start_server.go
+++ b/cmd/dev_server/start_server.go
@@ -2,6 +2,10 @@ package dev_server
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -37,6 +41,44 @@ func startServer(client dev_server.Client) func(*cobra.Command, []string) error 
 			viper.GetString(cliflags.BaseURIFlag),
 			viper.GetString(cliflags.DevStreamURIFlag),
 		)
+
+		return nil
+	}
+}
+
+func NewUICmd() *cobra.Command {
+	cmd := &cobra.Command{
+		GroupID: "server",
+		Args:    validators.Validate(),
+		Long:    "open the dev ui in your default browser",
+		RunE:    openUI(),
+		Short:   "open the ui",
+		Use:     "ui",
+	}
+
+	cmd.SetUsageTemplate(resourcescmd.SubcommandUsageTemplate())
+
+	return cmd
+}
+
+func openUI() func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		url := "http://localhost:8765/ui"
+
+		var err error
+		switch runtime.GOOS {
+		case "linux":
+			err = exec.Command("xdg-open", url).Start()
+		case "windows":
+			err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+		case "darwin":
+			err = exec.Command("open", url).Start()
+		default:
+			err = fmt.Errorf("unsupported platform")
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		return nil
 	}

--- a/internal/dev_server/dev_server.go
+++ b/internal/dev_server/dev_server.go
@@ -57,6 +57,7 @@ func (c LDClient) RunServer(ctx context.Context, accessToken, baseURI, devStream
 	handler = handlers.CombinedLoggingHandler(os.Stdout, handler)
 	handler = handlers.RecoveryHandler(handlers.PrintRecoveryStack(true))(handler)
 	fmt.Println("Server running on 0.0.0.0:8765")
+	fmt.Println("Access the UI for toggling overrides at http://localhost:8765/ui or by running `ldcli dev-server ui`")
 	server := http.Server{
 		Addr:    "0.0.0.0:8765",
 		Handler: handler,


### PR DESCRIPTION
`go run . dev-server ui` should pop open a new browser window for the UI

also adds a log line when the server starts to include those instructions as well ✨ 

