### PR TITLE
fix error response expected by ldcli cmds

### DIFF
--- a/internal/dev_server/api/api.yaml
+++ b/internal/dev_server/api/api.yaml
@@ -74,7 +74,7 @@ paths:
         204:
           description: OK. Project & overrides were removed
         404:
-          description: no project found
+          $ref: "#/components/responses/NotFoundErrorResp"
     post:
       summary: Add the project to the dev server
       parameters:
@@ -237,3 +237,17 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Project"
+    NotFoundErrorResp:
+      description: not found
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - code
+              - message
+            properties:
+              code:
+                type: string
+              message:
+                type: string

--- a/internal/dev_server/api/server.gen.go
+++ b/internal/dev_server/api/server.gen.go
@@ -79,6 +79,12 @@ type FlagOverride struct {
 	Value FlagValue `json:"value"`
 }
 
+// NotFoundErrorResp defines model for NotFoundErrorResp.
+type NotFoundErrorResp struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 // GetDevProjectsProjectKeyParams defines parameters for GetDevProjectsProjectKey.
 type GetDevProjectsProjectKeyParams struct {
 	// Expand Available expand options for this endpoint.
@@ -578,6 +584,11 @@ type FlagOverrideJSONResponse struct {
 	Value FlagValue `json:"value"`
 }
 
+type NotFoundErrorRespJSONResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 type ProjectJSONResponse Project
 
 type GetDevProjectsRequestObject struct {
@@ -612,12 +623,13 @@ func (response DeleteDevProjectsProjectKey204Response) VisitDeleteDevProjectsPro
 	return nil
 }
 
-type DeleteDevProjectsProjectKey404Response struct {
-}
+type DeleteDevProjectsProjectKey404JSONResponse struct{ NotFoundErrorRespJSONResponse }
 
-func (response DeleteDevProjectsProjectKey404Response) VisitDeleteDevProjectsProjectKeyResponse(w http.ResponseWriter) error {
+func (response DeleteDevProjectsProjectKey404JSONResponse) VisitDeleteDevProjectsProjectKeyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
-	return nil
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type GetDevProjectsProjectKeyRequestObject struct {

--- a/internal/dev_server/api/server.go
+++ b/internal/dev_server/api/server.go
@@ -35,7 +35,10 @@ func (s Server) DeleteDevProjectsProjectKey(ctx context.Context, request DeleteD
 		return nil, err
 	}
 	if !deleted {
-		return DeleteDevProjectsProjectKey404Response{}, nil
+		return DeleteDevProjectsProjectKey404JSONResponse{NotFoundErrorRespJSONResponse{
+			Code:    "not_found",
+			Message: "project not found",
+		}}, nil
 	}
 	return DeleteDevProjectsProjectKey204Response{}, nil
 }


### PR DESCRIPTION
the ldcli handles errors more nicely when they include an expected rep - added that to our server so that they display more nicely:

```
$ go run . dev-server remove-project --project does-not-exist
project not found (code: not_found)
```