### PR TITLE
fix: error handling when project is missing

### DIFF
--- a/internal/dev_server/adapters/sdk.go
+++ b/internal/dev_server/adapters/sdk.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	ldsdk "github.com/launchdarkly/go-server-sdk/v7"
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces/flagstate"
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
@@ -35,6 +36,7 @@ func (s Sdk) GetAllFlagsState(ctx context.Context, ldContext ldcontext.Context, 
 	config := ldsdk.Config{
 		DiagnosticOptOut: true,
 		Events:           ldcomponents.NoEvents(),
+		Logging:          ldcomponents.Logging().MinLevel(ldlog.Debug),
 	}
 	if s.streamingUrl != "" {
 		config.ServiceEndpoints.Streaming = s.streamingUrl

--- a/internal/dev_server/api/server.go
+++ b/internal/dev_server/api/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/launchdarkly/ldcli/internal/dev_server/db"
 	"github.com/launchdarkly/ldcli/internal/dev_server/model"
 )
 
@@ -221,7 +220,7 @@ func (s Server) DeleteDevProjectsProjectKeyOverridesFlagKey(ctx context.Context,
 	store := model.StoreFromContext(ctx)
 	err := store.DeleteOverride(ctx, request.ProjectKey, request.FlagKey)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
+		if errors.Is(err, model.ErrNotFound) {
 			return DeleteDevProjectsProjectKeyOverridesFlagKey404Response{}, nil
 		}
 		return nil, err

--- a/internal/dev_server/db/sqlite.go
+++ b/internal/dev_server/db/sqlite.go
@@ -77,6 +77,9 @@ func (s Sqlite) UpdateProject(ctx context.Context, project model.Project) (bool,
 		SET flag_state = ?, last_sync_time = ?, context=?
 		WHERE key = ?;
 	`, flagsStateJson, project.LastSyncTime, project.Context.JSONString(), project.Key)
+	if err != nil {
+		return false, errors.Wrap(err, "unable to execute update project")
+	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {

--- a/internal/dev_server/model/store.go
+++ b/internal/dev_server/model/store.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 )
 
 type ctxKey string
@@ -14,6 +15,7 @@ const ctxKeyStore = ctxKey("model.Store")
 type Store interface {
 	DeleteOverride(ctx context.Context, projectKey, flagKey string) error
 	GetDevProjects(ctx context.Context) ([]string, error)
+	// GetDevProject fetches the project based on the projectKey. If it doesn't exist, ErrNotFound is returned
 	GetDevProject(ctx context.Context, projectKey string) (*Project, error)
 	UpdateProject(ctx context.Context, project Project) (bool, error)
 	DeleteDevProject(ctx context.Context, projectKey string) (bool, error)
@@ -40,3 +42,5 @@ func StoreMiddleware(store Store) mux.MiddlewareFunc {
 		})
 	}
 }
+
+var ErrNotFound = errors.New("not found")

--- a/internal/dev_server/sdk/get_client_flags.go
+++ b/internal/dev_server/sdk/get_client_flags.go
@@ -11,15 +11,15 @@ func GetClientFlags(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	allFlags, err := GetAllFlagsFromContext(ctx)
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "failed to get flag state"))
+		WriteError(ctx, w, errors.Wrap(err, "failed to get flag state"))
 	}
 	jsonBody, err := json.Marshal(allFlags)
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "failed to marshal flag state"))
+		WriteError(ctx, w, errors.Wrap(err, "failed to marshal flag state"))
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(jsonBody)
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "unable to write response"))
+		WriteError(ctx, w, errors.Wrap(err, "unable to write response"))
 	}
 }

--- a/internal/dev_server/sdk/get_client_flags.go
+++ b/internal/dev_server/sdk/get_client_flags.go
@@ -4,29 +4,22 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/launchdarkly/ldcli/internal/dev_server/model"
 	"github.com/pkg/errors"
 )
 
 func GetClientFlags(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	store := model.StoreFromContext(ctx)
-	projectKey := GetProjectKeyFromContext(ctx)
-	project, err := store.GetDevProject(ctx, projectKey)
+	allFlags, err := GetAllFlagsFromContext(ctx)
 	if err != nil {
-		panic(errors.Wrap(err, "unable to get dev project"))
-	}
-	allFlags, err := project.GetFlagStateWithOverridesForProject(ctx)
-	if err != nil {
-		panic(errors.Wrap(err, "failed to get flag state"))
+		WriteError(w, errors.Wrap(err, "failed to get flag state"))
 	}
 	jsonBody, err := json.Marshal(allFlags)
 	if err != nil {
-		panic(errors.Wrap(err, "failed to marshal flag state"))
+		WriteError(w, errors.Wrap(err, "failed to marshal flag state"))
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(jsonBody)
 	if err != nil {
-		panic(errors.Wrap(err, "unable to write response"))
+		WriteError(w, errors.Wrap(err, "unable to write response"))
 	}
 }

--- a/internal/dev_server/sdk/get_client_flags.go
+++ b/internal/dev_server/sdk/get_client_flags.go
@@ -12,14 +12,17 @@ func GetClientFlags(w http.ResponseWriter, r *http.Request) {
 	allFlags, err := GetAllFlagsFromContext(ctx)
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "failed to get flag state"))
+		return
 	}
 	jsonBody, err := json.Marshal(allFlags)
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "failed to marshal flag state"))
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(jsonBody)
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "unable to write response"))
+		return
 	}
 }

--- a/internal/dev_server/sdk/get_server_flags.go
+++ b/internal/dev_server/sdk/get_server_flags.go
@@ -12,7 +12,7 @@ func GetServerFlags(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	allFlags, err := GetAllFlagsFromContext(ctx)
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "failed to get flag state"))
+		WriteError(ctx, w, errors.Wrap(err, "failed to get flag state"))
 	}
 	var body interface{}
 	if flagKey, ok := mux.Vars(r)["flagKey"]; ok {
@@ -25,11 +25,11 @@ func GetServerFlags(w http.ResponseWriter, r *http.Request) {
 	}
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "failed to marshal flag state"))
+		WriteError(ctx, w, errors.Wrap(err, "failed to marshal flag state"))
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(jsonBody)
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "unable to write response"))
+		WriteError(ctx, w, errors.Wrap(err, "unable to write response"))
 	}
 }

--- a/internal/dev_server/sdk/get_server_flags.go
+++ b/internal/dev_server/sdk/get_server_flags.go
@@ -5,35 +5,31 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	"github.com/launchdarkly/ldcli/internal/dev_server/model"
 	"github.com/pkg/errors"
 )
 
 func GetServerFlags(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	store := model.StoreFromContext(ctx)
-	projectKey := GetProjectKeyFromContext(ctx)
-	project, err := store.GetDevProject(ctx, projectKey)
+	allFlags, err := GetAllFlagsFromContext(ctx)
 	if err != nil {
-		panic(errors.Wrap(err, "unable to get dev project"))
-	}
-	allFlags, err := project.GetFlagStateWithOverridesForProject(ctx)
-	if err != nil {
-		panic(errors.Wrap(err, "failed to get flag state"))
+		WriteError(w, errors.Wrap(err, "failed to get flag state"))
 	}
 	var body interface{}
 	if flagKey, ok := mux.Vars(r)["flagKey"]; ok {
-		body = ServerFlagsFromFlagsState(allFlags)[flagKey]
+		body, ok = ServerFlagsFromFlagsState(allFlags)[flagKey]
+		if !ok {
+			http.Error(w, "flag not found", http.StatusNotFound)
+		}
 	} else {
 		body = ServerAllPayloadFromFlagsState(allFlags)
 	}
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
-		panic(errors.Wrap(err, "failed to marshal flag state"))
+		WriteError(w, errors.Wrap(err, "failed to marshal flag state"))
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(jsonBody)
 	if err != nil {
-		panic(errors.Wrap(err, "unable to write response"))
+		WriteError(w, errors.Wrap(err, "unable to write response"))
 	}
 }

--- a/internal/dev_server/sdk/get_server_flags.go
+++ b/internal/dev_server/sdk/get_server_flags.go
@@ -13,6 +13,7 @@ func GetServerFlags(w http.ResponseWriter, r *http.Request) {
 	allFlags, err := GetAllFlagsFromContext(ctx)
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "failed to get flag state"))
+		return
 	}
 	var body interface{}
 	if flagKey, ok := mux.Vars(r)["flagKey"]; ok {
@@ -26,10 +27,12 @@ func GetServerFlags(w http.ResponseWriter, r *http.Request) {
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "failed to marshal flag state"))
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(jsonBody)
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "unable to write response"))
+		return
 	}
 }

--- a/internal/dev_server/sdk/store_facade.go
+++ b/internal/dev_server/sdk/store_facade.go
@@ -17,9 +17,10 @@ import (
 func WriteError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, model.ErrNotFound):
-		message := fmt.Sprintf("project, %s, not found", GetProjectKeyFromContext(ctx))
+		projectKey := GetProjectKeyFromContext(ctx)
+		message := fmt.Sprintf("project, %s, not found", projectKey)
 		log.Println(message)
-		log.Println("You may need to call ldcli dev-server add-project")
+		log.Printf("To add your project to the dev server, call `ldcli dev-server add-project --project %s --source {SOURCE_ENV_KEY}", projectKey)
 		http.Error(w, message, http.StatusNotFound)
 	case err != nil:
 		panic(err)

--- a/internal/dev_server/sdk/store_facade.go
+++ b/internal/dev_server/sdk/store_facade.go
@@ -1,0 +1,36 @@
+package sdk
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/launchdarkly/ldcli/internal/dev_server/model"
+	"github.com/pkg/errors"
+)
+
+// WriteError writes out a given error if it's known or panics if it isn't.
+// Two assumptions it's making
+//   - a panic handling middleware is in use
+//   - This is in the context of flag delivery which has pretty consistent semantics for what's an error across handlers.
+func WriteError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, model.ErrNotFound):
+		http.Error(w, "project not found", http.StatusNotFound)
+	case err != nil:
+		panic(err)
+	}
+}
+
+func GetAllFlagsFromContext(ctx context.Context) (model.FlagsState, error) {
+	store := model.StoreFromContext(ctx)
+	projectKey := GetProjectKeyFromContext(ctx)
+	project, err := store.GetDevProject(ctx, projectKey)
+	if err != nil {
+		return model.FlagsState{}, errors.Wrap(err, "unable to get dev project")
+	}
+	allFlags, err := project.GetFlagStateWithOverridesForProject(ctx)
+	if err != nil {
+		return model.FlagsState{}, errors.Wrap(err, "unable to get flags for project")
+	}
+	return allFlags, nil
+}

--- a/internal/dev_server/sdk/store_facade.go
+++ b/internal/dev_server/sdk/store_facade.go
@@ -2,6 +2,8 @@ package sdk
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/launchdarkly/ldcli/internal/dev_server/model"
@@ -12,10 +14,12 @@ import (
 // Two assumptions it's making
 //   - a panic handling middleware is in use
 //   - This is in the context of flag delivery which has pretty consistent semantics for what's an error across handlers.
-func WriteError(w http.ResponseWriter, err error) {
+func WriteError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, model.ErrNotFound):
-		http.Error(w, "project not found", http.StatusNotFound)
+		message := fmt.Sprintf("project, %s, not found", GetProjectKeyFromContext(ctx))
+		log.Println(message)
+		http.Error(w, message, http.StatusNotFound)
 	case err != nil:
 		panic(err)
 	}

--- a/internal/dev_server/sdk/store_facade.go
+++ b/internal/dev_server/sdk/store_facade.go
@@ -19,6 +19,7 @@ func WriteError(ctx context.Context, w http.ResponseWriter, err error) {
 	case errors.Is(err, model.ErrNotFound):
 		message := fmt.Sprintf("project, %s, not found", GetProjectKeyFromContext(ctx))
 		log.Println(message)
+		log.Println("You may need to call ldcli dev-server add-project")
 		http.Error(w, message, http.StatusNotFound)
 	case err != nil:
 		panic(err)

--- a/internal/dev_server/sdk/stream_client_flags.go
+++ b/internal/dev_server/sdk/stream_client_flags.go
@@ -14,11 +14,11 @@ func StreamClientFlags(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	allFlags, err := GetAllFlagsFromContext(ctx)
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "failed to get flag state"))
+		WriteError(ctx, w, errors.Wrap(err, "failed to get flag state"))
 	}
 	jsonBody, err := json.Marshal(allFlags)
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "failed to marshal flag state"))
+		WriteError(ctx, w, errors.Wrap(err, "failed to marshal flag state"))
 	}
 	updateChan, doneChan := OpenStream(w, r.Context().Done(), Message{"put", jsonBody}) // TODO Wireup updateChan
 	defer close(updateChan)
@@ -34,7 +34,7 @@ func StreamClientFlags(w http.ResponseWriter, r *http.Request) {
 	}()
 	err = <-doneChan
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "stream failure"))
+		WriteError(ctx, w, errors.Wrap(err, "stream failure"))
 	}
 }
 

--- a/internal/dev_server/sdk/stream_client_flags.go
+++ b/internal/dev_server/sdk/stream_client_flags.go
@@ -15,10 +15,12 @@ func StreamClientFlags(w http.ResponseWriter, r *http.Request) {
 	allFlags, err := GetAllFlagsFromContext(ctx)
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "failed to get flag state"))
+		return
 	}
 	jsonBody, err := json.Marshal(allFlags)
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "failed to marshal flag state"))
+		return
 	}
 	updateChan, doneChan := OpenStream(w, r.Context().Done(), Message{"put", jsonBody}) // TODO Wireup updateChan
 	defer close(updateChan)
@@ -35,6 +37,7 @@ func StreamClientFlags(w http.ResponseWriter, r *http.Request) {
 	err = <-doneChan
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "stream failure"))
+		return
 	}
 }
 

--- a/internal/dev_server/sdk/stream_server_flags.go
+++ b/internal/dev_server/sdk/stream_server_flags.go
@@ -15,12 +15,12 @@ func StreamServerAllPayload(w http.ResponseWriter, r *http.Request) {
 	projectKey := GetProjectKeyFromContext(ctx)
 	allFlags, err := GetAllFlagsFromContext(ctx)
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "failed to get flag state"))
+		WriteError(ctx, w, errors.Wrap(err, "failed to get flag state"))
 	}
 	serverFlags := ServerAllPayloadFromFlagsState(allFlags)
 	jsonBody, err := json.Marshal(serverFlags)
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "failed to marshal flag state"))
+		WriteError(ctx, w, errors.Wrap(err, "failed to marshal flag state"))
 	}
 	updateChan, doneChan := OpenStream(w, r.Context().Done(), Message{"put", jsonBody})
 	defer close(updateChan)
@@ -35,7 +35,7 @@ func StreamServerAllPayload(w http.ResponseWriter, r *http.Request) {
 	}()
 	err = <-doneChan
 	if err != nil {
-		WriteError(w, errors.Wrap(err, "stream failure"))
+		WriteError(ctx, w, errors.Wrap(err, "stream failure"))
 	}
 }
 

--- a/internal/dev_server/sdk/stream_server_flags.go
+++ b/internal/dev_server/sdk/stream_server_flags.go
@@ -16,11 +16,13 @@ func StreamServerAllPayload(w http.ResponseWriter, r *http.Request) {
 	allFlags, err := GetAllFlagsFromContext(ctx)
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "failed to get flag state"))
+		return
 	}
 	serverFlags := ServerAllPayloadFromFlagsState(allFlags)
 	jsonBody, err := json.Marshal(serverFlags)
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "failed to marshal flag state"))
+		return
 	}
 	updateChan, doneChan := OpenStream(w, r.Context().Done(), Message{"put", jsonBody})
 	defer close(updateChan)
@@ -36,6 +38,7 @@ func StreamServerAllPayload(w http.ResponseWriter, r *http.Request) {
 	err = <-doneChan
 	if err != nil {
 		WriteError(ctx, w, errors.Wrap(err, "stream failure"))
+		return
 	}
 }
 


### PR DESCRIPTION
Improves error handling when an sdk connects and a project is missing.

Previous behavior was a scary panic log. Now there's a more helpful

```
2024/06/28 16:26:02 project, default2, not found
2024/06/28 16:26:02 You may need to call ldcli dev-server add-project
```
