### PR TITLE
chore: Simplify config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,6 @@ type Config struct {
 	Flag            string `json:"flag,omitempty" yaml:"flag,omitempty"`
 	Output          string `json:"output,omitempty" yaml:"output,omitempty"`
 	Project         string `json:"project,omitempty" yaml:"project,omitempty"`
-	filename        string
 }
 
 func New(filename string, readFile ReadFile) (Config, error) {
@@ -36,9 +35,7 @@ func New(filename string, readFile ReadFile) (Config, error) {
 		return Config{}, err
 	}
 
-	c := Config{
-		filename: filename,
-	}
+	var c Config
 	err = yaml.Unmarshal([]byte(data), &c)
 	if err != nil {
 		return Config{}, errors.NewError("config file is invalid yaml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -21,156 +20,10 @@ type mockReadFile struct {
 func (m mockReadFile) readFile(name string) ([]byte, error) {
 	if m.contents != nil {
 		return m.contents, nil
-		// return yaml.Marshal(m.contents)
 	}
 
 	return yaml.Marshal(map[string]interface{}{
 		"access-token": "test-access-token",
-	})
-}
-
-func TestNewConfigFromFile(t *testing.T) {
-	t.Run("with valid input is a valid config", func(t *testing.T) {
-		mock := mockReadFile{}
-
-		c, err := config.NewConfigFromFile("test-config-file", mock.readFile)
-
-		require.NoError(t, err)
-		assert.Equal(t, "test-access-token", c.AccessToken)
-	})
-
-	t.Run("with invalid formatting in the file contents is an error", func(t *testing.T) {
-		mock := mockReadFile{
-			contents: []byte(`invalid`),
-		}
-
-		_, err := config.NewConfigFromFile("test-config-file", mock.readFile)
-
-		assert.EqualError(t, err, "config file is invalid yaml")
-	})
-}
-
-func TestNewConfig(t *testing.T) {
-	t.Run("analytics-opt-out", func(t *testing.T) {
-		tests := map[string]struct {
-			expected bool
-			input    interface{}
-		}{
-			"when value is true": {
-				expected: true,
-				input:    true,
-			},
-			"when value is 1": {
-				expected: true,
-				input:    1,
-			},
-			"when value is false": {
-				expected: false,
-				input:    false,
-			},
-			"when value is 0": {
-				expected: false,
-				input:    0,
-			},
-		}
-		for name, tt := range tests {
-			tt := tt
-			t.Run(fmt.Sprintf("%s is %t", name, tt.expected), func(t *testing.T) {
-				rawConfig := map[string]interface{}{
-					"analytics-opt-out": tt.input,
-				}
-
-				configFile, err := config.NewConfigFile(rawConfig)
-
-				require.NoError(t, err)
-				assert.Equal(t, tt.expected, *configFile.AnalyticsOptOut)
-			})
-		}
-	})
-
-	t.Run("is an error when analytics-opt-out is something else", func(t *testing.T) {
-		rawConfig := map[string]interface{}{
-			"analytics-opt-out": "something",
-		}
-
-		_, err := config.NewConfigFile(rawConfig)
-
-		assert.EqualError(t, err, "analytics-opt-out must be true or false")
-	})
-
-	t.Run("analytics-opt-out", func(t *testing.T) {
-		tests := map[string]struct {
-			input string
-		}{
-			"is valid when value is json": {
-				input: "json",
-			},
-			"is valid when value is plaintext": {
-				input: "json",
-			},
-		}
-		for name, tt := range tests {
-			tt := tt
-			t.Run(name, func(t *testing.T) {
-				rawConfig := map[string]interface{}{
-					"output": tt.input,
-				}
-
-				configFile, err := config.NewConfigFile(rawConfig)
-
-				require.NoError(t, err)
-				assert.Equal(t, tt.input, configFile.Output)
-			})
-		}
-	})
-
-	t.Run("is invalid with an invalid output", func(t *testing.T) {
-		rawConfig := map[string]interface{}{
-			"output": "invalid",
-		}
-
-		_, err := config.NewConfigFile(rawConfig)
-
-		assert.EqualError(t, err, "output is invalid. Use 'json' or 'plaintext'")
-	})
-
-	t.Run("environment", func(t *testing.T) {
-		t.Run("sets the given value", func(t *testing.T) {
-			rawConfig := map[string]interface{}{
-				"environment": "test-key",
-			}
-
-			configFile, err := config.NewConfigFile(rawConfig)
-
-			require.NoError(t, err)
-			assert.Equal(t, "test-key", configFile.Environment)
-		})
-	})
-
-	t.Run("flag", func(t *testing.T) {
-		t.Run("sets the given value", func(t *testing.T) {
-			rawConfig := map[string]interface{}{
-				"flag": "test-key",
-			}
-
-			configFile, err := config.NewConfigFile(rawConfig)
-
-			require.NoError(t, err)
-			assert.Equal(t, "test-key", configFile.Flag)
-		})
-	})
-
-	t.Run("project", func(t *testing.T) {
-		t.Run("sets the given value", func(t *testing.T) {
-			rawConfig := map[string]interface{}{
-				"project": "test-key",
-			}
-
-			configFile, err := config.NewConfigFile(rawConfig)
-
-			require.NoError(t, err)
-			assert.Equal(t, "test-key", configFile.Project)
-		})
 	})
 }
 
@@ -212,10 +65,10 @@ analytics-opt-out: true
 }
 
 func TestUpdate(t *testing.T) {
-	t.Run("updates valid fields", func(t *testing.T) {
-		c, err := config.New("test", mockReadFile{}.readFile)
-		require.NoError(t, err)
+	c, err := config.New("test", mockReadFile{}.readFile)
+	require.NoError(t, err)
 
+	t.Run("updates valid fields", func(t *testing.T) {
 		result, updatedFields, err := c.Update(
 			[]string{
 				"access-token", "test-access-token",
@@ -252,38 +105,44 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("with an invalid output flag", func(t *testing.T) {
-		c, err := config.New("test", mockReadFile{}.readFile)
-		require.NoError(t, err)
-
 		_, _, err = c.Update([]string{"output", "invalid"})
 
 		assert.EqualError(t, err, "output is invalid. Use 'json' or 'plaintext'")
 	})
 
 	t.Run("with an invalid analytics-opt-out flag", func(t *testing.T) {
-		c, err := config.New("test", mockReadFile{}.readFile)
-		require.NoError(t, err)
-
 		_, _, err = c.Update([]string{"analytics-opt-out", "invalid"})
 
 		assert.EqualError(t, err, "analytics-opt-out must be true or false")
 	})
 
 	t.Run("with an invalid amount of flags", func(t *testing.T) {
-		c, err := config.New("test", mockReadFile{}.readFile)
-		require.NoError(t, err)
-
 		_, _, err = c.Update([]string{"access-token"})
 
 		assert.EqualError(t, err, "flag needs an argument: --set")
 	})
 
 	t.Run("with an invalid flag", func(t *testing.T) {
-		c, err := config.New("test", mockReadFile{}.readFile)
-		require.NoError(t, err)
-
 		_, _, err = c.Update([]string{"invalid-flag", "val"})
 
 		assert.EqualError(t, err, "invalid-flag is not a valid configuration option")
+	})
+}
+
+func TestRemove(t *testing.T) {
+	c, err := config.New("test", mockReadFile{}.readFile)
+	require.NoError(t, err)
+
+	t.Run("with a valid flag is a no-op", func(t *testing.T) {
+		c, err = c.Remove("access-token")
+
+		require.NoError(t, err)
+		assert.Equal(t, "test-access-token", c.AccessToken)
+	})
+
+	t.Run("with an invalid flag is an error", func(t *testing.T) {
+		c, err = c.Remove("invalid")
+
+		assert.EqualError(t, err, "invalid is not a valid configuration option")
 	})
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -6,7 +6,7 @@ import (
 	"github.com/launchdarkly/ldcli/internal/errors"
 )
 
-var ErrInvalidOutputKind = errors.NewError("output is invalid, use 'json' or 'plaintext'")
+var ErrInvalidOutputKind = errors.NewError("output is invalid. Use 'json' or 'plaintext'")
 
 type OutputKind string
 


### PR DESCRIPTION
Consolidate config actions to use the same underlying struct type and methods. This should simplify how values are set and unset by removing a layer of unmarshaling.
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
