### PR TITLE
fix: use sync map for observers

### DIFF
--- a/internal/dev_server/api/api.yaml
+++ b/internal/dev_server/api/api.yaml
@@ -96,25 +96,6 @@ paths:
       responses:
         201:
           $ref: "#/components/responses/Project"
-  # WIP updates can be added later
-  #    patch:
-  #      summary: change configuration of the project
-  #      parameters:
-  #        - $ref: '#/components/parameters/projectKey'
-  #      responses:
-
-  # WIP NOT SURE IF NEEDED TBH
-  #  /dev/projects/{projectKey}/overrides:
-  #    get:
-  #      summary: return all the flag overrides for the project
-  #      parameters:
-  #        - $ref: '#/components/parameters/projectKey'
-  #      responses: // WIP
-  #    delete:
-  #      summary: clear all overrides for the project
-  #      parameters:
-  #        - $ref: '#/components/parameters/projectKey'
-  #      responses: // WIP
   /dev/projects/{projectKey}/overrides/{flagKey}:
     put:
       summary: override flag value with value provided in the body

--- a/internal/dev_server/model/observer.go
+++ b/internal/dev_server/model/observer.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"log"
+	"sync"
 
 	"github.com/google/uuid"
 )
@@ -13,36 +14,32 @@ type Observer interface {
 }
 
 type Observers struct {
-	observers map[uuid.UUID]Observer
+	observers sync.Map
 }
 
 func NewObservers() *Observers {
 	observers := new(Observers)
-	observers.observers = make(map[uuid.UUID]Observer)
+	observers.observers = sync.Map{}
 	return observers
 }
 
 func (o *Observers) DeregisterObserver(observerId uuid.UUID) bool {
-	log.Printf("DeregisterObserver: observer %+v", observerId)
-	for key := range o.observers {
-		if key == observerId {
-			delete(o.observers, key)
-			return true
-		}
-	}
-	return false
+	log.Printf("DeregisterObserver: observerId %+v", observerId)
+	_, exists := o.observers.LoadAndDelete(observerId)
+	return exists
 }
 
 func (o *Observers) RegisterObserver(observer Observer) uuid.UUID {
-	log.Printf("RegisterObserver: observer %+v", observer)
 	id := uuid.New()
-	o.observers[id] = observer
+	log.Printf("RegisterObserver: observer %+v, id %s", observer, id)
+	o.observers.Store(id, observer)
 	return id
 }
 
 func (o *Observers) Notify(event interface{}) {
-	log.Printf("Notify: event %+v to %d observers", event, len(o.observers))
-	for _, observer := range o.observers {
-		observer.Handle(event)
-	}
+	log.Printf("Notify: event %+v to observers", event)
+	o.observers.Range(func(_, observer any) bool {
+		observer.(Observer).Handle(event)
+		return true
+	})
 }

--- a/internal/dev_server/model/observer_test.go
+++ b/internal/dev_server/model/observer_test.go
@@ -1,8 +1,10 @@
 package model
 
 import (
+	"sync"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,5 +35,25 @@ func TestObservers(t *testing.T) {
 		assert.True(t, ok, "observer should be deregistered")
 		observers.Notify("lol")
 	})
-
+	t.Run("deregistering from multiple go routines should not panic", func(t *testing.T) {
+		observers := NewObservers()
+		observer := testObserver{handle: func(i interface{}) {
+			assert.Fail(t, "should not be called")
+		}}
+		ids := make([]uuid.UUID, 100)
+		for i := 0; i < 100; i++ {
+			i := i
+			ids[i] = observers.RegisterObserver(observer)
+		}
+		wg := sync.WaitGroup{}
+		for _, id := range ids {
+			id := id
+			wg.Add(1)
+			go func() {
+				observers.DeregisterObserver(id)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	})
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [?] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

Used a sync map because there's a data race using a non-synchronized one.

