### PR TITLE
chore: Remove analytics for login

### DIFF
--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -10,49 +10,20 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	cmdAnalytics "github.com/launchdarkly/ldcli/cmd/analytics"
 	"github.com/launchdarkly/ldcli/cmd/cliflags"
 	configcmd "github.com/launchdarkly/ldcli/cmd/config"
-	"github.com/launchdarkly/ldcli/internal/analytics"
 	"github.com/launchdarkly/ldcli/internal/config"
 	"github.com/launchdarkly/ldcli/internal/login"
 	"github.com/launchdarkly/ldcli/internal/resources"
 )
 
-func NewLoginCmd(
-	analyticsTrackerFn analytics.TrackerFn,
-	client resources.UnauthenticatedClient,
-) *cobra.Command {
+func NewLoginCmd(client resources.UnauthenticatedClient) *cobra.Command {
 	cmd := cobra.Command{
-		Long: "",
-		PreRun: func(cmd *cobra.Command, args []string) {
-			analyticsTrackerFn(
-				viper.GetString(cliflags.AccessTokenFlag),
-				viper.GetString(cliflags.BaseURIFlag),
-				viper.GetBool(cliflags.AnalyticsOptOut),
-			).SendCommandRunEvent(cmdAnalytics.CmdRunEventProperties(cmd, "login", nil))
-		},
+		Long:  "",
 		RunE:  run(client),
 		Short: "Log in to your LaunchDarkly account to set up the CLI",
 		Use:   "login",
 	}
-
-	helpFun := cmd.HelpFunc()
-	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		analyticsTrackerFn(
-			viper.GetString(cliflags.AccessTokenFlag),
-			viper.GetString(cliflags.BaseURIFlag),
-			viper.GetBool(cliflags.AnalyticsOptOut),
-		).SendCommandRunEvent(cmdAnalytics.CmdRunEventProperties(
-			cmd,
-			"login",
-			map[string]interface{}{
-				"action": "help",
-			},
-		))
-
-		helpFun(cmd, args)
-	})
 
 	return &cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -188,7 +188,7 @@ func NewRootCommand(
 	configCmd := configcmd.NewConfigCmd(configService, analyticsTrackerFn)
 	cmd.AddCommand(configCmd.Cmd())
 	cmd.AddCommand(NewQuickStartCmd(analyticsTrackerFn, clients.EnvironmentsClient, clients.FlagsClient))
-	cmd.AddCommand(logincmd.NewLoginCmd(analyticsTrackerFn, resources.NewClient(version)))
+	cmd.AddCommand(logincmd.NewLoginCmd(resources.NewClient(version)))
 	cmd.AddCommand(resourcecmd.NewResourcesCmd())
 	resourcecmd.AddAllResourceCmds(cmd, clients.ResourcesClient, analyticsTrackerFn)
 

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -106,12 +106,12 @@ func (c *Client) sendEvent(eventName string, properties map[string]interface{}) 
 			c.wg.Done()
 			return
 		}
-		resp.Body.Close()
 
 		_, err = io.ReadAll(resp.Body)
 		if err != nil { //nolint:staticcheck
 			// TODO: log error
 		}
+		resp.Body.Close()
 		c.wg.Done()
 	}()
 }


### PR DESCRIPTION
The login command doesn't have an existing access token, so the normal path for tracking analytics doesn't work. We would have to add an unauthorized endpoint to track analytics or do some manual work to allow both unauthed and authed requests in the same endpoint.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
