### PR TITLE
feat: Allow for the customization of the port when starting dev server

### DIFF
--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -3,6 +3,7 @@ package cliflags
 const (
 	BaseURIDefault      = "https://app.launchdarkly.com"
 	DevStreamURIDefault = "https://stream.launchdarkly.com"
+	PortDefault         = "8765"
 
 	AccessTokenFlag  = "access-token"
 	AnalyticsOptOut  = "analytics-opt-out"
@@ -13,6 +14,7 @@ const (
 	EnvironmentFlag  = "environment"
 	FlagFlag         = "flag"
 	OutputFlag       = "output"
+	PortFlag         = "port"
 	ProjectFlag      = "project"
 	RoleFlag         = "role"
 
@@ -23,6 +25,7 @@ const (
 	EnvironmentFlagDescription = "Default environment key"
 	FlagFlagDescription        = "Default feature flag key"
 	OutputFlagDescription      = "Command response output format in either JSON or plain text"
+	PortFlagDescription        = "Port for the dev server to run on"
 	ProjectFlagDescription     = "Default project key"
 )
 
@@ -36,5 +39,6 @@ func AllFlagsHelp() map[string]string {
 		FlagFlag:         FlagFlagDescription,
 		OutputFlag:       OutputFlagDescription,
 		ProjectFlag:      ProjectFlagDescription,
+		PortFlag:         PortFlagDescription,
 	}
 }

--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -38,7 +38,7 @@ func AllFlagsHelp() map[string]string {
 		EnvironmentFlag:  EnvironmentFlagDescription,
 		FlagFlag:         FlagFlagDescription,
 		OutputFlag:       OutputFlagDescription,
-		ProjectFlag:      ProjectFlagDescription,
 		PortFlag:         PortFlagDescription,
+		ProjectFlag:      ProjectFlagDescription,
 	}
 }

--- a/cmd/dev_server/dev_server.go
+++ b/cmd/dev_server/dev_server.go
@@ -24,6 +24,14 @@ func NewDevServerCmd(client resources.Client, ldClient dev_server.Client) *cobra
 	)
 	_ = viper.BindPFlag(cliflags.DevStreamURIFlag, cmd.PersistentFlags().Lookup(cliflags.DevStreamURIFlag))
 
+	cmd.PersistentFlags().String(
+		cliflags.PortFlag,
+		cliflags.PortDefault,
+		cliflags.PortFlagDescription,
+	)
+
+	_ = viper.BindPFlag(cliflags.PortFlag, cmd.PersistentFlags().Lookup(cliflags.PortFlag))
+
 	// Add subcommands here
 	cmd.AddGroup(&cobra.Group{ID: "projects", Title: "Project commands:"})
 	cmd.AddCommand(NewListProjectsCmd(client))

--- a/cmd/dev_server/start_server.go
+++ b/cmd/dev_server/start_server.go
@@ -34,13 +34,14 @@ func NewStartServerCmd(client dev_server.Client) *cobra.Command {
 func startServer(client dev_server.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
+		params := dev_server.ServerParams{
+			AccessToken:  viper.GetString(cliflags.AccessTokenFlag),
+			BaseURI:      viper.GetString(cliflags.BaseURIFlag),
+			DevStreamURI: viper.GetString(cliflags.DevStreamURIFlag),
+			Port:         "0.0.0.0:8765",
+		}
 
-		client.RunServer(
-			ctx,
-			viper.GetString(cliflags.AccessTokenFlag),
-			viper.GetString(cliflags.BaseURIFlag),
-			viper.GetString(cliflags.DevStreamURIFlag),
-		)
+		client.RunServer(ctx, params)
 
 		return nil
 	}

--- a/cmd/dev_server/start_server.go
+++ b/cmd/dev_server/start_server.go
@@ -38,7 +38,7 @@ func startServer(client dev_server.Client) func(*cobra.Command, []string) error 
 			AccessToken:  viper.GetString(cliflags.AccessTokenFlag),
 			BaseURI:      viper.GetString(cliflags.BaseURIFlag),
 			DevStreamURI: viper.GetString(cliflags.DevStreamURIFlag),
-			Port:         "8765",
+			Port:         viper.GetString(cliflags.PortFlag),
 		}
 
 		client.RunServer(ctx, params)

--- a/cmd/dev_server/start_server.go
+++ b/cmd/dev_server/start_server.go
@@ -38,7 +38,7 @@ func startServer(client dev_server.Client) func(*cobra.Command, []string) error 
 			AccessToken:  viper.GetString(cliflags.AccessTokenFlag),
 			BaseURI:      viper.GetString(cliflags.BaseURIFlag),
 			DevStreamURI: viper.GetString(cliflags.DevStreamURIFlag),
-			Port:         "0.0.0.0:8765",
+			Port:         "8765",
 		}
 
 		client.RunServer(ctx, params)

--- a/internal/dev_server/dev_server.go
+++ b/internal/dev_server/dev_server.go
@@ -63,10 +63,12 @@ func (c LDClient) RunServer(ctx context.Context, serverParams ServerParams) {
 	handler := api.HandlerFromMux(apiServer, r)
 	handler = handlers.CombinedLoggingHandler(os.Stdout, handler)
 	handler = handlers.RecoveryHandler(handlers.PrintRecoveryStack(true))(handler)
-	fmt.Printf("Server running on %s", serverParams.Port)
-	fmt.Println("Access the UI for toggling overrides at http://localhost:8765/ui or by running `ldcli dev-server ui`")
+
+	addr := fmt.Sprintf("0.0.0.0:%s", serverParams.Port)
+	fmt.Printf("Server running on %s", addr)
+	fmt.Printf("Access the UI for toggling overrides at http://localhost:%s/ui or by running `ldcli dev-server ui`", serverParams.Port)
 	server := http.Server{
-		Addr:    serverParams.Port,
+		Addr:    addr,
 		Handler: handler,
 	}
 	log.Fatal(server.ListenAndServe())


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

When you run the command you can add a `port` flag to specify something other than `8675` for it to run on. If none is provided, it will use the default we had hardcoded before.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
