### PR TITLE
fix: Create config file if it does not exist

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -290,7 +290,11 @@ func setFlagsFromConfig() error {
 		return err
 	}
 
-	_ = viper.ReadInConfig()
+	err = viper.ReadInConfig()
+	if err != nil {
+		// attempt to write config file if it does not exist
+		_ = viper.SafeWriteConfigAs(configFile)
+	}
 
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,9 @@ type Config struct {
 func New(filename string, readFile ReadFile) (Config, error) {
 	data, err := readFile(filename)
 	if err != nil {
-		return Config{}, err
+		return Config{}, errors.NewError(
+			fmt.Sprintf("unable to open config file. The file or directory may not exist: %s", filename),
+		)
 	}
 
 	var c Config


### PR DESCRIPTION
When running a command, if there isn't a config file then create one. Since most users will not want to specify their access token, etc. for each command, we can assume they will want a config file.

If we can't write the config file, fail silently. Then when running any `config` commands, the error will give more details.

You can test this by deleting or moving the `~/.config/ldcli/config.yml` file and running `ldcli config --list`.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
