### PR TITLE
chore: transfer code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo.
 
-- @launchdarkly/ldcli-app-platform
+- @launchdarkly/team-feature-management


### PR DESCRIPTION
This PR transfers code ownership to [TEAM - Feature Management](https://github.com/orgs/launchdarkly/teams/team-feature-management).
