### PR TITLE
ci: add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/" # Location of go.mod
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

This should cause Dependabot to be enabled (hopefully), keeping Go dependencies up to date on a weekly cadence. 

The reason I'm specifically making this PR now is because the `sdk-meta` dependency should be automatically kept up-to-date.

I'm not sure if we need to Terraform something to get Dependabot actually running or not, but we should find out when/if this is merged. 

**Describe alternatives you've considered**

Manually update dependencies - the purpose of sdk-meta is to be an automatic solution. Needing to manually check for updates and create PRs would significantly increase the toil, especially if updates are frequent. 
