### PR TITLE
fix: Remove stutter from "fetching {sdk name} SDK SDK"

### DIFF
--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -2,8 +2,8 @@ package quickstart
 
 import (
 	"fmt"
-	"github.com/launchdarkly/sdk-meta/api/sdkmeta"
 
+	"github.com/launchdarkly/sdk-meta/api/sdkmeta"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -156,7 +156,7 @@ func (m showSDKInstructionsModel) View() string {
 	}
 
 	if m.instructions == "" || m.environment == nil {
-		return m.spinner.View() + fmt.Sprintf(" Fetching %s SDK instructions...\n", m.displayName) + footerView(m.help.View(m.helpKeys), nil)
+		return m.spinner.View() + fmt.Sprintf(" Fetching %s instructions...\n", m.displayName) + footerView(m.help.View(m.helpKeys), nil)
 	}
 
 	m.help.ShowAll = true

--- a/internal/quickstart/show_sdk_instructions.go
+++ b/internal/quickstart/show_sdk_instructions.go
@@ -3,7 +3,6 @@ package quickstart
 import (
 	"fmt"
 
-	"github.com/launchdarkly/sdk-meta/api/sdkmeta"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -11,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/launchdarkly/sdk-meta/api/sdkmeta"
 
 	"github.com/launchdarkly/ldcli/internal/environments"
 	"github.com/launchdarkly/ldcli/internal/flags"


### PR DESCRIPTION
Since switching to using the sdkmeta library, each SDK name has "SDK" in it. The placeholder for fetching the SDK instructions doesn't need "SDK" in it now.

This is what it looks like after the change:
![Screenshot 2024-08-13 at 2 55 08 PM](https://github.com/user-attachments/assets/a6e9171a-4f73-4944-ab35-0c96b485fa08)

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
