### PR TITLE
fix: Use ubuntu for the base image

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,5 @@
-FROM alpine:3.19.1
+FROM ubuntu:22.04
+# note that we're not using alpine because we need libresolv.
 
 COPY ldcli /ldcli
 


### PR DESCRIPTION
Use ubuntu as the base image. With alpine, because it has none of the standard shared libraries installed, we were running into the following issue.

```
 ldd ldcli
     /lib/ld-linux-aarch64.so.1 (0xffffb7229000)
Error loading shared library libresolv.so.2: No such file or directory (needed by ldcli)
     libpthread.so.0 => /lib/ld-linux-aarch64.so.1 (0xffffb7229000)
     libdl.so.2 => /lib/ld-linux-aarch64.so.1 (0xffffb7229000)
     libc.so.6 => /lib/ld-linux-aarch64.so.1 (0xffffb7229000)
Error relocating ldcli: fcntl64: symbol not found
Error relocating ldcli: __res_search: symbol not found
```

This in turn, caused `ldcli` to not be executable from the image.

By using ubuntu, standard c libraries are pre-installed, so we won't have this issue. 

We probably do want to investigate the build process to see if we can produce an executable without external dependencies, but I think I'll need to work with @hoshsadiq on that.


### Testing

Manually tested by building locally using the dockerfile. The error went away.