### PR TITLE
fix: Add dev server to usage template

### DIFF
--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -15,6 +15,7 @@ Commands:
   {{rpad "config" 29}} View and modify specific configuration values
   {{rpad "completion" 29}} Enable command autocompletion within supported shells
   {{rpad "login" 29}} Log in to your LaunchDarkly account
+  {{rpad "dev-server" 29}} Run a development server to serve flags locally
 
 Common resource commands:
   {{rpad "flags" 29}} List, create, and modify feature flags and their targeting


### PR DESCRIPTION
This adds a note in the usage text about the dev-server command.

example
```
❯ go run . --help
LaunchDarkly CLI to control your feature flags

Usage:
  ldcli [command]

Commands:
  setup                         Create your first feature flag using a step-by-step guide
  config                        View and modify specific configuration values
  completion                    Enable command autocompletion within supported shells
  login                         Log in to your LaunchDarkly account
  dev-server                    Run a development server to serve flags locally

Common resource commands:
  flags                         List, create, and modify feature flags and their targeting
  environments                  List, create, and manage environments
  projects                      List, create, and manage projects
  members                       Invite new members to an account
  segments                      List, create, modify, and delete segments
  ...                           To see more resource commands, run 'ldcli resources'

Flags:
      --access-token string   LaunchDarkly access token with write-level access
      --analytics-opt-out     Opt out of analytics tracking
      --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
  -h, --help                  help for ldcli
  -o, --output string         Command response output format in either JSON or plain text (default "plaintext")
  -v, --version               version for ldcli
```