### PR TITLE
fix: Propagate dev server errors in CLI compatible format

### DIFF
--- a/internal/dev_server/api/error_handlers.go
+++ b/internal/dev_server/api/error_handlers.go
@@ -25,11 +25,15 @@ func (eh errorHandler) HandleError(w http.ResponseWriter, r *http.Request, err e
 }
 
 var RequestErrorHandler = errorHandler{
+	// HACK: This is really just repeating the status code.
+	// It'd be nice to make these be codes that are meaningful to the user.
 	code:       "bad_request",
 	statusCode: http.StatusBadRequest,
 }.HandleError
 
 var ResponseErrorHandler = errorHandler{
+	// HACK: This is really just repeating the status code.
+	// It'd be nice to make these be codes that are meaningful to the user.
 	code:       "internal_server_error",
 	statusCode: http.StatusInternalServerError,
 }.HandleError

--- a/internal/dev_server/api/error_handlers.go
+++ b/internal/dev_server/api/error_handlers.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+type errorHandler struct {
+	code       string
+	statusCode int
+}
+
+func (eh errorHandler) HandleError(w http.ResponseWriter, r *http.Request, err error) {
+	log.Printf("Error while handling request: %+v", err)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(eh.statusCode)
+	err = json.NewEncoder(w).Encode(ErrorResponseJSONResponse{
+		Code:    eh.code,
+		Message: err.Error(),
+	})
+	if err != nil {
+		log.Printf("Error while writing error response: %+v", err)
+	}
+}
+
+var RequestErrorHandler = errorHandler{
+	code:       "bad_request",
+	statusCode: http.StatusBadRequest,
+}.HandleError
+
+var ResponseErrorHandler = errorHandler{
+	code:       "internal_server_error",
+	statusCode: http.StatusInternalServerError,
+}.HandleError

--- a/internal/dev_server/dev_server.go
+++ b/internal/dev_server/dev_server.go
@@ -2,7 +2,6 @@ package dev_server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -51,8 +50,8 @@ func (c LDClient) RunServer(ctx context.Context, serverParams ServerParams) {
 	}
 	ss := api.NewStrictServer()
 	apiServer := api.NewStrictHandlerWithOptions(ss, nil, api.StrictHTTPServerOptions{
-		RequestErrorHandlerFunc:  RequestErrorHandler,
-		ResponseErrorHandlerFunc: ResponseErrorHandler,
+		RequestErrorHandlerFunc:  api.RequestErrorHandler,
+		ResponseErrorHandlerFunc: api.ResponseErrorHandler,
 	})
 	r := mux.NewRouter()
 	r.Use(adapters.Middleware(*ldClient, serverParams.DevStreamURI))
@@ -74,24 +73,6 @@ func (c LDClient) RunServer(ctx context.Context, serverParams ServerParams) {
 		Handler: handler,
 	}
 	log.Fatal(server.ListenAndServe())
-}
-
-// TODO move to api package
-func ResponseErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
-	log.Printf("Error while serving response: %+v", err)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusInternalServerError)
-	err = json.NewEncoder(w).Encode(api.ErrorResponseJSONResponse{
-		Code:    "internal_server_error",
-		Message: err.Error(),
-	})
-	if err != nil {
-		log.Printf("Error while writing error response: %+v", err)
-	}
-}
-func RequestErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
-	log.Printf("Error while reading request: %+v", err)
-	http.Error(w, err.Error(), http.StatusBadRequest)
 }
 
 func getDBPath() string {

--- a/internal/dev_server/dev_server.go
+++ b/internal/dev_server/dev_server.go
@@ -2,6 +2,7 @@ package dev_server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -75,12 +76,21 @@ func (c LDClient) RunServer(ctx context.Context, serverParams ServerParams) {
 	log.Fatal(server.ListenAndServe())
 }
 
+// TODO move to api package
 func ResponseErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
 	log.Printf("Error while serving response: %+v", err)
-	http.Error(w, err.Error(), http.StatusInternalServerError)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	err = json.NewEncoder(w).Encode(api.ErrorResponseJSONResponse{
+		Code:    "internal_server_error",
+		Message: err.Error(),
+	})
+	if err != nil {
+		log.Printf("Error while writing error response: %+v", err)
+	}
 }
 func RequestErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
-	log.Printf("Error while serving request: %+v", err)
+	log.Printf("Error while reading request: %+v", err)
 	http.Error(w, err.Error(), http.StatusBadRequest)
 }
 


### PR DESCRIPTION
This makes it so that errors from the dev server are propagated back to the CLI in a way that the CLI can reasonably render. This way, we can return something that gives the user an idea of what went wrong vs. a generic "unexpected error" message.

example
```
❯ ldcli dev-server add-project --project jimbo-jones --source staging
unable to get SDK key from LD API: 404 Not Found (code: internal_server_error)
```
