### PR TITLE
fix: LaunchDevly: Search clear not clearing filter

### DIFF
--- a/internal/dev_server/ui/src/EnvironmentSelector.tsx
+++ b/internal/dev_server/ui/src/EnvironmentSelector.tsx
@@ -62,6 +62,8 @@ export function EnvironmentSelector({
     return <span>Loading environments...</span>;
   }
 
+  console.log(searchQuery);
+
   return (
     <Stack gap="3">
       <Box display="flex" justifyContent="space-between" alignItems="center">
@@ -77,8 +79,12 @@ export function EnvironmentSelector({
           <Input
             id="environmentSearch"
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={(e) => {
+              console.log(e.target.value);
+              setSearchQuery(e.target.value || '');
+            }}
             placeholder="Search environments..."
+            aria-label="Search environments"
           />
         </div>
         <span

--- a/internal/dev_server/ui/src/EnvironmentSelector.tsx
+++ b/internal/dev_server/ui/src/EnvironmentSelector.tsx
@@ -62,8 +62,6 @@ export function EnvironmentSelector({
     return <span>Loading environments...</span>;
   }
 
-  console.log(searchQuery);
-
   return (
     <Stack gap="3">
       <Box display="flex" justifyContent="space-between" alignItems="center">
@@ -79,10 +77,7 @@ export function EnvironmentSelector({
           <Input
             id="environmentSearch"
             value={searchQuery}
-            onChange={(e) => {
-              console.log(e.target.value);
-              setSearchQuery(e.target.value || '');
-            }}
+            onChange={(e) => setSearchQuery(e.target.value || '')}
             placeholder="Search environments..."
             aria-label="Search environments"
           />

--- a/internal/dev_server/ui/src/Flags.tsx
+++ b/internal/dev_server/ui/src/Flags.tsx
@@ -222,7 +222,7 @@ function Flags({
       </Box>
       <Stack gap="4">
         <Inline gap="4">
-          <SearchField>
+          <SearchField aria-label="Search flags">
             <Group>
               <Icon name="search" size="small" />
               <Input
@@ -231,12 +231,14 @@ function Flags({
                   setSearchTerm(e.target.value);
                   setCurrentPage(0); // Reset pagination
                 }}
+                aria-label="Search flags input"
               />
               <IconButton
                 aria-label="clear"
                 icon="cancel-circle-outline"
                 size="small"
                 variant="minimal"
+                onPress={() => setSearchTerm('')}
               />
             </Group>
           </SearchField>


### PR DESCRIPTION
Previously, the search bar didn't clear when the clear button was clicked.  
