### PR TITLE
fix: LaunchDevly: Pagination for 'Only show flags with overrides'

### DIFF
--- a/internal/dev_server/ui/src/Flags.tsx
+++ b/internal/dev_server/ui/src/Flags.tsx
@@ -53,12 +53,24 @@ function Flags({
   const filteredFlags = useMemo(() => {
     if (!flags) return [];
     const flagEntries = Object.entries(flags);
-    const search = searchTerm.toLowerCase();
-    const filtered = fuzzysort
-      .go(search, flagEntries, { all: true, key: '0', threshold: 0.7 })
-      .map((result) => result.obj);
-    return filtered;
-  }, [flags, searchTerm]);
+    return flagEntries
+      .filter((entry) => {
+        if (!searchTerm) return true;
+        const [flagKey] = entry;
+        const result = fuzzysort.single(searchTerm.toLowerCase(), flagKey);
+        return result && result.score > -5000; // Adjust threshold as needed
+      })
+      .filter((entry) => {
+        const [flagKey] = entry;
+        const hasOverride = flagKey in overrides;
+
+        if (onlyShowOverrides && !hasOverride) {
+          return false;
+        }
+
+        return true;
+      });
+  }, [flags, searchTerm, onlyShowOverrides]);
 
   const paginatedFlags = useMemo(() => {
     const startIndex = currentPage * flagsPerPage; // Adjust startIndex calculation
@@ -231,6 +243,7 @@ function Flags({
                   setSearchTerm(e.target.value);
                   setCurrentPage(0); // Reset pagination
                 }}
+                value={searchTerm}
               />
               <IconButton
                 aria-label="clear"
@@ -246,10 +259,6 @@ function Flags({
             const overrideValue = overrides[flagKey]?.value;
             const hasOverride = flagKey in overrides;
             const currentValue = hasOverride ? overrideValue : flagValue;
-
-            if (onlyShowOverrides && !hasOverride) {
-              return null;
-            }
 
             return (
               <li


### PR DESCRIPTION
Fixes the interaction with pagination when toggling the "only" toggle.  Puts the filter ahead of the display logic so that our pagination doesn't get confused why the render is leaving flags out.  

This works as expected now. 