### PR TITLE
chore: Set default flag pagination size to 100

### DIFF
--- a/internal/dev_server/adapters/api.go
+++ b/internal/dev_server/adapters/api.go
@@ -65,7 +65,7 @@ func (a apiClientApi) GetProjectEnvironments(ctx context.Context, projectKey str
 
 func (a apiClientApi) getFlags(ctx context.Context, projectKey string, href *string) ([]ldapi.FeatureFlag, error) {
 	return getPaginatedItems(ctx, projectKey, href, func(ctx context.Context, projectKey string, limit, offset *int64) (*ldapi.FeatureFlags, error) {
-		query := a.apiClient.FeatureFlagsApi.GetFeatureFlags(ctx, projectKey)
+		query := a.apiClient.FeatureFlagsApi.GetFeatureFlags(ctx, projectKey).Limit(100)
 
 		if limit != nil {
 			query = query.Limit(*limit)


### PR DESCRIPTION
Previously we were doing `numFlags / 20` requests  to fetch all flags.  This was pretty slow.  A page size of 100 is much more performant.  (For our env, query time went from roughly 12 seconds to like 4, meaning a lot of the overhead was network related, which we just cut by a factor of 5.)