### PR TITLE
feat: Add command to launchDevly to update the project environment and context

### DIFF
--- a/cmd/dev_server/dev_server.go
+++ b/cmd/dev_server/dev_server.go
@@ -58,6 +58,7 @@ func NewDevServerCmd(client resources.Client, analyticsTrackerFn analytics.Track
 	cmd.AddCommand(NewSyncProjectCmd(client))
 	cmd.AddCommand(NewRemoveProjectCmd(client))
 	cmd.AddCommand(NewAddProjectCmd(client))
+	cmd.AddCommand(NewUpdateProjectCmd(client))
 
 	cmd.AddGroup(&cobra.Group{ID: "overrides", Title: "Override commands:"})
 	cmd.AddCommand(NewAddOverrideCmd(client))

--- a/cmd/dev_server/flags.go
+++ b/cmd/dev_server/flags.go
@@ -1,0 +1,6 @@
+package dev_server
+
+const (
+	ContextFlag           = "context"
+	SourceEnvironmentFlag = "source"
+)


### PR DESCRIPTION
```
update the specified project and its flag configuration with the LaunchDarkly Service

Usage:
  ldcli dev-server update-project [flags]

Required flags:
      --project string   The project key

Optional flags:
      --context string   Stringified JSON representation of your context object ex. {"user": { "email": "test@gmail.com", "username": "foo", "key": "bar"}}
      --source string    environment to copy flag values from

Global flags:
  -h, --help                  Get help about any command
      --access-token string     LaunchDarkly access token with write-level access
      --analytics-opt-out       Opt out of analytics tracking
      --base-uri string         LaunchDarkly base URI (default "https://app.launchdarkly.com")
      --dev-stream-uri string   Streaming service endpoint that the dev server uses to obtain authoritative flag data. This may be a LaunchDarkly or Relay Proxy endpoint (default "https://stream.launchdarkly.com")
  -o, --output string           Command response output format in either JSON or plain text (default "plaintext")
      --port string             Port for the dev server to run on (default "8765")
```

```
$ go run . dev-server update-project --context '{"kind": "user", "key": "dev-environment"}' --source staging                

Context updated successfully to:
{
  "key": "dev-environment",
  "kind": "user"
}
Source environment updated successfully to 'staging'
```
