### PR TITLE
fix: Context updating, environment rate limiting, toggle styling

### DIFF
--- a/cmd/dev_server/dev_server.go
+++ b/cmd/dev_server/dev_server.go
@@ -7,10 +7,9 @@ import (
 	"github.com/spf13/viper"
 
 	cmdAnalytics "github.com/launchdarkly/ldcli/cmd/analytics"
-	"github.com/launchdarkly/ldcli/internal/analytics"
-
 	"github.com/launchdarkly/ldcli/cmd/cliflags"
 	resourcecmd "github.com/launchdarkly/ldcli/cmd/resources"
+	"github.com/launchdarkly/ldcli/internal/analytics"
 	"github.com/launchdarkly/ldcli/internal/dev_server"
 	"github.com/launchdarkly/ldcli/internal/resources"
 )

--- a/internal/dev_server/adapters/mocks/api.go
+++ b/internal/dev_server/adapters/mocks/api.go
@@ -56,18 +56,18 @@ func (mr *MockApiMockRecorder) GetAllFlags(arg0, arg1 any) *gomock.Call {
 }
 
 // GetProjectEnvironments mocks base method.
-func (m *MockApi) GetProjectEnvironments(arg0 context.Context, arg1 string) ([]ldapi.Environment, error) {
+func (m *MockApi) GetProjectEnvironments(arg0 context.Context, arg1, arg2 string) ([]ldapi.Environment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjectEnvironments", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetProjectEnvironments", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]ldapi.Environment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProjectEnvironments indicates an expected call of GetProjectEnvironments.
-func (mr *MockApiMockRecorder) GetProjectEnvironments(arg0, arg1 any) *gomock.Call {
+func (mr *MockApiMockRecorder) GetProjectEnvironments(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectEnvironments", reflect.TypeOf((*MockApi)(nil).GetProjectEnvironments), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectEnvironments", reflect.TypeOf((*MockApi)(nil).GetProjectEnvironments), arg0, arg1, arg2)
 }
 
 // GetSdkKey mocks base method.

--- a/internal/dev_server/adapters/mocks/api.go
+++ b/internal/dev_server/adapters/mocks/api.go
@@ -56,18 +56,18 @@ func (mr *MockApiMockRecorder) GetAllFlags(arg0, arg1 any) *gomock.Call {
 }
 
 // GetProjectEnvironments mocks base method.
-func (m *MockApi) GetProjectEnvironments(arg0 context.Context, arg1, arg2 string) ([]ldapi.Environment, error) {
+func (m *MockApi) GetProjectEnvironments(arg0 context.Context, arg1, arg2 string, arg3 *int) ([]ldapi.Environment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjectEnvironments", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetProjectEnvironments", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]ldapi.Environment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProjectEnvironments indicates an expected call of GetProjectEnvironments.
-func (mr *MockApiMockRecorder) GetProjectEnvironments(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockApiMockRecorder) GetProjectEnvironments(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectEnvironments", reflect.TypeOf((*MockApi)(nil).GetProjectEnvironments), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectEnvironments", reflect.TypeOf((*MockApi)(nil).GetProjectEnvironments), arg0, arg1, arg2, arg3)
 }
 
 // GetSdkKey mocks base method.

--- a/internal/dev_server/api/api.yaml
+++ b/internal/dev_server/api/api.yaml
@@ -137,6 +137,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: limit
+          in: query
+          description: limit the number of environments returned
+          required: false
+          schema:
+              type: integer
       responses:
         200:
           description: OK. List of environments

--- a/internal/dev_server/api/api.yaml
+++ b/internal/dev_server/api/api.yaml
@@ -131,6 +131,12 @@ paths:
       summary: list all environments for the given project
       parameters:
         - $ref: "#/components/parameters/projectKey"
+        - name: name
+          in: query
+          description: filter by environment name
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: OK. List of environments

--- a/internal/dev_server/api/get_environments.go
+++ b/internal/dev_server/api/get_environments.go
@@ -16,7 +16,12 @@ func (s server) GetEnvironments(ctx context.Context, request GetEnvironmentsRequ
 		return GetEnvironments404JSONResponse{}, nil
 	}
 
-	environments, err := model.GetEnvironmentsForProject(ctx, project.Key)
+	var query string
+	if request.Params.Name != nil {
+		query = *request.Params.Name
+	}
+
+	environments, err := model.GetEnvironmentsForProject(ctx, project.Key, query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dev_server/api/get_environments.go
+++ b/internal/dev_server/api/get_environments.go
@@ -21,7 +21,7 @@ func (s server) GetEnvironments(ctx context.Context, request GetEnvironmentsRequ
 		query = *request.Params.Name
 	}
 
-	environments, err := model.GetEnvironmentsForProject(ctx, project.Key, query)
+	environments, err := model.GetEnvironmentsForProject(ctx, project.Key, query, request.Params.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dev_server/api/server.gen.go
+++ b/internal/dev_server/api/server.gen.go
@@ -154,6 +154,9 @@ type PostAddProjectParamsExpand string
 type GetEnvironmentsParams struct {
 	// Name filter by environment name
 	Name *string `form:"name,omitempty" json:"name,omitempty"`
+
+	// Limit limit the number of environments returned
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
 // PatchProjectJSONRequestBody defines body for PatchProject for application/json ContentType.
@@ -377,6 +380,14 @@ func (siw *ServerInterfaceWrapper) GetEnvironments(w http.ResponseWriter, r *htt
 	err = runtime.BindQueryParameter("form", true, false, "name", r.URL.Query(), &params.Name)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "limit", r.URL.Query(), &params.Limit)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
 		return
 	}
 

--- a/internal/dev_server/model/environments.go
+++ b/internal/dev_server/model/environments.go
@@ -11,9 +11,9 @@ type Environment struct {
 	Name string
 }
 
-func GetEnvironmentsForProject(ctx context.Context, projectKey string) ([]Environment, error) {
+func GetEnvironmentsForProject(ctx context.Context, projectKey string, query string) ([]Environment, error) {
 	apiAdapter := adapters.GetApi(ctx)
-	environments, err := apiAdapter.GetProjectEnvironments(ctx, projectKey)
+	environments, err := apiAdapter.GetProjectEnvironments(ctx, projectKey, query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dev_server/model/environments.go
+++ b/internal/dev_server/model/environments.go
@@ -11,9 +11,9 @@ type Environment struct {
 	Name string
 }
 
-func GetEnvironmentsForProject(ctx context.Context, projectKey string, query string) ([]Environment, error) {
+func GetEnvironmentsForProject(ctx context.Context, projectKey string, query string, limit *int) ([]Environment, error) {
 	apiAdapter := adapters.GetApi(ctx)
-	environments, err := apiAdapter.GetProjectEnvironments(ctx, projectKey, query)
+	environments, err := apiAdapter.GetProjectEnvironments(ctx, projectKey, query, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dev_server/model/project_test.go
+++ b/internal/dev_server/model/project_test.go
@@ -5,6 +5,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
 	ldapi "github.com/launchdarkly/api-client-go/v14"
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
@@ -12,10 +17,6 @@ import (
 	adapters_mocks "github.com/launchdarkly/ldcli/internal/dev_server/adapters/mocks"
 	"github.com/launchdarkly/ldcli/internal/dev_server/model"
 	"github.com/launchdarkly/ldcli/internal/dev_server/model/mocks"
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 )
 
 func TestCreateProject(t *testing.T) {

--- a/internal/dev_server/sdk/go_sdk_test.go
+++ b/internal/dev_server/sdk/go_sdk_test.go
@@ -9,6 +9,10 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	ldclient "github.com/launchdarkly/go-server-sdk/v7"
@@ -17,9 +21,6 @@ import (
 	"github.com/launchdarkly/ldcli/internal/dev_server/adapters/mocks"
 	"github.com/launchdarkly/ldcli/internal/dev_server/db"
 	"github.com/launchdarkly/ldcli/internal/dev_server/model"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 )
 
 // TestSdkRoutesViaGoSDK is an integration test. It hooks up a real go SDK to our SDK routes and makes changes to the

--- a/internal/dev_server/ui/src/EnvironmentSelector.tsx
+++ b/internal/dev_server/ui/src/EnvironmentSelector.tsx
@@ -25,9 +25,7 @@ export function EnvironmentSelector({
   setSelectedEnvironment,
 }: Props) {
   const [environments, setEnvironments] = useState<Environment[] | null>(null);
-  const [filteredEnvironments, setFilteredEnvironments] = useState<
-    Environment[] | null
-  >([]);
+
   const [searchQuery, setSearchQuery] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
@@ -37,7 +35,6 @@ export function EnvironmentSelector({
       fetchEnvironments(projectKey, query)
         .then((envs) => {
           setEnvironments(envs);
-          setFilteredEnvironments(envs);
           if (!selectedEnvironment) {
             const sourceEnv = envs.find(
               (env) => env.key === sourceEnvironmentKey,
@@ -67,15 +64,6 @@ export function EnvironmentSelector({
   useEffect(() => {
     fetchEnvironmentsDebounced(searchQuery);
   }, [fetchEnvironmentsDebounced, searchQuery]);
-
-  useEffect(() => {
-    const filtered = environments?.filter(
-      (env) =>
-        env.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        env.key.toLowerCase().includes(searchQuery.toLowerCase()),
-    );
-    setFilteredEnvironments(filtered || []);
-  }, [searchQuery, environments]);
 
   return (
     <Stack gap="3">
@@ -143,7 +131,7 @@ export function EnvironmentSelector({
             }
           }}
         >
-          {filteredEnvironments?.map((env) => (
+          {environments?.map((env) => (
             <ListBoxItem key={env.key} id={env.key}>
               {env.name}
             </ListBoxItem>

--- a/internal/dev_server/ui/src/Flag.tsx
+++ b/internal/dev_server/ui/src/Flag.tsx
@@ -14,7 +14,6 @@ import {
   Popover,
   Select,
   SelectValue,
-  Switch,
   Text,
   TextArea,
   TextField,
@@ -27,6 +26,8 @@ import { LDFlagValue } from 'launchdarkly-js-client-sdk';
 import { FlagVariation } from './api.ts';
 import { Box, Inline } from '@launchpad-ui/core';
 import { isEqual } from 'lodash';
+import { Switch } from 'react-aria-components';
+import './Switch.css';
 
 type VariationValuesProps = {
   availableVariations: FlagVariation[];
@@ -35,6 +36,7 @@ type VariationValuesProps = {
   flagKey: string;
   updateOverride: (flagKey: string, overrideValue: LDFlagValue) => void;
 };
+
 const VariationValues = ({
   availableVariations,
   currentValue,
@@ -45,12 +47,18 @@ const VariationValues = ({
   switch (typeof flagValue) {
     case 'boolean':
       return (
-        <Switch
-          isSelected={currentValue}
-          onChange={(newValue) => {
-            updateOverride(flagKey, newValue);
-          }}
-        />
+        <div className="animated-switch-container">
+          <Switch
+            className="animated-switch"
+            isSelected={currentValue}
+            onChange={(newValue) => {
+              updateOverride(flagKey, newValue);
+            }}
+          >
+            <span className="switch-text switch-text-false">False</span>
+            <span className="switch-text switch-text-true">True</span>
+          </Switch>
+        </div>
       );
     default:
       let variations = availableVariations;

--- a/internal/dev_server/ui/src/ProjectEditor.tsx
+++ b/internal/dev_server/ui/src/ProjectEditor.tsx
@@ -62,18 +62,23 @@ export function ProjectEditor({
     }
   };
 
+  const handleClose = () => {
+    setTempSelectedEnvironment(selectedEnvironment);
+    setTempContext(context);
+  };
+
   return (
     <DialogTrigger>
       <TooltipTrigger>
         <ProjectEditButton
           isSubmitting={isSubmitting}
-          selectedEnvironment={selectedEnvironment}
+          selectedEnvironment={sourceEnvironmentKey}
         />
         <Tooltip>
           <span>Current environment. Click to update.</span>
         </Tooltip>
       </TooltipTrigger>
-      <ModalOverlay>
+      <ModalOverlay isDismissable={false}>
         <Modal>
           <Dialog>
             {({ close }) => (
@@ -115,7 +120,10 @@ export function ProjectEditor({
                 </Stack>
                 <ButtonGroup style={{ justifyContent: 'flex-end' }}>
                   <Button
-                    onPress={close}
+                    onPress={() => {
+                      handleClose();
+                      close();
+                    }}
                     variant="destructive"
                     isDisabled={isSubmitting}
                   >

--- a/internal/dev_server/ui/src/SubmitButton.tsx
+++ b/internal/dev_server/ui/src/SubmitButton.tsx
@@ -1,11 +1,10 @@
 import { Button, ProgressBar } from '@launchpad-ui/components';
 import { Box, Inline } from '@launchpad-ui/core';
 import { Icon } from '@launchpad-ui/icons';
-import { Environment } from './types';
 
 type Props = {
   isSubmitting: boolean;
-  selectedEnvironment?: Environment | null;
+  selectedEnvironment: string | null;
 };
 
 export function ProjectEditButton({
@@ -28,7 +27,7 @@ export function ProjectEditButton({
       ) : selectedEnvironment ? (
         <Inline gap="2">
           <Icon name="bullseye-arrow" size="medium" />
-          <span>{selectedEnvironment.name}</span>
+          <span>{selectedEnvironment}</span>
         </Inline>
       ) : (
         'Environment'

--- a/internal/dev_server/ui/src/Switch.css
+++ b/internal/dev_server/ui/src/Switch.css
@@ -1,0 +1,77 @@
+
+.animated-switch-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  .animated-switch {
+    --switch-width: 60px;
+    --switch-height: calc(var(--switch-width) * 0.4);
+    --switch-thumb-size: calc(var(--switch-height) * 0.8);
+  
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    width: var(--switch-width);
+    height: var(--switch-height);
+    border-radius: calc(var(--switch-height) / 1.5);
+    padding: 2px;
+    background-color: #ccc;
+    transition: background-color 0.1s ease-out;
+    cursor: pointer;
+    overflow: hidden;
+  }
+  
+  .animated-switch[data-selected] {
+    background-color: #4CAF50;
+  }
+  
+  .animated-switch::before {
+    content: "";
+    position: absolute;
+    left: 4px;
+    width: var(--switch-thumb-size);
+    height: var(--switch-thumb-size);
+    border-radius: 50%;
+    background-color: white;
+    transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.3);
+    z-index: 2;
+  }
+  
+  .animated-switch[data-selected]::before {
+    transform: translateX(calc(var(--switch-width) - var(--switch-height)));
+  }
+  
+  .switch-text {
+    font-size: 10px;
+    font-weight: bold;
+    position: absolute;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+    transition: opacity 0.3s ease-out;
+    z-index: 1;
+    user-select: none;
+  }
+  
+  .switch-text-false {
+    right: 10px;
+    color: #333;
+  }
+  
+  .switch-text-true {
+    left: 10px;
+    color: white;
+  }
+  
+  .animated-switch[data-selected] .switch-text-false,
+  .animated-switch:not([data-selected]) .switch-text-true {
+    opacity: 0;
+  }
+  
+  .animated-switch[data-selected] .switch-text-true,
+  .animated-switch:not([data-selected]) .switch-text-false {
+    opacity: 1;
+  }

--- a/internal/dev_server/ui/src/api.ts
+++ b/internal/dev_server/ui/src/api.ts
@@ -22,8 +22,8 @@ export type FlagsApiResponse = {
 import { apiRoute } from './util';
 import { Environment } from './types';
 
-export async function fetchEnvironments(projectKey: string): Promise<Environment[]> {
-  const res = await fetch(apiRoute(`/dev/projects/${projectKey}/environments`));
+export async function fetchEnvironments(projectKey: string, query?: string): Promise<Environment[]> {
+  const res = await fetch(apiRoute(`/dev/projects/${projectKey}/environments?limit=20${query ? `&name=${query}` : ''}`));
   if (!res.ok) {
     throw new Error(`Got ${res.status}, ${res.statusText} from environments fetch`);
   }


### PR DESCRIPTION
We now query environments by name, instead of all X at once up front.  

![image](https://github.com/user-attachments/assets/d7827a2b-cb91-4c19-b9bf-cd14a99c6b5c)

![image](https://github.com/user-attachments/assets/c5181ee3-ac2e-4797-9f76-5896f9f54b5d)

![image](https://github.com/user-attachments/assets/fa3cc6b0-83b5-4799-9be4-2b46ad152bd1)

![image](https://github.com/user-attachments/assets/6972a82e-a73b-48a0-a4c1-aadb0fa4a079)
