### PR TITLE
Support polling API

### DIFF
--- a/internal/dev_server/sdk/polling.go
+++ b/internal/dev_server/sdk/polling.go
@@ -1,0 +1,24 @@
+package sdk
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+func LatestAll(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	allFlags, err := GetAllFlagsFromContext(ctx)
+	if err != nil {
+		WriteError(ctx, w, errors.Wrap(err, "failed to get flag state"))
+		return
+	}
+	serverFlags := ServerAllPayloadFromFlagsState(allFlags)
+	enc := json.NewEncoder(w)
+	err = enc.Encode(serverFlags.Data)
+	if err != nil {
+		WriteError(ctx, w, errors.Wrap(err, "failed to encode response"))
+		return
+	}
+}

--- a/internal/dev_server/sdk/routes.go
+++ b/internal/dev_server/sdk/routes.go
@@ -20,6 +20,7 @@ func BindRoutes(router *mux.Router) {
 	router.HandleFunc("/mobile/events/diagnostic", DevNull)
 
 	router.Handle("/all", GetProjectKeyFromAuthorizationHeader(http.HandlerFunc(StreamServerAllPayload)))
+	router.Handle("/sdk/latest-all", GetProjectKeyFromAuthorizationHeader(http.HandlerFunc(LatestAll)))
 
 	router.PathPrefix("/sdk/flags").
 		Methods(http.MethodGet).


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

**Describe the solution you've provided**

It provides `/sdk/latest-all` endpoint for polling. I've confirmed that this change works for a modified version of the Haskell SDK.

**Describe alternatives you've considered**

**Additional context**

I know streaming is a more preferred way than polling, but our application uses polling for some stability reason. To test such an application, I want ldcli to support polling.
