### PR TITLE
feat: Skip syncing on start if flag set

### DIFF
--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -17,7 +17,7 @@ const (
 	PortFlag         = "port"
 	ProjectFlag      = "project"
 	RoleFlag         = "role"
-	SyncOnStartFlag  = "should-sync"
+	SyncOnceFlag     = "sync-once"
 
 	AccessTokenFlagDescription = "LaunchDarkly access token with write-level access"
 	AnalyticsOptOutDescription = "Opt out of analytics tracking"
@@ -28,7 +28,7 @@ const (
 	OutputFlagDescription      = "Command response output format in either JSON or plain text"
 	PortFlagDescription        = "Port for the dev server to run on"
 	ProjectFlagDescription     = "Default project key"
-	SyncOnStartFlagDescription = "Sync local flags with Launchdarkly on server startup."
+	SyncOnceFlagDescription    = "Only sync new projects. Existing projects will not be resynced on startup"
 )
 
 func AllFlagsHelp() map[string]string {
@@ -42,5 +42,6 @@ func AllFlagsHelp() map[string]string {
 		OutputFlag:       OutputFlagDescription,
 		PortFlag:         PortFlagDescription,
 		ProjectFlag:      ProjectFlagDescription,
+		SyncOnceFlag:     SyncOnceFlagDescription,
 	}
 }

--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -17,6 +17,7 @@ const (
 	PortFlag         = "port"
 	ProjectFlag      = "project"
 	RoleFlag         = "role"
+	SyncOnStartFlag  = "should-sync"
 
 	AccessTokenFlagDescription = "LaunchDarkly access token with write-level access"
 	AnalyticsOptOutDescription = "Opt out of analytics tracking"
@@ -27,6 +28,7 @@ const (
 	OutputFlagDescription      = "Command response output format in either JSON or plain text"
 	PortFlagDescription        = "Port for the dev server to run on"
 	ProjectFlagDescription     = "Default project key"
+	SyncOnStartFlagDescription = "Sync local flags with Launchdarkly on server startup."
 )
 
 func AllFlagsHelp() map[string]string {

--- a/cmd/config/testdata/help.golden
+++ b/cmd/config/testdata/help.golden
@@ -10,6 +10,7 @@ Supported settings:
 - `output`: Command response output format in either JSON or plain text
 - `port`: Port for the dev server to run on
 - `project`: Default project key
+- `sync-once`: Only sync new projects. Existing projects will not be resynced on startup
 
 Usage:
   ldcli config [flags]

--- a/cmd/dev_server/start_server.go
+++ b/cmd/dev_server/start_server.go
@@ -43,6 +43,9 @@ func NewStartServerCmd(client dev_server.Client) *cobra.Command {
 	cmd.Flags().String(OverrideFlag, "", `Stringified JSON representation of flag overrides ex. {"flagName": true, "stringFlagName": "test" }`)
 	_ = viper.BindPFlag(OverrideFlag, cmd.Flags().Lookup(OverrideFlag))
 
+	cmd.Flags().Bool(cliflags.SyncOnStartFlag, true, cliflags.SyncOnStartFlagDescription)
+	_ = viper.BindPFlag(cliflags.SyncOnStartFlag, cmd.Flags().Lookup(cliflags.SyncOnStartFlag))
+
 	return cmd
 }
 
@@ -55,7 +58,7 @@ func startServer(client dev_server.Client) func(*cobra.Command, []string) error 
 		if viper.IsSet(cliflags.ProjectFlag) && viper.IsSet(SourceEnvironmentFlag) {
 
 			initialSetting = model.InitialProjectSettings{
-				Enabled:    true,
+				Enabled:    viper.GetBool(cliflags.SyncOnStartFlag),
 				ProjectKey: viper.GetString(cliflags.ProjectFlag),
 				EnvKey:     viper.GetString(SourceEnvironmentFlag),
 			}

--- a/cmd/dev_server/start_server.go
+++ b/cmd/dev_server/start_server.go
@@ -43,8 +43,8 @@ func NewStartServerCmd(client dev_server.Client) *cobra.Command {
 	cmd.Flags().String(OverrideFlag, "", `Stringified JSON representation of flag overrides ex. {"flagName": true, "stringFlagName": "test" }`)
 	_ = viper.BindPFlag(OverrideFlag, cmd.Flags().Lookup(OverrideFlag))
 
-	cmd.Flags().Bool(cliflags.SyncOnStartFlag, true, cliflags.SyncOnStartFlagDescription)
-	_ = viper.BindPFlag(cliflags.SyncOnStartFlag, cmd.Flags().Lookup(cliflags.SyncOnStartFlag))
+	cmd.Flags().Bool(cliflags.SyncOnceFlag, false, cliflags.SyncOnceFlagDescription)
+	_ = viper.BindPFlag(cliflags.SyncOnceFlag, cmd.Flags().Lookup(cliflags.SyncOnceFlag))
 
 	return cmd
 }
@@ -58,9 +58,10 @@ func startServer(client dev_server.Client) func(*cobra.Command, []string) error 
 		if viper.IsSet(cliflags.ProjectFlag) && viper.IsSet(SourceEnvironmentFlag) {
 
 			initialSetting = model.InitialProjectSettings{
-				Enabled:    viper.GetBool(cliflags.SyncOnStartFlag),
+				Enabled:    true,
 				ProjectKey: viper.GetString(cliflags.ProjectFlag),
 				EnvKey:     viper.GetString(SourceEnvironmentFlag),
+				SyncOnce:   viper.GetBool(cliflags.SyncOnceFlag),
 			}
 			if viper.IsSet(ContextFlag) {
 				var c ldcontext.Context

--- a/internal/dev_server/model/sync.go
+++ b/internal/dev_server/model/sync.go
@@ -34,6 +34,8 @@ func CreateOrSyncProject(ctx context.Context, settings InitialProjectSettings) e
 			return createError
 		}
 
+		// If set, don't resync and don't apply overrides because whatever you have locally
+		// is already set up with what you want.
 		if settings.SyncOnce {
 			log.Printf("Project [%s] exists, but --sync-once flag is set, skipping refresh", settings.ProjectKey)
 			return nil

--- a/internal/dev_server/model/sync.go
+++ b/internal/dev_server/model/sync.go
@@ -27,8 +27,7 @@ func CreateOrSyncProject(ctx context.Context, settings InitialProjectSettings) e
 	}
 
 	log.Printf("Initial project [%s] with env [%s]", settings.ProjectKey, settings.EnvKey)
-	var project Project
-	project, createError := CreateProject(ctx, settings.ProjectKey, settings.EnvKey, settings.Context)
+	_, createError := CreateProject(ctx, settings.ProjectKey, settings.EnvKey, settings.Context)
 	if createError != nil {
 		if !errors.Is(createError, ErrAlreadyExists) {
 			return createError
@@ -39,7 +38,7 @@ func CreateOrSyncProject(ctx context.Context, settings InitialProjectSettings) e
 		} else {
 			log.Printf("Project [%s] exists, refreshing data", settings.ProjectKey)
 			var updateErr error
-			project, updateErr = UpdateProject(ctx, settings.ProjectKey, settings.Context, &settings.EnvKey)
+			_, updateErr = UpdateProject(ctx, settings.ProjectKey, settings.Context, &settings.EnvKey)
 			if updateErr != nil {
 				return updateErr
 			}
@@ -52,6 +51,6 @@ func CreateOrSyncProject(ctx context.Context, settings InitialProjectSettings) e
 		}
 	}
 
-	log.Printf("Successfully synced Initial project [%s]", project.Key)
+	log.Printf("Successfully synced Initial project [%s]", settings.ProjectKey)
 	return nil
 }

--- a/internal/dev_server/model/sync_test.go
+++ b/internal/dev_server/model/sync_test.go
@@ -170,4 +170,22 @@ func TestInitialSync(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("If SyncOnce is set and the project already exists, return early", func(t *testing.T) {
+		api.EXPECT().GetSdkKey(gomock.Any(), projKey, sourceEnvKey).Return(sdkKey, nil)
+		sdk.EXPECT().GetAllFlagsState(gomock.Any(), gomock.Any(), sdkKey).Return(allFlagsState, nil)
+		api.EXPECT().GetAllFlags(gomock.Any(), projKey).Return(allFlags, nil)
+		store.EXPECT().InsertProject(gomock.Any(), gomock.Any()).Return(model.ErrAlreadyExists)
+
+		input := model.InitialProjectSettings{
+			Enabled:    true,
+			ProjectKey: projKey,
+			EnvKey:     sourceEnvKey,
+			Context:    nil,
+			SyncOnce:   true,
+		}
+		err := model.CreateOrSyncProject(ctx, input)
+
+		assert.NoError(t, err)
+	})
+
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**
https://launchdarkly.atlassian.net/browse/FUN-447

**Describe the solution you've provided**

Added a `should-sync` flag to the server startup command that sets `model.InitialProjectSettings.Enable` which controls whether [this function ](https://github.com/launchdarkly/ldcli/blob/FUN-447-start-n-sync-dont-blow-away-existing-db/internal/dev_server/model/sync.go#L24) no-ops or not.

Using the no-op made sense for the persistent volumes use case, since all the project and env data will already exist locally, but open to being more surgical if so desired.

**Describe alternatives you've considered**

We could skip the `UpdateProject` call specifically in the `CreateOrSyncProject` function, which does the sync bit. Then we'd have to decide if we still want to do the overrides.

**Additional context**

Add any other context about the pull request here.
