### PR TITLE
fix: Handle api_key prefix in auth header

### DIFF
--- a/internal/dev_server/db/backup/sqllite_backup.go
+++ b/internal/dev_server/db/backup/sqllite_backup.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	sqllite "github.com/mattn/go-sqlite3"
-	"github.com/pkg/errors"
 	"io"
 	"log"
 	"os"
 	"sync"
 	"sync/atomic"
+
+	sqllite "github.com/mattn/go-sqlite3"
+	"github.com/pkg/errors"
 )
 
 var c atomic.Int32
@@ -195,7 +196,7 @@ func runBackup(backupDbConn *sqllite.SQLiteConn, srcDbConn *sqllite.SQLiteConn, 
 	}(backup)
 
 	var isDone = false
-	var stepError error = nil
+	var stepError error
 	for !isDone {
 		isDone, stepError = backup.Step(1)
 		if stepError != nil {

--- a/internal/dev_server/db/sqlite.go
+++ b/internal/dev_server/db/sqlite.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	_ "github.com/mattn/go-sqlite3"
-	"github.com/pkg/errors"
 	"io"
 	"os"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/pkg/errors"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"github.com/launchdarkly/ldcli/internal/dev_server/db/backup"
@@ -380,6 +381,9 @@ func (s *Sqlite) RestoreBackup(ctx context.Context, stream io.Reader) (string, e
 
 func (s *Sqlite) CreateBackup(ctx context.Context) (io.ReadCloser, int64, error) {
 	backupPath, err := s.backupManager.MakeBackupFile(ctx)
+	if err != nil {
+		return nil, 0, errors.Wrapf(err, "unable to make backup file, %s", backupPath)
+	}
 	fi, err := os.Open(backupPath)
 	if err != nil {
 		return nil, 0, errors.Wrapf(err, "unable to open backup db at %s", backupPath)

--- a/internal/dev_server/sdk/http_test.go
+++ b/internal/dev_server/sdk/http_test.go
@@ -1,0 +1,62 @@
+package sdk
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/ldcli/internal/dev_server/model"
+	"github.com/launchdarkly/ldcli/internal/dev_server/model/mocks"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+var exampleProjectKey = "my-project"
+var exampleProject = &model.Project{
+	Key:                  exampleProjectKey,
+	SourceEnvironmentKey: "my-environment",
+	Context:              ldcontext.Context{},
+	LastSyncTime:         time.Unix(0, 0),
+	AllFlagsState:        make(model.FlagsState),
+	AvailableVariations:  nil,
+}
+
+func TestMobileAuth(t *testing.T) {
+	mockController := gomock.NewController(t)
+	store := mocks.NewMockStore(mockController)
+	observers := model.NewObservers()
+
+	// Wire up sdk routes in test server
+	router := mux.NewRouter()
+	router.Use(model.ObserversMiddleware(observers))
+	router.Use(model.StoreMiddleware(store))
+	BindRoutes(router)
+
+	t.Run("given project key prefixed with api_key, it should authenticate successfully", func(t *testing.T) {
+		store.EXPECT().GetDevProject(gomock.Any(), exampleProjectKey).Return(exampleProject, nil)
+		store.EXPECT().GetOverridesForProject(gomock.Any(), exampleProjectKey).Return(nil, nil)
+
+		req := httptest.NewRequest("GET", "/msdk/evalx/eyJrZXkiOiJib2FyZCBjYXQifQ==", nil)
+		req.Header.Set("Authorization", fmt.Sprintf("api_key %s", exampleProjectKey))
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("given just the project key, it should authenticate successfully", func(t *testing.T) {
+		store.EXPECT().GetDevProject(gomock.Any(), exampleProjectKey).Return(exampleProject, nil)
+		store.EXPECT().GetOverridesForProject(gomock.Any(), exampleProjectKey).Return(nil, nil)
+
+		req := httptest.NewRequest("GET", "/msdk/evalx/eyJrZXkiOiJib2FyZCBjYXQifQ==", nil)
+		req.Header.Set("Authorization", exampleProjectKey)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+}

--- a/internal/dev_server/sdk/project_key_middleware.go
+++ b/internal/dev_server/sdk/project_key_middleware.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 )
@@ -38,6 +39,7 @@ func GetProjectKeyFromAuthorizationHeader(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		ctx := request.Context()
 		projectKey := request.Header.Get("Authorization")
+		projectKey = strings.TrimPrefix(projectKey, "api_key ") // some sdks set this as a prefix
 		if projectKey == "" {
 			http.Error(writer, "project key not on Authorization header", http.StatusUnauthorized)
 			return


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Closes https://github.com/launchdarkly/ldcli/issues/490

**Describe the solution you've provided**

Supports the `api_key ` prefix on keys used for authentication.
