### PR TITLE
chore: Go Build first

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,10 +20,10 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: stable
+    - name: build
+      run: go build .
 
     - uses: actions/setup-python@v3
     - uses: pre-commit/action@v3.0.1
-    - name: build
-      run: go build .
     - name: test
       run: go test ./...

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -18,11 +18,8 @@ on:
         type: string
 
 jobs:
-  go-versions:
-    uses: ./.github/workflows/go-versions.yml
 
   release-ldcli:
-    needs: go-versions
     permissions:
       id-token: write # Needed to obtain Docker tokens
       contents: write # Needed to upload release artifacts
@@ -84,7 +81,7 @@ jobs:
         actions: read
         id-token: write
         contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
         base64-subjects: "${{ needs.release-ldcli.outputs.hashes }}"
         upload-assets: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,9 +7,6 @@ on:
       - main
 
 jobs:
-  go-versions:
-    uses: ./.github/workflows/go-versions.yml
-
   release-please:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
@@ -26,7 +23,7 @@ jobs:
     permissions:
       id-token: write # Needed to obtain Docker tokens
       contents: write # Needed to upload release artifacts
-    needs: [ release-please, go-versions ]
+    needs: [ release-please ]
     if: always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'pull_request')
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Most builds are failing right now. This is due to a pre-commit timeout when the go module cache is refreshed. This moves the go build to the first step. That makes go build refresh the module cache and makes it so that pre-commit won't need to, avoiding the timeout.