### PR TITLE
chore: Revert "chore: Update dependabot configuration for auto-merge"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,3 @@ updates:
     directory: "/" # Location of go.mod
     schedule:
       interval: "weekly"
-    # Enable auto-merge for Dependabot PRs
-    open-pull-requests-limit: 10
-    pull-request-branch-name:
-      separator: "-"
-    # Auto-merge configuration
-    auto-merge: true
-    # Limit auto-merge to patch and minor updates
-    versioning-strategy: auto
-    # Configure PR settings
-    commit-message:
-      prefix: "deps"
-      include: "scope"


### PR DESCRIPTION
Turns out that dependabot change was invalid and auto-merge isn't a concept.