### PR TITLE
🤞 fix release to dockerhub

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -53,14 +53,13 @@ runs:
             ghcr.io/launchdarkly/goreleaser-cross:v1.24.2  \
               -f /dev/null
         )"
+        docker exec --workdir "$PWD" --tty "$CONTAINER_ID" docker login --username "$DOCKER_HUB_USERNAME" --password "$DOCKER_HUB_TOKEN"
         echo "CONTAINER_ID=$CONTAINER_ID" >> "$GITHUB_ENV"
     - name: Run Goreleaser
       shell: bash
       run: docker exec
         --env GITHUB_TOKEN
         --env HOMEBREW_DEPLOY_KEY
-        --env DOCKER_USERNAME=${{ env.DOCKER_HUB_USERNAME }}
-        --env DOCKER_PASSWORD=${{ env.DOCKER_HUB_TOKEN }}
         --workdir "$PWD"
         --tty
         "$CONTAINER_ID"

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -54,11 +54,6 @@ runs:
               -f /dev/null
         )"
         echo "CONTAINER_ID=$CONTAINER_ID" >> "$GITHUB_ENV"
-    - name: Logout of Docker
-      shell: bash
-      run: |
-        docker logout ghcr.io
-        docker logout docker.io
     - name: Run Goreleaser
       shell: bash
       run: docker exec
@@ -69,7 +64,7 @@ runs:
         --workdir "$PWD"
         --tty
         "$CONTAINER_ID"
-        goreleaser release
+        goreleaser release 
             ${{ inputs.dry-run == 'true' && '--skip=publish' || '' }}
             ${{ inputs.snapshot == 'true' && '--snapshot' || '' }}
             ${{ inputs.skip == '' && '' || format('--skip={0}', inputs.skip) }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -59,7 +59,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    if: always() && needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,7 @@ jobs:
       contents: write # Needed to upload release artifacts
       packages: read # Needed to load goreleaser-cross image
     needs: [ release-please ]
-    if: always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'pull_request')
+    if: needs.release-please.outputs.release_created == 'true' || github.event_name == 'pull_request'
     runs-on: ubuntu-22.04-8core-32gb
     outputs:
       hashes: ${{ steps.publish.outputs.hashes }}


### PR DESCRIPTION
This should fix two things

- Broken publishes to npm (remove spurious `always()` conditions)
- Dockerhub publish failures (log in to docker on the goreleaser container)
