### PR TITLE
fix(ci): [FUN-804] docker login command

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -53,7 +53,7 @@ runs:
             ghcr.io/launchdarkly/goreleaser-cross:v1.24.2  \
               -f /dev/null
         )"
-        echo "$DOCKER_HUB_TOKEN" | docker exec --workdir "$PWD" --tty "$CONTAINER_ID" docker login --username "$DOCKER_HUB_USERNAME" --password-stdin
+        docker exec --workdir "$PWD" --tty "$CONTAINER_ID" docker login --username "$DOCKER_HUB_USERNAME" --password "$DOCKER_HUB_TOKEN"
         echo "CONTAINER_ID=$CONTAINER_ID" >> "$GITHUB_ENV"
     - name: Run Goreleaser
       shell: bash


### PR DESCRIPTION
This corrects the docker login command to not accept the password via stdin. The command needs to be done on the container, not on the host.
<!-- ld-jira-link -->
---
Related Jira issue: [FUN-804: Release new ldcli](https://launchdarkly.atlassian.net/browse/FUN-804)
<!-- end-ld-jira-link -->