### PR TITLE
feat: Allow the path to the database file to be configurable

### DIFF
--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -8,6 +8,7 @@ const (
 	AccessTokenFlag  = "access-token"
 	AnalyticsOptOut  = "analytics-opt-out"
 	BaseURIFlag      = "base-uri"
+	DatabasePathFlag = "database-path"
 	DataFlag         = "data"
 	DevStreamURIFlag = "dev-stream-uri"
 	EmailsFlag       = "emails"
@@ -19,16 +20,17 @@ const (
 	RoleFlag         = "role"
 	SyncOnceFlag     = "sync-once"
 
-	AccessTokenFlagDescription = "LaunchDarkly access token with write-level access"
-	AnalyticsOptOutDescription = "Opt out of analytics tracking"
-	BaseURIFlagDescription     = "LaunchDarkly base URI"
-	DevStreamURIDescription    = "Streaming service endpoint that the dev server uses to obtain authoritative flag data. This may be a LaunchDarkly or Relay Proxy endpoint"
-	EnvironmentFlagDescription = "Default environment key"
-	FlagFlagDescription        = "Default feature flag key"
-	OutputFlagDescription      = "Command response output format in either JSON or plain text"
-	PortFlagDescription        = "Port for the dev server to run on"
-	ProjectFlagDescription     = "Default project key"
-	SyncOnceFlagDescription    = "Only sync new projects. Existing projects will neither be resynced nor have overrides specified by CLI flags applied."
+	AccessTokenFlagDescription  = "LaunchDarkly access token with write-level access"
+	AnalyticsOptOutDescription  = "Opt out of analytics tracking"
+	BaseURIFlagDescription      = "LaunchDarkly base URI"
+	DatabasePathFlagDescription = "Path to the database file for the dev server"
+	DevStreamURIDescription     = "Streaming service endpoint that the dev server uses to obtain authoritative flag data. This may be a LaunchDarkly or Relay Proxy endpoint"
+	EnvironmentFlagDescription  = "Default environment key"
+	FlagFlagDescription         = "Default feature flag key"
+	OutputFlagDescription       = "Command response output format in either JSON or plain text"
+	PortFlagDescription         = "Port for the dev server to run on"
+	ProjectFlagDescription      = "Default project key"
+	SyncOnceFlagDescription     = "Only sync new projects. Existing projects will neither be resynced nor have overrides specified by CLI flags applied."
 )
 
 func AllFlagsHelp() map[string]string {
@@ -36,6 +38,7 @@ func AllFlagsHelp() map[string]string {
 		AccessTokenFlag:  AccessTokenFlagDescription,
 		AnalyticsOptOut:  AnalyticsOptOutDescription,
 		BaseURIFlag:      BaseURIFlagDescription,
+		DatabasePathFlag: DatabasePathFlagDescription,
 		DevStreamURIFlag: DevStreamURIDescription,
 		EnvironmentFlag:  EnvironmentFlagDescription,
 		FlagFlag:         FlagFlagDescription,

--- a/cmd/config/testdata/help.golden
+++ b/cmd/config/testdata/help.golden
@@ -4,6 +4,7 @@ Supported settings:
 - `access-token`: LaunchDarkly access token with write-level access
 - `analytics-opt-out`: Opt out of analytics tracking
 - `base-uri`: LaunchDarkly base URI
+- `database-path`: Path to the database file for the dev server
 - `dev-stream-uri`: Streaming service endpoint that the dev server uses to obtain authoritative flag data. This may be a LaunchDarkly or Relay Proxy endpoint
 - `environment`: Default environment key
 - `flag`: Default feature flag key

--- a/cmd/dev_server/dev_server.go
+++ b/cmd/dev_server/dev_server.go
@@ -50,6 +50,14 @@ func NewDevServerCmd(client resources.Client, analyticsTrackerFn analytics.Track
 
 	_ = viper.BindPFlag(cliflags.PortFlag, cmd.PersistentFlags().Lookup(cliflags.PortFlag))
 
+	cmd.PersistentFlags().String(
+		cliflags.DatabasePathFlag,
+		"",
+		cliflags.DatabasePathFlagDescription,
+	)
+
+	_ = viper.BindPFlag(cliflags.DatabasePathFlag, cmd.PersistentFlags().Lookup(cliflags.DatabasePathFlag))
+
 	// Add subcommands here
 	cmd.AddGroup(&cobra.Group{ID: "projects", Title: "Project commands:"})
 	cmd.AddCommand(NewListProjectsCmd(client))

--- a/cmd/dev_server/start_server.go
+++ b/cmd/dev_server/start_server.go
@@ -87,6 +87,7 @@ func startServer(client dev_server.Client) func(*cobra.Command, []string) error 
 		params := dev_server.ServerParams{
 			AccessToken:            viper.GetString(cliflags.AccessTokenFlag),
 			BaseURI:                viper.GetString(cliflags.BaseURIFlag),
+			DatabasePath:           viper.GetString(cliflags.DatabasePathFlag),
 			DevStreamURI:           viper.GetString(cliflags.DevStreamURIFlag),
 			Port:                   viper.GetString(cliflags.PortFlag),
 			InitialProjectSettings: initialSetting,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	AccessToken     string `json:"access-token,omitempty" yaml:"access-token,omitempty"`
 	AnalyticsOptOut *bool  `json:"analytics-opt-out,omitempty" yaml:"analytics-opt-out,omitempty"`
 	BaseURI         string `json:"base-uri,omitempty" yaml:"base-uri,omitempty"`
+	DatabasePath    string `json:"database-path,omitempty" yaml:"database-path,omitempty"`
 	DevStreamURI    string `json:"dev-stream-uri,omitempty" yaml:"dev-stream-uri,omitempty"`
 	Environment     string `json:"environment,omitempty" yaml:"environment,omitempty"`
 	Flag            string `json:"flag,omitempty" yaml:"flag,omitempty"`
@@ -81,6 +82,8 @@ func (c Config) Update(kvs []string) (Config, []string, error) {
 				c.AnalyticsOptOut = &val
 			case cliflags.BaseURIFlag:
 				c.BaseURI = v
+			case cliflags.DatabasePathFlag:
+				c.DatabasePath = v
 			case cliflags.DevStreamURIFlag:
 				c.DevStreamURI = v
 			case cliflags.EnvironmentFlag:


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

#564 

If a user wanted to run more than one launch darkly dev server on the same machine - for the purposes of playwright testing parallelization, for example, (unique dev server per application/playwright worker), they would be unable to do so because the database path is fixed. 

**Describe the solution you've provided**

Allowed the database path to be configurable

**Describe alternatives you've considered**

Project aliases would also accomplish this, although it would likely be more difficult structurally to implement (although maybe more valuable?)

**Additional context**

Add any other context about the pull request here.
