### PR TITLE
feat: add copy-project command to clone a project

### DIFF
--- a/cmd/dev_server/dev_server.go
+++ b/cmd/dev_server/dev_server.go
@@ -58,6 +58,7 @@ func NewDevServerCmd(client resources.Client, analyticsTrackerFn analytics.Track
 	cmd.AddCommand(NewRemoveProjectCmd(client))
 	cmd.AddCommand(NewAddProjectCmd(client))
 	cmd.AddCommand(NewUpdateProjectCmd(client))
+	cmd.AddCommand(NewCopyProjectCmd(client))
 
 	cmd.AddGroup(&cobra.Group{ID: "overrides", Title: "Override commands:"})
 	cmd.AddCommand(NewAddOverrideCmd(client))

--- a/internal/dev_server/api/api.yaml
+++ b/internal/dev_server/api/api.yaml
@@ -113,6 +113,33 @@ paths:
           $ref: "#/components/responses/ErrorResponse"
         409:
           $ref: "#/components/responses/ErrorResponse"
+  /dev/projects/{projectKey}/copy:
+    post:
+      summary: Copy an existing project to create a new project namespace
+      operationId: postCopyProject
+      parameters:
+        - $ref: "#/components/parameters/projectKey"
+        - $ref: "#/components/parameters/projectExpand"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - newProjectKey
+              properties:
+                newProjectKey:
+                  type: string
+                  description: key for the new copied project
+      responses:
+        201:
+          $ref: "#/components/responses/Project"
+        400:
+          $ref: "#/components/responses/ErrorResponse"
+        404:
+          $ref: "#/components/responses/ErrorResponse"
+        409:
+          $ref: "#/components/responses/ErrorResponse"
   /dev/projects/{projectKey}/overrides:
     delete:
       summary: remove all overrides for the given project

--- a/internal/dev_server/api/delete_overrides.go
+++ b/internal/dev_server/api/delete_overrides.go
@@ -12,7 +12,12 @@ func (s server) DeleteOverrides(ctx context.Context, request DeleteOverridesRequ
 	err := model.DeleteOverrides(ctx, request.ProjectKey)
 	if err != nil {
 		if errors.As(err, &model.ErrNotFound{}) {
-			return DeleteOverrides404Response{}, nil
+			return DeleteOverrides404JSONResponse{
+				ErrorResponseJSONResponse{
+					Code:    "not_found",
+					Message: "project not found",
+				},
+			}, nil
 		}
 		return nil, err
 	}

--- a/internal/dev_server/api/post_copy_project.go
+++ b/internal/dev_server/api/post_copy_project.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/launchdarkly/ldcli/internal/dev_server/model"
+)
+
+func (s server) PostCopyProject(ctx context.Context, request PostCopyProjectRequestObject) (PostCopyProjectResponseObject, error) {
+	if request.Body.NewProjectKey == "" {
+		return PostCopyProject400JSONResponse{
+			ErrorResponseJSONResponse{
+				Code:    "invalid_request",
+				Message: "newProjectKey is required",
+			},
+		}, nil
+	}
+
+	store := model.StoreFromContext(ctx)
+
+	// Check if source project exists
+	_, err := store.GetDevProject(ctx, request.ProjectKey)
+	if err != nil {
+		var notFoundErr model.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return PostCopyProject404JSONResponse{
+				Code:    "not_found",
+				Message: "source project not found",
+			}, nil
+		}
+		return nil, err
+	}
+
+	// Copy the project
+	newProject, err := model.CopyProject(ctx, request.ProjectKey, request.Body.NewProjectKey, nil)
+	switch {
+	case errors.As(err, &model.ErrAlreadyExists{}):
+		return PostCopyProject409JSONResponse{
+			Code:    "conflict",
+			Message: err.Error(),
+		}, nil
+	case err != nil:
+		return nil, err
+	}
+
+	response := ProjectJSONResponse{
+		LastSyncedFromSource: newProject.LastSyncTime.Unix(),
+		Context:              newProject.Context,
+		SourceEnvironmentKey: newProject.SourceEnvironmentKey,
+		FlagsState:           &newProject.AllFlagsState,
+	}
+
+	if request.Params.Expand != nil {
+		for _, item := range *request.Params.Expand {
+			if item == "overrides" {
+				overrides, err := store.GetOverridesForProject(ctx, request.Body.NewProjectKey)
+				if err != nil {
+					return nil, err
+				}
+				respOverrides := make(model.FlagsState)
+				for _, override := range overrides {
+					if !override.Active {
+						continue
+					}
+					respOverrides[override.FlagKey] = model.FlagState{
+						Value:   override.Value,
+						Version: override.Version,
+					}
+				}
+				response.Overrides = &respOverrides
+			}
+			if item == "availableVariations" {
+				availableVariations, err := store.GetAvailableVariationsForProject(ctx, request.Body.NewProjectKey)
+				if err != nil {
+					return nil, err
+				}
+				respAvailableVariations := availableVariationsToResponseFormat(availableVariations)
+				response.AvailableVariations = &respAvailableVariations
+			}
+		}
+	}
+
+	return PostCopyProject201JSONResponse{
+		response,
+	}, nil
+}

--- a/internal/dev_server/api/post_copy_project_test.go
+++ b/internal/dev_server/api/post_copy_project_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/ldcli/internal/dev_server/model"
+	"github.com/launchdarkly/ldcli/internal/dev_server/model/mocks"
+)
+
+func TestPostCopyProject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	store := mocks.NewMockStore(ctrl)
+
+	ctx := context.Background()
+	ctx = model.ContextWithStore(ctx, store)
+
+	s := server{}
+
+	sourceProject := &model.Project{
+		Key:                  "source-project",
+		SourceEnvironmentKey: "production",
+		Context:              ldcontext.NewBuilder("user").Key("test-user").Build(),
+		AllFlagsState: model.FlagsState{
+			"flag-1": model.FlagState{Value: ldvalue.Bool(true), Version: 1},
+		},
+	}
+
+	t.Run("copies project successfully", func(t *testing.T) {
+		store.EXPECT().GetDevProject(gomock.Any(), "source-project").Return(sourceProject, nil).Times(2)
+		store.EXPECT().InsertProject(gomock.Any(), gomock.Any()).Return(nil)
+
+		request := PostCopyProjectRequestObject{
+			ProjectKey: "source-project",
+			Body: &PostCopyProjectJSONRequestBody{
+				NewProjectKey: "new-project",
+			},
+		}
+
+		response, err := s.PostCopyProject(ctx, request)
+		assert.NoError(t, err)
+
+		successResponse, ok := response.(PostCopyProject201JSONResponse)
+		assert.True(t, ok)
+		assert.Equal(t, sourceProject.SourceEnvironmentKey, successResponse.SourceEnvironmentKey)
+		assert.Equal(t, sourceProject.Context, successResponse.Context)
+		assert.NotNil(t, successResponse.FlagsState)
+	})
+
+	t.Run("returns 400 when newProjectKey is missing", func(t *testing.T) {
+		request := PostCopyProjectRequestObject{
+			ProjectKey: "source-project",
+			Body: &PostCopyProjectJSONRequestBody{
+				NewProjectKey: "",
+			},
+		}
+
+		response, err := s.PostCopyProject(ctx, request)
+		assert.NoError(t, err)
+
+		errorResponse, ok := response.(PostCopyProject400JSONResponse)
+		assert.True(t, ok)
+		assert.Equal(t, "invalid_request", errorResponse.Code)
+		assert.Equal(t, "newProjectKey is required", errorResponse.Message)
+	})
+
+	t.Run("returns 404 when source project not found", func(t *testing.T) {
+		store.EXPECT().GetDevProject(gomock.Any(), "non-existent").Return(nil, model.NewErrNotFound("project", "non-existent"))
+
+		request := PostCopyProjectRequestObject{
+			ProjectKey: "non-existent",
+			Body: &PostCopyProjectJSONRequestBody{
+				NewProjectKey: "new-project",
+			},
+		}
+
+		response, err := s.PostCopyProject(ctx, request)
+		assert.NoError(t, err)
+
+		errorResponse, ok := response.(PostCopyProject404JSONResponse)
+		assert.True(t, ok)
+		assert.Equal(t, "not_found", errorResponse.Code)
+		assert.Equal(t, "source project not found", errorResponse.Message)
+	})
+
+	t.Run("returns 409 when new project already exists", func(t *testing.T) {
+		store.EXPECT().GetDevProject(gomock.Any(), "source-project").Return(sourceProject, nil).Times(2)
+		store.EXPECT().InsertProject(gomock.Any(), gomock.Any()).Return(model.NewErrAlreadyExists("project", "existing-project"))
+
+		request := PostCopyProjectRequestObject{
+			ProjectKey: "source-project",
+			Body: &PostCopyProjectJSONRequestBody{
+				NewProjectKey: "existing-project",
+			},
+		}
+
+		response, err := s.PostCopyProject(ctx, request)
+		assert.NoError(t, err)
+
+		errorResponse, ok := response.(PostCopyProject409JSONResponse)
+		assert.True(t, ok)
+		assert.Equal(t, "conflict", errorResponse.Code)
+	})
+}


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

#564 

**Describe the solution you've provided**

The ability to copy a project locally - effectively providing namespaces for the same set of flags.

It's possible this might not be the right approach because projects should have a 1:1 representation to a project in launch darkly, and this would break that contract.

#563 might be the simpler way to go, unless full on namespaces are reasonable to implement as a separate feature.

**Describe alternatives you've considered**

Allowed the database path to be configurable - #563 

**Additional context**

N/A
