### PR TITLE
fix: improve help text and add analytics

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -204,7 +204,7 @@ func NewRootCommand(
 	cmd.AddCommand(logincmd.NewLoginCmd(resources.NewClient(version)))
 	cmd.AddCommand(resourcecmd.NewResourcesCmd())
 	cmd.AddCommand(devcmd.NewDevServerCmd(resources.NewClient(version), analyticsTrackerFn, dev_server.NewClient(version)))
-	cmd.AddCommand(sourcemapscmd.NewSourcemapsCmd())
+	cmd.AddCommand(sourcemapscmd.NewSourcemapsCmd(resources.NewClient(version), analyticsTrackerFn))
 	resourcecmd.AddAllResourceCmds(cmd, clients.ResourcesClient, analyticsTrackerFn)
 
 	// add non-generated commands

--- a/cmd/sourcemaps/sourcemaps.go
+++ b/cmd/sourcemaps/sourcemaps.go
@@ -3,20 +3,21 @@ package sourcemaps
 import (
 	"github.com/spf13/cobra"
 
+	resourcescmd "github.com/launchdarkly/ldcli/cmd/resources"
+	"github.com/launchdarkly/ldcli/internal/analytics"
 	"github.com/launchdarkly/ldcli/internal/resources"
 )
 
-func NewSourcemapsCmd() *cobra.Command {
+func NewSourcemapsCmd(client resources.Client, analyticsTrackerFn analytics.TrackerFn) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sourcemaps",
 		Short: "Manage sourcemaps",
 		Long:  "Manage sourcemaps for LaunchDarkly error monitoring",
-		Run: func(cmd *cobra.Command, args []string) {
-			_ = cmd.Help()
-		},
+		Args:  cobra.MinimumNArgs(1),
 	}
 
-	cmd.AddCommand(NewUploadCmd(resources.NewClient("")))
+	cmd.AddCommand(NewUploadCmd(client, analyticsTrackerFn))
+	cmd.SetUsageTemplate(resourcescmd.SubcommandUsageTemplate())
 
 	return cmd
 }


### PR DESCRIPTION
* Add analytics tracking to sourcemaps command
* Improve help text of `ldcli sourcemaps`

Local Testing:

<img width="1077" alt="Screenshot 2025-06-10 at 17 43 07" src="https://github.com/user-attachments/assets/c4fcefc7-0f52-44ef-8e27-031adeba4683" />

![Screenshot 2025-06-12 at 14 10 28](https://github.com/user-attachments/assets/45edcd4d-2946-4289-80d0-44975c7e590b)

