### PR TITLE
fix: [REL-8702] fix flags get-status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Additional documentation is available at https://docs.launchdarkly.com/home/gett
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this project.
 
+### Running a local build of the CLI
+If you wish to test your changes locally, simply
+1. Clone this repo to your local machine;
+2. Run `make build` from the repo root;
+3. Run commands as usual with `./ldcli`.
+
 ## Verifying build provenance with the SLSA framework
 
 LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](./PROVENANCE.md).

--- a/internal/output/plaintext_fns.go
+++ b/internal/output/plaintext_fns.go
@@ -65,6 +65,8 @@ var SingularPlaintextOutputFn = func(r resource) string {
 		return email.(string)
 	case id != nil:
 		return id.(string)
+	case name != nil:
+		return name.(string)
 	default:
 		return "cannot read resource"
 	}

--- a/internal/output/resource_output.go
+++ b/internal/output/resource_output.go
@@ -103,7 +103,7 @@ func CmdOutput(action string, outputKind string, input []byte) (string, error) {
 }
 
 func plaintextOutput(out string, successMessage string) string {
-	if successMessage != "" {
+	if strings.TrimSpace(successMessage) != "" {
 		return fmt.Sprintf("%s%s", successMessage, out)
 	}
 


### PR DESCRIPTION
**Requirements**
It seems that the flags `get-status` command was consistently returning `"cannot read resource"` when it should, of course, be returning the flag status. This turned out to be because we were not handling the parsing of the body correctly:
```
{
   "name":"inactive",
   "lastRequested":null,
   "_links":{
      "parent":{
         "href":"/api/v2/flags/default/sample-flag",
         "type":"application/json"
      },
      "self":{
         "href":"/api/v2/flag-statuses/default/sample-environment/sample-flag",
         "type":"application/json"
      }
   }
}
```
We were failing to parse out the `"name"` field where neither `"key"`, `"id"`, or `"email"` was specified.

Also stripped some whitespace off the output for cleanliness' sake and added instructions to the README on running locally.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-8702: ldcli flags get-status cannot read resource](https://launchdarkly.atlassian.net/browse/REL-8702)
<!-- end-ld-jira-link -->