### PR TITLE
fix: [REL-8111] [rel-8111] investigate and fix ldcli returning zero error code on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Additional documentation is available at https://docs.launchdarkly.com/home/gett
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this project.
 
+### Running a local build of the CLI
+If you wish to test your changes locally, simply
+1. Clone this repo to your local machine;
+2. Run `make build` from the repo root;
+3. Run commands as usual with `./ldcli`.
+
 ## Verifying build provenance with the SLSA framework
 
 LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](./PROVENANCE.md).

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -270,6 +270,7 @@ See each command's help for details on how to use the generated script.`, rootCm
 	case err != nil:
 		outcome = analytics.ERROR
 		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
 	default:
 		outcome = analytics.SUCCESS
 	}

--- a/internal/output/plaintext_fns.go
+++ b/internal/output/plaintext_fns.go
@@ -65,6 +65,8 @@ var SingularPlaintextOutputFn = func(r resource) string {
 		return email.(string)
 	case id != nil:
 		return id.(string)
+	case name != nil:
+		return name.(string)
 	default:
 		return "cannot read resource"
 	}

--- a/internal/output/resource_output.go
+++ b/internal/output/resource_output.go
@@ -103,7 +103,7 @@ func CmdOutput(action string, outputKind string, input []byte) (string, error) {
 }
 
 func plaintextOutput(out string, successMessage string) string {
-	if successMessage != "" {
+	if strings.TrimSpace(successMessage) != "" {
 		return fmt.Sprintf("%s%s", successMessage, out)
 	}
 


### PR DESCRIPTION
We were returning a 0 exit status when the API was erroring out (reported [here](https://github.com/launchdarkly/ldcli/issues/554)). This just sets the exit code
<!-- ld-jira-link -->
---
Related Jira issue: [REL-8111: Investigate and fix ldcli not returning non-zero error code on failure](https://launchdarkly.atlassian.net/browse/REL-8111)
<!-- end-ld-jira-link -->