### PR TITLE
Comprehesive fix for browser-based SDKs

### DIFF
--- a/internal/dev_server/model/mocks/store.go
+++ b/internal/dev_server/model/mocks/store.go
@@ -118,6 +118,21 @@ func (mr *MockStoreMockRecorder) GetDevProject(ctx, projectKey any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevProject", reflect.TypeOf((*MockStore)(nil).GetDevProject), ctx, projectKey)
 }
 
+// GetDevProjectByClientSideId mocks base method.
+func (m *MockStore) GetDevProjectByClientSideId(ctx context.Context, clientSideId string) (*model.Project, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDevProjectByClientSideId", ctx, clientSideId)
+	ret0, _ := ret[0].(*model.Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDevProjectByClientSideId indicates an expected call of GetDevProjectByClientSideId.
+func (mr *MockStoreMockRecorder) GetDevProjectByClientSideId(ctx, clientSideId any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevProjectByClientSideId", reflect.TypeOf((*MockStore)(nil).GetDevProjectByClientSideId), ctx, clientSideId)
+}
+
 // GetDevProjectKeys mocks base method.
 func (m *MockStore) GetDevProjectKeys(ctx context.Context) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/internal/dev_server/model/store.go
+++ b/internal/dev_server/model/store.go
@@ -21,6 +21,8 @@ type Store interface {
 	GetDevProjectKeys(ctx context.Context) ([]string, error)
 	// GetDevProject fetches the project based on the projectKey. If it doesn't exist, ErrNotFound is returned
 	GetDevProject(ctx context.Context, projectKey string) (*Project, error)
+	// GetDevProjectByClientSideId fetches the project based on the client-side ID. If it doesn't exist, ErrNotFound is returned
+	GetDevProjectByClientSideId(ctx context.Context, clientSideId string) (*Project, error)
 	UpdateProject(ctx context.Context, project Project) (bool, error)
 	DeleteDevProject(ctx context.Context, projectKey string) (bool, error)
 	// InsertProject inserts the project. If it already exists, ErrAlreadyExists is returned

--- a/internal/dev_server/model/sync_test.go
+++ b/internal/dev_server/model/sync_test.go
@@ -81,6 +81,7 @@ func TestInitialSync(t *testing.T) {
 		api.EXPECT().GetSdkKey(gomock.Any(), projKey, sourceEnvKey).Return(sdkKey, nil)
 		sdk.EXPECT().GetAllFlagsState(gomock.Any(), gomock.Any(), sdkKey).Return(allFlagsState, nil)
 		api.EXPECT().GetAllFlags(gomock.Any(), projKey).Return(nil, errors.New("fetch flags failed"))
+		api.EXPECT().GetProjectEnvironments(gomock.Any(), projKey, "", nil).Return(nil, nil)
 		input := model.InitialProjectSettings{
 			Enabled:    true,
 			ProjectKey: projKey,
@@ -97,6 +98,7 @@ func TestInitialSync(t *testing.T) {
 		api.EXPECT().GetSdkKey(gomock.Any(), projKey, sourceEnvKey).Return(sdkKey, nil)
 		sdk.EXPECT().GetAllFlagsState(gomock.Any(), gomock.Any(), sdkKey).Return(allFlagsState, nil)
 		api.EXPECT().GetAllFlags(gomock.Any(), projKey).Return(allFlags, nil)
+		api.EXPECT().GetProjectEnvironments(gomock.Any(), projKey, "", nil).Return([]ldapi.Environment{{Key: sourceEnvKey, Id: "test-client-side-id"}}, nil)
 		store.EXPECT().InsertProject(gomock.Any(), gomock.Any()).Return(errors.New("insert fails"))
 
 		input := model.InitialProjectSettings{
@@ -115,6 +117,7 @@ func TestInitialSync(t *testing.T) {
 		api.EXPECT().GetSdkKey(gomock.Any(), projKey, sourceEnvKey).Return(sdkKey, nil)
 		sdk.EXPECT().GetAllFlagsState(gomock.Any(), gomock.Any(), sdkKey).Return(allFlagsState, nil)
 		api.EXPECT().GetAllFlags(gomock.Any(), projKey).Return(allFlags, nil)
+		api.EXPECT().GetProjectEnvironments(gomock.Any(), projKey, "", nil).Return([]ldapi.Environment{{Key: sourceEnvKey, Id: "test-client-side-id"}}, nil)
 		store.EXPECT().InsertProject(gomock.Any(), gomock.Any()).Return(nil)
 
 		input := model.InitialProjectSettings{
@@ -152,6 +155,7 @@ func TestInitialSync(t *testing.T) {
 		api.EXPECT().GetSdkKey(gomock.Any(), projKey, sourceEnvKey).Return(sdkKey, nil)
 		sdk.EXPECT().GetAllFlagsState(gomock.Any(), gomock.Any(), sdkKey).Return(allFlagsState, nil)
 		api.EXPECT().GetAllFlags(gomock.Any(), projKey).Return(allFlags, nil)
+		api.EXPECT().GetProjectEnvironments(gomock.Any(), projKey, "", nil).Return([]ldapi.Environment{{Key: sourceEnvKey, Id: "test-client-side-id"}}, nil)
 		store.EXPECT().InsertProject(gomock.Any(), gomock.Any()).Return(nil)
 		store.EXPECT().UpsertOverride(gomock.Any(), override).Return(override, nil)
 		store.EXPECT().GetDevProject(gomock.Any(), projKey).Return(&proj, nil)

--- a/internal/dev_server/sdk/cors.go
+++ b/internal/dev_server/sdk/cors.go
@@ -10,6 +10,10 @@ func CorsHeaders(handler http.Handler) http.Handler {
 		writer.Header().Set("Access-Control-Allow-Headers", "Cache-Control,Content-Type,Content-Length,Accept-Encoding,X-LaunchDarkly-User-Agent,X-LaunchDarkly-Payload-ID,X-LaunchDarkly-Wrapper,X-LaunchDarkly-Event-Schema,X-LaunchDarkly-Tags")
 		writer.Header().Set("Access-Control-Expose-Headers", "Date")
 		writer.Header().Set("Access-Control-Max-Age", "300")
+		if request.Method == http.MethodOptions {
+			writer.WriteHeader(http.StatusOK)
+			return
+		}
 		handler.ServeHTTP(writer, request)
 	})
 }

--- a/internal/dev_server/sdk/go_sdk_test.go
+++ b/internal/dev_server/sdk/go_sdk_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	ldapi "github.com/launchdarkly/api-client-go/v14"
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	ldclient "github.com/launchdarkly/go-server-sdk/v7"
@@ -48,6 +49,14 @@ func TestSDKRoutesViaGoSDK(t *testing.T) {
 	api.EXPECT().GetSdkKey(gomock.Any(), projectKey, environmentKey).Return(testSdkKey, nil).AnyTimes()
 	api.EXPECT().GetAllFlags(gomock.Any(), projectKey).
 		Return(nil, nil). // Available variations are not used for evaluation
+		AnyTimes()
+	api.EXPECT().GetProjectEnvironments(gomock.Any(), projectKey, "", nil).
+		Return([]ldapi.Environment{
+			{
+				Key: environmentKey,
+				Id:  "test-client-side-id",
+			},
+		}, nil).
 		AnyTimes()
 
 	// Wire up sdk routes in test server

--- a/internal/dev_server/sdk/project_key_middleware.go
+++ b/internal/dev_server/sdk/project_key_middleware.go
@@ -2,10 +2,13 @@ package sdk
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/launchdarkly/ldcli/internal/dev_server/model"
 )
 
 type ctxKey string
@@ -22,11 +25,14 @@ func GetProjectKeyFromContext(ctx context.Context) string {
 func GetProjectKeyFromEnvIdParameter(pathParameter string) func(handler http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			log.Printf("GetProjectKeyFromEnvIdParameter middleware called: %s %s", request.Method, request.URL.Path)
 			projectKey, ok := mux.Vars(request)[pathParameter]
 			if !ok {
+				log.Printf("project key not found in path for parameter: %s", pathParameter)
 				http.Error(writer, "project key not on path", http.StatusNotFound)
 				return
 			}
+			log.Printf("Extracted project key: %s", projectKey)
 			ctx := request.Context()
 			ctx = SetProjectKeyOnContext(ctx, projectKey)
 			request = request.WithContext(ctx)
@@ -48,4 +54,35 @@ func GetProjectKeyFromAuthorizationHeader(handler http.Handler) http.Handler {
 		request = request.WithContext(ctx)
 		handler.ServeHTTP(writer, request)
 	})
+}
+
+func GetProjectKeyFromClientSideId(pathParameter string) func(handler http.Handler) http.Handler {
+	return func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			log.Printf("GetProjectKeyFromClientSideId middleware called: %s %s", request.Method, request.URL.Path)
+			clientSideId, ok := mux.Vars(request)[pathParameter]
+			if !ok {
+				log.Printf("client-side ID not found in path for parameter: %s", pathParameter)
+				http.Error(writer, "client-side ID not on path", http.StatusNotFound)
+				return
+			}
+			log.Printf("Extracted client-side ID: %s", clientSideId)
+
+			ctx := request.Context()
+			store := model.StoreFromContext(ctx)
+
+			// Look up project by client-side ID (fast database lookup)
+			project, err := store.GetDevProjectByClientSideId(ctx, clientSideId)
+			if err != nil {
+				log.Printf("No project found for client-side ID %s: %v", clientSideId, err)
+				http.Error(writer, fmt.Sprintf("project not found for client-side ID %s", clientSideId), http.StatusNotFound)
+				return
+			}
+
+			log.Printf("Found project %s for client-side ID %s", project.Key, clientSideId)
+			ctx = SetProjectKeyOnContext(ctx, project.Key)
+			request = request.WithContext(ctx)
+			handler.ServeHTTP(writer, request)
+		})
+	}
 }

--- a/internal/dev_server/sdk/project_key_middleware_test.go
+++ b/internal/dev_server/sdk/project_key_middleware_test.go
@@ -1,0 +1,72 @@
+package sdk
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/launchdarkly/ldcli/internal/dev_server/model"
+	"github.com/launchdarkly/ldcli/internal/dev_server/model/mocks"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetProjectKeyFromClientSideId(t *testing.T) {
+	mockController := gomock.NewController(t)
+	store := mocks.NewMockStore(mockController)
+
+	router := mux.NewRouter()
+	router.Use(model.StoreMiddleware(store))
+
+	// Create a test handler that will be wrapped by the middleware
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		projectKey := GetProjectKeyFromContext(r.Context())
+		fmt.Fprint(w, projectKey)
+	})
+
+	// Test case: project is found
+	t.Run("when project is found for client-side ID", func(t *testing.T) {
+		clientSideId := "test-client-side-id"
+		expectedProjectKey := "my-project"
+
+		// Set up the mock to return a project
+		store.EXPECT().GetDevProjectByClientSideId(gomock.Any(), clientSideId).Return(&model.Project{
+			Key: expectedProjectKey,
+		}, nil)
+
+		req := httptest.NewRequest("GET", fmt.Sprintf("/sdk/evalx/%s/some/other/path", clientSideId), nil)
+		rec := httptest.NewRecorder()
+
+		// Create a subrouter with the middleware
+		subrouter := router.PathPrefix("/sdk/evalx/{envId}").Subrouter()
+		subrouter.Use(GetProjectKeyFromClientSideId("envId"))
+		subrouter.PathPrefix("/").Handler(testHandler)
+
+		router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, expectedProjectKey, rec.Body.String())
+	})
+
+	// Test case: project is not found
+	t.Run("when project is not found for client-side ID", func(t *testing.T) {
+		clientSideId := "not-found-id"
+
+		// Set up the mock to return a not found error
+		store.EXPECT().GetDevProjectByClientSideId(gomock.Any(), clientSideId).Return(nil, model.NewErrNotFound("project", clientSideId))
+
+		req := httptest.NewRequest("GET", fmt.Sprintf("/sdk/evalx/%s/some/other/path", clientSideId), nil)
+		rec := httptest.NewRecorder()
+
+		// Create a subrouter with the middleware
+		subrouter := router.PathPrefix("/sdk/evalx/{envId}").Subrouter()
+		subrouter.Use(GetProjectKeyFromClientSideId("envId"))
+		subrouter.PathPrefix("/").Handler(testHandler)
+
+		router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+}

--- a/internal/dev_server/sdk/routes.go
+++ b/internal/dev_server/sdk/routes.go
@@ -35,20 +35,20 @@ func BindRoutes(router *mux.Router) {
 	evalRouter := router.PathPrefix("/eval").Subrouter()
 	evalRouter.Use(CorsHeaders)
 	evalRouter.Methods(http.MethodOptions).HandlerFunc(ConstantResponseHandler(http.StatusOK, ""))
-	evalRouter.Use(GetProjectKeyFromEnvIdParameter("envId"))
+	evalRouter.Use(GetProjectKeyFromClientSideId("envId"))
 	evalRouter.PathPrefix("/{envId}").
 		Methods(http.MethodGet, "REPORT").
 		HandlerFunc(StreamClientFlags)
 
 	goalsRouter := router.Path("/sdk/goals/{envId}").Subrouter()
 	goalsRouter.Use(CorsHeaders)
-	goalsRouter.Use(GetProjectKeyFromEnvIdParameter("envId"))
+	goalsRouter.Use(GetProjectKeyFromClientSideId("envId"))
 	goalsRouter.Methods(http.MethodOptions).HandlerFunc(ConstantResponseHandler(http.StatusOK, ""))
 	goalsRouter.Methods(http.MethodGet).HandlerFunc(ConstantResponseHandler(http.StatusOK, "[]"))
 
 	evalXRouter := router.PathPrefix("/sdk/evalx/{envId}").Subrouter()
 	evalXRouter.Use(CorsHeaders)
-	evalXRouter.Use(GetProjectKeyFromEnvIdParameter("envId"))
+	evalXRouter.Use(GetProjectKeyFromClientSideId("envId"))
 	evalXRouter.Methods(http.MethodOptions).HandlerFunc(ConstantResponseHandler(http.StatusOK, ""))
-	evalXRouter.Methods(http.MethodGet, "REPORT").HandlerFunc(GetClientFlags)
+	evalXRouter.PathPrefix("/").Methods(http.MethodGet, "REPORT").HandlerFunc(GetClientFlags)
 }


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

## 1. Problem: CORS Failure for JavaScript SDK

- **Symptom**:  
  The browser blocked the JavaScript SDK from connecting to the `ldcli` dev-server. The server's response to the preflight `OPTIONS` request was missing the required `X-LaunchDarkly-*` headers in its `Access-Control-Allow-Headers` list.

- **Root Cause**:  
  A restrictive CORS middleware, designed for the server's management API, was being incorrectly applied to all routes, including the SDK endpoints.

- **Solution**:
  - Refactored `ldcli/internal/dev_server/dev_server.go` to apply the API's CORS middleware only to API routes.
  - Allowed SDK routes to use their own, less restrictive CORS handler, which already included the correct `X-LaunchDarkly-*` headers.
  - Ensured the SDK's CORS handler in `ldcli/internal/dev_server/sdk/cors.go` correctly responded to `OPTIONS` requests with a `200 OK` status.

---

## 2. Problem: 404 Not Found for Client-Side Endpoints

- **Symptom**:  
  After fixing the CORS issue, the JS SDK received `404 Not Found` errors for flag evaluation endpoints like `/sdk/evalx/...`.

- **Root Cause**:  
  The `gorilla/mux` routing configuration in `ldcli/internal/dev_server/sdk/routes.go` was not correctly matching the full URL path. The subrouter was consuming `/sdk/evalx/{envId}` and not passing the remainder (`/contexts/...`) to the final handler.

- **Solution**:  
  Modified the handler registration in the subrouter to use `.PathPrefix("/")`, ensuring the handler correctly processed remaining path segments.

---

## 3. Problem: Incorrect Project Lookup Logic

- **Symptom**:  
  The server was treating the client-side ID from the URL (e.g., `5ba007d7e8b4491691b9fa4a`) as a project key (e.g., `sandbox`), leading to `"project not found"` errors.

- **Root Cause**:  
  Middleware was designed for server-side SDKs and did not differentiate between a project's key and its environment's client-side ID.

- **Solution**:  
  Created new middleware: `GetProjectKeyFromClientSideId`, which correctly maps client-side IDs to their corresponding project keys.

---

## 4. Problem: Performance and Caching

- **Symptom**:  
  The new middleware caused latency by making expensive API calls to LaunchDarkly on every request.

- **Root Cause**:  
  No local cache existed for the client-side ID to project key mapping.

- **Solution**:
  - Implemented DB caching by adding a `client_side_id` column to the local `projects` table.
  - Client-side ID is now fetched once on project creation/sync and stored locally.
  - Middleware was updated to query the local DB instead of the API.

---

## 5. Problem: Database Schema Evolution & Compatibility

- **Symptom**:  
  Server failed to start because existing databases didn’t have the new `client_side_id` column. Later, failures occurred due to `NULL` values in existing rows.

- **Root Cause**:  
  Schema changes weren’t backward-compatible, and the application couldn’t handle missing data.

- **Solution**:
  - Added a DB migration in `ldcli/internal/dev_server/db/sqlite.go` with `ALTER TABLE` on startup.
  - Updated `Project` model to use `*string` for `ClientSideId`, enabling graceful handling of `NULL`s.

---

## 6. Problem: Lack of Test Coverage

- **Symptom**:  
  The new middleware and DB logic were untested, and existing tests broke.

- **Root Cause**:  
  New logic lacked test coverage, and changes affected test expectations.

- **Solution**:
  - Created `ldcli/internal/dev_server/sdk/project_key_middleware_test.go` with unit tests for the new middleware.
  - Fixed broken test in `ldcli/internal/dev_server/sdk/go_sdk_test.go` by updating mock expectations.
  - Used `gomock` and `httptest` to align with existing test patterns.

