### PR TITLE
fix: Enhance flag search functionality to support quoted substrings

### DIFF
--- a/internal/dev_server/ui/src/Flags.tsx
+++ b/internal/dev_server/ui/src/Flags.tsx
@@ -63,8 +63,17 @@ function Flags({
       .filter((entry) => {
         if (!searchTerm) return true;
         const [flagKey] = entry;
-        const result = fuzzysort.single(searchTerm.toLowerCase(), flagKey);
-        return result && result.score > -5000;
+        if (
+          searchTerm.length > 1 &&
+          searchTerm.startsWith('"') &&
+          searchTerm.endsWith('"')
+        ) {
+          const substr = searchTerm.slice(1, -1).toLowerCase();
+          return flagKey.toLowerCase().includes(substr);
+        } else {
+          const result = fuzzysort.single(searchTerm.toLowerCase(), flagKey);
+          return result && result.score > -5000;
+        }
       })
       .filter((entry) => {
         const [flagKey] = entry;


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

The solution adds hybrid search functionality that intelligently switches between search modes based on the query format:

Quoted searches ("ai-", "feature-toggle"): Performs exact case-insensitive substring matching using String.includes()
Unquoted searches (ai recommendation, featr): Continues using the existing fuzzysort library for typo-tolerant matching

The implementation is lightweight and frontend-only, requiring no backend changes or additional dependencies. It maintains backward compatibility while adding precision for users who need exact prefix/substring matching.

Key benefits:

- Solves the "noisy results" problem when searching for flags with specific prefixes like "ai-"
- Intuitive UX pattern (quotes = exact search) familiar to users from search engines and IDEs
- Maintains existing fuzzy search capabilities for general exploration
- Zero performance impact on existing search behavior

**Describe alternatives you've considered**

None

**Additional context**

Problem context: When searching for flags with common prefixes like "ai-", the fuzzy search returns many false positives because it matches flags containing those characters in any order (e.g., analytics-integration, audit-info). This creates noise when users want to find flags with specific naming conventions.
Usage examples:

- Search "ai-" → Returns only flags that contain "ai-" as a substring
- Search ai recommendation → Uses fuzzy search to find flags even with typos
- Search "feature-toggle" → Exact substring match for precise results
- Search featr togl → Fuzzy search handles typos gracefully