### PR TITLE
feat: [experimental] autogenerated Claude skills for cli

### DIFF
--- a/skills/INSTALL.md
+++ b/skills/INSTALL.md
@@ -5,8 +5,22 @@ These skills give AI agents (Claude Code) the knowledge to manage LaunchDarkly r
 ## Prerequisites
 
 - [Claude Code](https://claude.ai/claude-code) installed
-- [`ldcli`](https://github.com/launchdarkly/ldcli) installed and on your PATH
-- Authenticated: run `ldcli login` or set `LD_ACCESS_TOKEN`
+
+`ldcli` does **not** need to be installed before running the skill installer. If it's missing, the installer will warn you and continue. Once the skills are installed, Claude will automatically detect that `ldcli` is missing when you ask it to do something with LaunchDarkly and offer to install it for you.
+
+If you'd rather install `ldcli` yourself first:
+
+```bash
+# macOS
+brew tap launchdarkly/homebrew-tap && brew install ldcli
+
+# npm
+npm install -g @launchdarkly/ldcli
+
+# Then authenticate
+ldcli login
+# or set LD_ACCESS_TOKEN in your environment
+```
 
 ## Quick Install
 

--- a/skills/INSTALL.md
+++ b/skills/INSTALL.md
@@ -1,0 +1,139 @@
+# Installing LaunchDarkly CLI Skills for Claude Code
+
+These skills give AI agents (Claude Code) the knowledge to manage LaunchDarkly resources using `ldcli`.
+
+## Prerequisites
+
+- [Claude Code](https://claude.ai/claude-code) installed
+- [`ldcli`](https://github.com/launchdarkly/ldcli) installed and on your PATH
+- Authenticated: run `ldcli login` or set `LD_ACCESS_TOKEN`
+
+## Quick Install
+
+```bash
+git clone https://github.com/launchdarkly/ldcli.git
+cd ldcli/skills
+./install.sh
+```
+
+That's it. The installer:
+
+1. **Symlinks skill files** into `~/.claude/commands/` as slash commands (`/ld-feature-flags`, `/ld-flag-targeting`, etc.)
+2. **Adds a block to `~/.claude/CLAUDE.md`** so Claude passively knows about `ldcli` in every session
+3. **Creates `~/.claude/launchdarkly-conventions.md`** — a template for your org-specific customizations
+
+## What Gets Installed
+
+### Slash Commands
+
+| Command | Skill |
+|---------|-------|
+| `/ld-feature-flags` | Create, list, get, toggle, archive, delete flags |
+| `/ld-flag-targeting` | Targeting rules, rollouts, individual targets, prerequisites |
+| `/ld-projects-and-environments` | Manage projects and environments |
+| `/ld-segments` | Create and manage audience segments |
+| `/ld-members-and-teams` | Invite members, manage teams and roles |
+| `/ld-dev-server` | Local development server and flag overrides |
+| `/ld-audit-and-observability` | Audit logs, contexts, metrics, experiments |
+
+### Passive Context (`~/.claude/CLAUDE.md`)
+
+A block is appended to your global `CLAUDE.md` that tells Claude about `ldcli` availability. This means you can just say "create a feature flag called dark-mode" and Claude will know to use `ldcli` — without invoking a slash command first.
+
+### Conventions File (`~/.claude/launchdarkly-conventions.md`)
+
+A template where you define your organization's standards. Uncomment and edit sections for:
+
+- Default project and environment keys
+- Flag naming conventions
+- Tagging standards
+- Safety rules (e.g., "always confirm before toggling in production")
+- Team-specific context
+
+Claude reads this file automatically and applies your conventions when working with `ldcli`.
+
+## How It Works
+
+The install uses **symlinks**, so the slash commands always reflect the latest skill files. If you `git pull` to update the skills, your Claude sessions pick up the changes immediately.
+
+```
+~/.claude/
+├── CLAUDE.md                          ← passive ldcli context appended here
+├── launchdarkly-conventions.md        ← YOUR org customizations (copied, not linked)
+└── commands/
+    ├── ld-feature-flags.md            → symlink to skills/feature-flags.md
+    ├── ld-flag-targeting.md           → symlink to skills/flag-targeting.md
+    ├── ld-projects-and-environments.md → symlink to skills/projects-and-environments.md
+    ├── ld-segments.md                 → symlink to skills/segments.md
+    ├── ld-members-and-teams.md        → symlink to skills/members-and-teams.md
+    ├── ld-dev-server.md               → symlink to skills/dev-server.md
+    └── ld-audit-and-observability.md  → symlink to skills/audit-and-observability.md
+```
+
+## Customization
+
+### The Layered Approach
+
+Skills are organized in two layers:
+
+1. **Standard skills** (symlinked) — describe *how* to use `ldcli`. You don't need to modify these.
+2. **Conventions file** (your copy) — describes *your team's standards*. This is where you customize.
+
+For example, if your team always uses project key `my-app` and environments `dev`/`staging`/`prod`, you'd edit `~/.claude/launchdarkly-conventions.md`:
+
+```markdown
+## Default Project and Environments
+- Default project key: `my-app`
+- Environments: `dev`, `staging`, `prod`
+- When I say "production", use environment key: `prod`
+```
+
+Then when you tell Claude "toggle dark-mode on in production," it knows to run:
+```bash
+ldcli flags toggle-on --project my-app --flag dark-mode --environment prod
+```
+
+### Forking Skills for Deep Customization
+
+If you need to modify the skill files themselves (not just conventions), **copy instead of symlink**:
+
+```bash
+# Remove the symlink
+rm ~/.claude/commands/ld-feature-flags.md
+
+# Copy the file (now you own it)
+cp skills/feature-flags.md ~/.claude/commands/ld-feature-flags.md
+
+# Edit as needed
+```
+
+Note: copied files won't auto-update on `git pull`.
+
+## Updating
+
+```bash
+cd ldcli/skills
+git pull
+# Symlinked skills update automatically. Re-run install.sh only if new skills were added:
+./install.sh
+```
+
+The installer is idempotent — it skips files that are already correctly linked and preserves your conventions file.
+
+## Uninstalling
+
+```bash
+cd ldcli/skills
+./install.sh --uninstall
+```
+
+This removes the slash command symlinks and the `CLAUDE.md` block. Your conventions file is preserved (delete `~/.claude/launchdarkly-conventions.md` manually if you want a full cleanup).
+
+## Manual Install
+
+If you prefer not to use the script:
+
+1. Create `~/.claude/commands/` if it doesn't exist
+2. Symlink (or copy) each skill `.md` file into `~/.claude/commands/` with an `ld-` prefix
+3. Add the ldcli context block to `~/.claude/CLAUDE.md` (see install.sh for the exact text)
+4. Copy `conventions.md.example` to `~/.claude/launchdarkly-conventions.md` and customize it

--- a/skills/INSTALL.md
+++ b/skills/INSTALL.md
@@ -42,6 +42,7 @@ That's it. The installer:
 
 | Command | Skill |
 |---------|-------|
+| `/ld-setup` | Install, authenticate, and verify `ldcli` |
 | `/ld-feature-flags` | Create, list, get, toggle, archive, delete flags |
 | `/ld-flag-targeting` | Targeting rules, rollouts, individual targets, prerequisites |
 | `/ld-projects-and-environments` | Manage projects and environments |
@@ -75,6 +76,7 @@ The install uses **symlinks**, so the slash commands always reflect the latest s
 ├── CLAUDE.md                          ← passive ldcli context appended here
 ├── launchdarkly-conventions.md        ← YOUR org customizations (copied, not linked)
 └── commands/
+    ├── ld-setup.md                    → symlink to skills/setup.md
     ├── ld-feature-flags.md            → symlink to skills/feature-flags.md
     ├── ld-flag-targeting.md           → symlink to skills/flag-targeting.md
     ├── ld-projects-and-environments.md → symlink to skills/projects-and-environments.md
@@ -145,9 +147,72 @@ This removes the slash command symlinks and the `CLAUDE.md` block. Your conventi
 
 ## Manual Install
 
-If you prefer not to use the script:
+No script required. Just copy files and paste a text block.
 
-1. Create `~/.claude/commands/` if it doesn't exist
-2. Symlink (or copy) each skill `.md` file into `~/.claude/commands/` with an `ld-` prefix
-3. Add the ldcli context block to `~/.claude/CLAUDE.md` (see install.sh for the exact text)
-4. Copy `conventions.md.example` to `~/.claude/launchdarkly-conventions.md` and customize it
+### 1. Copy skill files
+
+Create the commands directory if it doesn't exist, then copy (or symlink) each skill file with an `ld-` prefix:
+
+```bash
+mkdir -p ~/.claude/commands
+
+# From the skills/ directory, copy each file:
+cp setup.md              ~/.claude/commands/ld-setup.md
+cp feature-flags.md      ~/.claude/commands/ld-feature-flags.md
+cp flag-targeting.md     ~/.claude/commands/ld-flag-targeting.md
+cp projects-and-environments.md ~/.claude/commands/ld-projects-and-environments.md
+cp segments.md           ~/.claude/commands/ld-segments.md
+cp members-and-teams.md  ~/.claude/commands/ld-members-and-teams.md
+cp dev-server.md         ~/.claude/commands/ld-dev-server.md
+cp audit-and-observability.md ~/.claude/commands/ld-audit-and-observability.md
+```
+
+Or use symlinks if you want auto-updates on `git pull` (replace `cp` with `ln -s` using absolute paths).
+
+### 2. Add context to CLAUDE.md
+
+Open (or create) `~/.claude/CLAUDE.md` and paste this block:
+
+```markdown
+<!-- ldcli-skills -->
+## LaunchDarkly CLI (ldcli)
+
+When the user asks about feature flags, environments, projects, segments, or other LaunchDarkly resources, use `ldcli` to fulfill the request. Always use `-o json` for parseable output.
+
+**Before your first ldcli command in a session**, verify it is available by running `which ldcli`. If ldcli is not found, tell the user and use `/ld-setup` for install and auth instructions.
+
+**Skill commands available:** Use `/ld-setup`, `/ld-feature-flags`, `/ld-flag-targeting`, `/ld-projects-and-environments`, `/ld-segments`, `/ld-members-and-teams`, `/ld-dev-server`, or `/ld-audit-and-observability` to load detailed usage reference for a specific area.
+
+**Before making changes:** Always list/get resources first to confirm keys exist. Use `ldcli <resource> --help` to check available flags for any command.
+
+**Conventions:** See ~/.claude/launchdarkly-conventions.md for organization-specific naming, tagging, and safety conventions.
+<!-- ldcli-skills -->
+```
+
+### 3. Set up your conventions file (optional)
+
+```bash
+cp conventions.md.example ~/.claude/launchdarkly-conventions.md
+```
+
+Edit `~/.claude/launchdarkly-conventions.md` to add your org's project keys, environment names, naming conventions, and safety rules.
+
+### Manual uninstall
+
+```bash
+# Remove slash commands
+rm ~/.claude/commands/ld-setup.md
+rm ~/.claude/commands/ld-feature-flags.md
+rm ~/.claude/commands/ld-flag-targeting.md
+rm ~/.claude/commands/ld-projects-and-environments.md
+rm ~/.claude/commands/ld-segments.md
+rm ~/.claude/commands/ld-members-and-teams.md
+rm ~/.claude/commands/ld-dev-server.md
+rm ~/.claude/commands/ld-audit-and-observability.md
+
+# Remove the ldcli block from ~/.claude/CLAUDE.md
+# Delete everything between the two <!-- ldcli-skills --> markers (inclusive)
+
+# Optionally remove conventions
+rm ~/.claude/launchdarkly-conventions.md
+```

--- a/skills/README.md
+++ b/skills/README.md
@@ -14,14 +14,14 @@ See [INSTALL.md](./INSTALL.md) for full setup instructions, customization, and u
 
 ## Prerequisites
 
-- `ldcli` installed and on PATH
-- Authenticated via `ldcli login` or `--access-token` / `LD_ACCESS_TOKEN` env var
-- For JSON output (recommended for agents), use `-o json` on any command
+- [Claude Code](https://claude.ai/claude-code) installed
+- `ldcli` does **not** need to be pre-installed — each skill includes instructions for Claude to detect a missing `ldcli` and offer to install it automatically
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
+| [setup](./setup.md) | Install, authenticate, and verify `ldcli` |
 | [feature-flags](./feature-flags.md) | Create, read, update, toggle, and delete feature flags |
 | [flag-targeting](./flag-targeting.md) | Manage flag targeting rules, rollouts, and individual targets |
 | [projects-and-environments](./projects-and-environments.md) | Manage projects and environments |

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,54 @@
+# LaunchDarkly CLI Agent Skills
+
+AI agent skills for managing LaunchDarkly via `ldcli` — an alternative to the LaunchDarkly MCP server that works with any agent that can run shell commands.
+
+## Quick Start
+
+```bash
+# Install skills into Claude Code
+cd skills/
+./install.sh
+```
+
+See [INSTALL.md](./INSTALL.md) for full setup instructions, customization, and uninstall.
+
+## Prerequisites
+
+- `ldcli` installed and on PATH
+- Authenticated via `ldcli login` or `--access-token` / `LD_ACCESS_TOKEN` env var
+- For JSON output (recommended for agents), use `-o json` on any command
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| [feature-flags](./feature-flags.md) | Create, read, update, toggle, and delete feature flags |
+| [flag-targeting](./flag-targeting.md) | Manage flag targeting rules, rollouts, and individual targets |
+| [projects-and-environments](./projects-and-environments.md) | Manage projects and environments |
+| [segments](./segments.md) | Create and manage audience segments |
+| [members-and-teams](./members-and-teams.md) | Invite members, manage teams and roles |
+| [dev-server](./dev-server.md) | Run a local dev server for flag overrides |
+| [audit-and-observability](./audit-and-observability.md) | Query audit logs, contexts, and metrics |
+
+## Global Flags
+
+All commands support these flags:
+
+| Flag | Description |
+|------|-------------|
+| `--access-token <token>` | LaunchDarkly API access token (or set `LD_ACCESS_TOKEN`) |
+| `-o json` | Output as JSON (recommended for programmatic use) |
+| `--base-uri <uri>` | Custom LaunchDarkly instance URI |
+| `-h` / `--help` | Help for any command |
+
+## Tips for Agents
+
+1. **Always use `-o json`** for parseable output. Default `plaintext` is human-readable but harder to parse.
+2. **Discover available resources** with `ldcli resources` to see all resource commands.
+3. **Get help** on any command: `ldcli <command> [subcommand] --help`
+4. **List before acting**: always list/get resources first to confirm keys and IDs before making changes.
+5. **Semantic patch** for flag updates: use `--semantic-patch` with `ldcli flags update` for readable, intent-based changes.
+
+## Customization
+
+After installing, edit `~/.claude/launchdarkly-conventions.md` to set your org's defaults (project key, environments, naming conventions, safety rules). The skills describe *how* to use ldcli; the conventions file describes *your* standards. See [INSTALL.md](./INSTALL.md#customization) for details.

--- a/skills/audit-and-observability.md
+++ b/skills/audit-and-observability.md
@@ -1,11 +1,6 @@
 # Skill: Audit and Observability
 
-> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
-> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
-> - npm: `npm install -g @launchdarkly/ldcli`
-> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
->
-> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+> **Requires `ldcli`.** Run `which ldcli` to check. If missing, use `/ld-setup` for install and auth instructions.
 
 Query audit logs to track changes, search for contexts, and manage metrics for experiments.
 

--- a/skills/audit-and-observability.md
+++ b/skills/audit-and-observability.md
@@ -1,0 +1,192 @@
+# Skill: Audit and Observability
+
+Query audit logs to track changes, search for contexts, and manage metrics for experiments.
+
+## Audit Log
+
+The audit log records every change made in LaunchDarkly.
+
+### List Audit Log Entries
+
+```bash
+# List recent entries
+ldcli audit-log list -o json
+
+# Get a specific entry
+ldcli audit-log get --id <audit-log-entry-id> -o json
+```
+
+## Contexts
+
+Contexts represent the entities (users, services, devices, etc.) that encounter feature flags.
+
+### Search for Contexts
+
+```bash
+# Search contexts in a project/environment
+ldcli contexts search --project <project-key> --environment <env-key> -o json -d '{
+  "filter": "kind equals \"user\""
+}'
+
+# Search by key prefix
+ldcli contexts search --project <project-key> --environment <env-key> -o json -d '{
+  "filter": "key startsWith \"user-123\""
+}'
+
+# Search by attribute
+ldcli contexts search --project <project-key> --environment <env-key> -o json -d '{
+  "filter": "user.email equals \"alice@example.com\""
+}'
+
+# Fuzzy search across attribute values
+ldcli contexts search --project <project-key> --environment <env-key> -o json -d '{
+  "filter": "q equals \"alice\""
+}'
+```
+
+### List Contexts
+
+```bash
+ldcli contexts list --project <project-key> --environment <env-key> --kind <kind> -o json
+```
+
+### Context Attribute Names and Values
+
+```bash
+# List attribute names for a context kind
+ldcli contexts list-attribute-names --project <project-key> --environment <env-key> -o json
+
+# List values for a specific attribute
+ldcli contexts list-attribute-values --project <project-key> --environment <env-key> --attribute-name <attr> -o json
+```
+
+### Context Kinds
+
+```bash
+# List context kinds
+ldcli contexts list-kinds-key --project <project-key> -o json
+
+# Create or update a context kind
+ldcli contexts replace-kind --project <project-key> --key <kind-key> -o json -d '{
+  "name": "Organization",
+  "description": "Business organizations"
+}'
+```
+
+### Evaluate Flags for a Context
+
+```bash
+ldcli contexts evaluate-instance --project <project-key> --environment <env-key> --id <context-instance-id> -o json
+```
+
+### Delete Context Instances
+
+```bash
+ldcli contexts delete-instances --project <project-key> --environment <env-key> --id <context-instance-id>
+```
+
+## Metrics
+
+Metrics track flag behavior for experiments and observability.
+
+### List Metrics
+
+```bash
+ldcli metrics list --project <project-key> -o json
+```
+
+### Get a Metric
+
+```bash
+ldcli metrics get --project <project-key> --metric <metric-key> -o json
+```
+
+### Create a Metric
+
+```bash
+# Create a custom conversion metric
+ldcli metrics create --project <project-key> -o json -d '{
+  "name": "Button Clicks",
+  "key": "button-clicks",
+  "kind": "custom",
+  "eventKey": "button-click",
+  "isNumeric": false,
+  "description": "Tracks button click events"
+}'
+
+# Create a custom numeric metric
+ldcli metrics create --project <project-key> -o json -d '{
+  "name": "Revenue",
+  "key": "revenue",
+  "kind": "custom",
+  "eventKey": "purchase",
+  "isNumeric": true,
+  "unit": "USD",
+  "description": "Tracks purchase revenue"
+}'
+
+# Create a page view metric
+ldcli metrics create --project <project-key> -o json -d '{
+  "name": "Checkout Page Views",
+  "key": "checkout-views",
+  "kind": "pageview",
+  "urls": [{"kind": "substring", "substring": "/checkout"}],
+  "description": "Tracks visits to checkout pages"
+}'
+```
+
+### Delete a Metric
+
+```bash
+ldcli metrics delete --project <project-key> --metric <metric-key>
+```
+
+## Experiments (Beta)
+
+```bash
+# List experiments
+ldcli experiments-beta list --project <project-key> --environment <env-key> -o json
+
+# Get an experiment
+ldcli experiments-beta get --project <project-key> --environment <env-key> --experiment <experiment-key> -o json
+
+# Create an experiment
+ldcli experiments-beta create --project <project-key> --environment <env-key> -o json -d '{
+  "name": "Checkout Button Test",
+  "key": "checkout-button-test",
+  "maintainerId": "<member-id>",
+  "iteration": {
+    "hypothesis": "A green button will increase conversions",
+    "metrics": [{"key": "button-clicks", "isGroup": false}],
+    "treatments": [
+      {"name": "Control", "baseline": true, "allocationPercent": "50", "flagKey": "checkout-button-color", "variationId": "<variation-id>"},
+      {"name": "Treatment", "baseline": false, "allocationPercent": "50", "flagKey": "checkout-button-color", "variationId": "<variation-id>"}
+    ],
+    "flags": {"checkout-button-color": {"ruleId": "fallthrough", "flagConfigVersion": 1}}
+  }
+}'
+```
+
+## Filter Syntax Reference
+
+For context searches, filters use this syntax:
+
+| Operator | Example |
+|----------|---------|
+| `equals` | `kind equals "user"` |
+| `notEquals` | `kind notEquals "device"` |
+| `anyOf` | `kind anyOf ["user", "device"]` |
+| `startsWith` | `key startsWith "user-"` |
+| `contains` | `kinds contains ["user"]` |
+| `exists` | `*.name exists true` |
+| `before` | `myField before "2024-01-01T00:00:00Z"` |
+| `after` | `myField after "2024-01-01T00:00:00Z"` |
+
+Combine with `,` (AND), `|` (OR), and `()` (grouping).
+
+## Notes
+
+- Contexts are scoped to a project and environment.
+- The audit log entry ID is the `_id` field in list responses.
+- Metric keys and event keys are different: the metric key identifies the metric in the API, while the event key is what your SDK sends.
+- Experiments are a beta feature and use the `experiments-beta` command.

--- a/skills/audit-and-observability.md
+++ b/skills/audit-and-observability.md
@@ -1,5 +1,12 @@
 # Skill: Audit and Observability
 
+> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
+> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
+> - npm: `npm install -g @launchdarkly/ldcli`
+> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
+>
+> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+
 Query audit logs to track changes, search for contexts, and manage metrics for experiments.
 
 ## Audit Log

--- a/skills/conventions.md.example
+++ b/skills/conventions.md.example
@@ -1,0 +1,63 @@
+# LaunchDarkly Conventions
+#
+# This file customizes how AI agents use ldcli for YOUR organization.
+# Edit the sections below to match your team's standards.
+# This file is referenced from ~/.claude/CLAUDE.md and is always in context.
+#
+# Lines starting with # are comments and are ignored by the agent.
+
+## Default Project and Environments
+#
+# Uncomment and set these so the agent uses your defaults without asking:
+#
+# - Default project key: `my-app`
+# - Environments: `dev`, `staging`, `prod`
+# - When I say "production", use environment key: `prod`
+# - When I say "dev" or "local", use environment key: `dev`
+
+## Flag Naming Conventions
+#
+# Uncomment and customize:
+#
+# - Flag keys use kebab-case
+# - Prefix flag keys with the team name: e.g., `platform-dark-mode`, `payments-new-checkout`
+# - Boolean flags should be named as positive assertions: `enable-feature` not `disable-feature`
+
+## Tagging Standards
+#
+# Uncomment and customize:
+#
+# - Always tag new flags with the team name: e.g., `team-platform`
+# - Tag temporary/experiment flags with `temporary`
+# - Tag flags related to incidents with `incident-<number>`
+
+## Flag Creation Defaults
+#
+# Uncomment and customize:
+#
+# - All new flags should be `temporary: true` unless I say otherwise
+# - Always include a description when creating flags
+# - Default flag kind is `boolean` unless specified
+
+## Segments
+#
+# Uncomment and customize:
+#
+# - Segment keys follow the pattern: `<team>-<audience>` (e.g., `platform-beta-users`)
+# - Internal testing segment: `internal-testers`
+
+## Safety Rules
+#
+# Uncomment and customize:
+#
+# - Never toggle flags in `prod` without asking me to confirm first
+# - Never delete flags - archive them instead
+# - Always check flag status before toggling off in production
+
+## Team Context
+#
+# Add any other context that helps the agent work with your LD setup:
+#
+# - Our main SDK is the Node.js server-side SDK
+# - We use LaunchDarkly contexts with kinds: user, organization, device
+# - Our CI/CD pipeline auto-creates flags tagged with `ci-managed` - don't modify those

--- a/skills/dev-server.md
+++ b/skills/dev-server.md
@@ -1,11 +1,6 @@
 # Skill: Dev Server
 
-> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
-> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
-> - npm: `npm install -g @launchdarkly/ldcli`
-> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
->
-> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+> **Requires `ldcli`.** Run `which ldcli` to check. If missing, use `/ld-setup` for install and auth instructions.
 
 Run a local development server that mirrors LaunchDarkly flag state and allows local overrides. This is useful for local development and testing without affecting real environments.
 

--- a/skills/dev-server.md
+++ b/skills/dev-server.md
@@ -1,5 +1,12 @@
 # Skill: Dev Server
 
+> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
+> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
+> - npm: `npm install -g @launchdarkly/ldcli`
+> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
+>
+> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+
 Run a local development server that mirrors LaunchDarkly flag state and allows local overrides. This is useful for local development and testing without affecting real environments.
 
 ## Starting the Dev Server

--- a/skills/dev-server.md
+++ b/skills/dev-server.md
@@ -1,0 +1,150 @@
+# Skill: Dev Server
+
+Run a local development server that mirrors LaunchDarkly flag state and allows local overrides. This is useful for local development and testing without affecting real environments.
+
+## Starting the Dev Server
+
+```bash
+# Start with a specific project and source environment
+ldcli dev-server start --project <project-key> --source <env-key>
+
+# Start with a custom context
+ldcli dev-server start --project <project-key> --source <env-key> \
+  --context '{"kind": "user", "key": "test-user", "email": "test@example.com"}'
+
+# Start with initial flag overrides
+ldcli dev-server start --project <project-key> --source <env-key> \
+  --override '{"my-flag": true, "banner-color": "red"}'
+
+# Start on a custom port
+ldcli dev-server start --port 9000
+
+# Start without continuous sync (snapshot mode)
+ldcli dev-server start --project <project-key> --source <env-key> --sync-once
+```
+
+The dev server runs on `http://localhost:8765` by default.
+
+## Open the UI
+
+```bash
+ldcli dev-server ui
+```
+
+Opens the dev server's web UI in your default browser for visual flag management.
+
+## Managing Projects
+
+The dev server can track multiple projects simultaneously.
+
+```bash
+# List all projects configured in the dev server
+ldcli dev-server list-projects -o json
+
+# Add a project (copies flags from the source environment)
+ldcli dev-server add-project --project <project-key> --source <env-key>
+
+# Add a project with a custom context
+ldcli dev-server add-project --project <project-key> --source <env-key> \
+  --context '{"kind": "user", "key": "dev-user"}'
+
+# Get project details
+ldcli dev-server get-project --project <project-key> -o json
+
+# Get project with overrides and available variations
+ldcli dev-server get-project --project <project-key> --expand overrides --expand availableVariations -o json
+
+# Sync a project's flags from LaunchDarkly
+ldcli dev-server sync-project --project <project-key>
+
+# Update a project's source or context
+ldcli dev-server update-project --project <project-key> --source <new-env-key>
+ldcli dev-server update-project --project <project-key> \
+  --context '{"kind": "user", "key": "different-user"}'
+
+# Remove a project
+ldcli dev-server remove-project --project <project-key>
+```
+
+## Managing Flag Overrides
+
+Override flag values locally without affecting the real LaunchDarkly environment.
+
+```bash
+# Override a boolean flag
+ldcli dev-server add-override --project <project-key> --flag <flag-key> --data 'true'
+
+# Override a string flag
+ldcli dev-server add-override --project <project-key> --flag <flag-key> --data '"new-value"'
+
+# Override a JSON flag
+ldcli dev-server add-override --project <project-key> --flag <flag-key> \
+  --data '{"enabled": true, "limit": 500}'
+
+# Override a number flag
+ldcli dev-server add-override --project <project-key> --flag <flag-key> --data '42'
+
+# Remove a single override (reverts to synced value)
+ldcli dev-server remove-override --project <project-key> --flag <flag-key>
+
+# Remove all overrides for a project
+ldcli dev-server remove-overrides --project <project-key>
+```
+
+## Import/Export
+
+```bash
+# Import a project from a JSON file (server need not be running)
+ldcli dev-server import-project --project <project-key> --file ./project-backup.json
+```
+
+## Common Workflows
+
+### Set up local development
+
+```bash
+# 1. Start the dev server with your project
+ldcli dev-server start --project my-app --source development
+
+# 2. Point your SDK to the dev server instead of LaunchDarkly
+#    SDK base URI: http://localhost:8765
+#    (Configure this in your application's LaunchDarkly SDK initialization)
+
+# 3. Override flags as needed for testing
+ldcli dev-server add-override --project my-app --flag new-feature --data 'true'
+
+# 4. When done, remove overrides
+ldcli dev-server remove-overrides --project my-app
+```
+
+### Test different flag configurations
+
+```bash
+# Override multiple flags for a test scenario
+ldcli dev-server add-override --project my-app --flag feature-a --data 'true'
+ldcli dev-server add-override --project my-app --flag feature-b --data '"variant-2"'
+ldcli dev-server add-override --project my-app --flag rate-limit --data '1000'
+
+# Run your tests...
+
+# Reset to production-like values
+ldcli dev-server remove-overrides --project my-app
+ldcli dev-server sync-project --project my-app
+```
+
+## Dev Server Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--port` | `8765` | Port for the dev server |
+| `--dev-stream-uri` | `https://stream.launchdarkly.com` | Streaming endpoint for flag data |
+| `--cors-enabled` | `false` | Enable CORS headers |
+| `--cors-origin` | `*` | Allowed CORS origin |
+
+## Notes
+
+- The dev server uses SQLite locally to store flag state and overrides.
+- The `--data` value for overrides is the JSON representation of the variation value (not the variation index).
+- The `--source` environment is where the dev server copies initial flag configurations from.
+- The `--sync-once` flag fetches flag data once instead of streaming continuously.
+- The dev server supports both server-side and client-side SDK protocols.

--- a/skills/feature-flags.md
+++ b/skills/feature-flags.md
@@ -1,5 +1,12 @@
 # Skill: Feature Flags
 
+> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
+> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
+> - npm: `npm install -g @launchdarkly/ldcli`
+> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
+>
+> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+
 Manage the lifecycle of feature flags: list, create, get, toggle, update, archive, and delete.
 
 ## List Flags

--- a/skills/feature-flags.md
+++ b/skills/feature-flags.md
@@ -1,0 +1,187 @@
+# Skill: Feature Flags
+
+Manage the lifecycle of feature flags: list, create, get, toggle, update, archive, and delete.
+
+## List Flags
+
+```bash
+# List all flags in a project
+ldcli flags list --project <project-key> -o json
+
+# Filter by environment (reduces response size - recommended)
+ldcli flags list --project <project-key> --env <env-key> -o json
+
+# Search by name/key
+ldcli flags list --project <project-key> --filter "query:my-flag" -o json
+
+# Filter by tag
+ldcli flags list --project <project-key> --tag "beta" -o json
+
+# Filter by state (live, deprecated, archived)
+ldcli flags list --project <project-key> --filter "state:live" -o json
+
+# Paginate results
+ldcli flags list --project <project-key> --limit 10 --offset 0 -o json
+
+# Sort flags
+ldcli flags list --project <project-key> --sort "-creationDate" -o json
+
+# Include full targeting details (prerequisites, targets, rules)
+ldcli flags list --project <project-key> --env production --summary 0 -o json
+```
+
+## Get a Single Flag
+
+```bash
+# Get a flag (all environments)
+ldcli flags get --project <project-key> --flag <flag-key> -o json
+
+# Get a flag filtered to specific environment (recommended - much smaller response)
+ldcli flags get --project <project-key> --flag <flag-key> --env <env-key> -o json
+```
+
+## Create a Flag
+
+```bash
+# Create a boolean flag
+ldcli flags create --project <project-key> -o json -d '{
+  "name": "My New Flag",
+  "key": "my-new-flag",
+  "kind": "boolean",
+  "description": "Controls the new feature",
+  "tags": ["team-platform"],
+  "variations": [
+    {"value": true, "name": "Enabled"},
+    {"value": false, "name": "Disabled"}
+  ],
+  "defaults": {
+    "onVariation": 0,
+    "offVariation": 1
+  }
+}'
+
+# Create a multivariate string flag
+ldcli flags create --project <project-key> -o json -d '{
+  "name": "Banner Color",
+  "key": "banner-color",
+  "kind": "multivariate",
+  "description": "Controls banner color",
+  "variations": [
+    {"value": "red", "name": "Red"},
+    {"value": "blue", "name": "Blue"},
+    {"value": "green", "name": "Green"}
+  ],
+  "defaults": {
+    "onVariation": 0,
+    "offVariation": 2
+  }
+}'
+
+# Create a JSON flag
+ldcli flags create --project <project-key> -o json -d '{
+  "name": "Feature Config",
+  "key": "feature-config",
+  "kind": "multivariate",
+  "variations": [
+    {"value": {"enabled": true, "limit": 100}, "name": "Full"},
+    {"value": {"enabled": false, "limit": 0}, "name": "Off"}
+  ],
+  "defaults": {
+    "onVariation": 0,
+    "offVariation": 1
+  }
+}'
+
+# Clone an existing flag
+ldcli flags create --project <project-key> --clone <source-flag-key> -o json -d '{
+  "name": "Cloned Flag",
+  "key": "cloned-flag"
+}'
+
+# Create a temporary flag (marks it for cleanup)
+ldcli flags create --project <project-key> -o json -d '{
+  "name": "Temporary Experiment",
+  "key": "temp-experiment",
+  "kind": "boolean",
+  "temporary": true,
+  "variations": [
+    {"value": true},
+    {"value": false}
+  ],
+  "defaults": {
+    "onVariation": 0,
+    "offVariation": 1
+  }
+}'
+```
+
+## Toggle a Flag On/Off
+
+```bash
+# Turn a flag ON in an environment
+ldcli flags toggle-on --project <project-key> --flag <flag-key> --environment <env-key>
+
+# Turn a flag OFF in an environment
+ldcli flags toggle-off --project <project-key> --flag <flag-key> --environment <env-key>
+```
+
+## Archive a Flag
+
+Archives a flag across all environments. Archived flags don't appear in the default list.
+
+```bash
+ldcli flags archive --project <project-key> --flag <flag-key>
+```
+
+## Delete a Flag
+
+Permanently deletes a flag in all environments. Use with caution.
+
+```bash
+ldcli flags delete --project <project-key> --flag <flag-key>
+```
+
+## Get Flag Status
+
+```bash
+# Status in a specific environment
+ldcli flags get-status --project <project-key> --flag <flag-key> --environment <env-key> -o json
+
+# Status across all environments
+ldcli flags get-status-across-environments --project <project-key> --flag <flag-key> -o json
+```
+
+## Common Workflows
+
+### Create and immediately enable a boolean flag
+
+```bash
+# 1. Create the flag
+ldcli flags create --project my-project -o json -d '{
+  "name": "New Feature",
+  "key": "new-feature",
+  "kind": "boolean",
+  "variations": [{"value": true}, {"value": false}],
+  "defaults": {"onVariation": 0, "offVariation": 1}
+}'
+
+# 2. Toggle it on in the desired environment
+ldcli flags toggle-on --project my-project --flag new-feature --environment production
+```
+
+### Find and clean up stale flags
+
+```bash
+# List archived flags
+ldcli flags list --project my-project --filter "state:archived" -o json
+
+# List flags not evaluated recently (requires filterEnv)
+ldcli flags list --project my-project --filter 'evaluated:{"after":1690000000000},filterEnv:production' -o json
+```
+
+## Notes
+
+- Flag keys must be unique within a project and can contain only lowercase letters, numbers, periods, and hyphens.
+- `kind` is either `"boolean"` or `"multivariate"` (for string, number, or JSON variations).
+- Newly created flags default to OFF in all environments.
+- The `--env` filter on `get`/`list` significantly reduces response size and is recommended.

--- a/skills/feature-flags.md
+++ b/skills/feature-flags.md
@@ -1,11 +1,6 @@
 # Skill: Feature Flags
 
-> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
-> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
-> - npm: `npm install -g @launchdarkly/ldcli`
-> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
->
-> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+> **Requires `ldcli`.** Run `which ldcli` to check. If missing, use `/ld-setup` for install and auth instructions.
 
 Manage the lifecycle of feature flags: list, create, get, toggle, update, archive, and delete.
 

--- a/skills/flag-targeting.md
+++ b/skills/flag-targeting.md
@@ -1,11 +1,6 @@
 # Skill: Flag Targeting
 
-> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
-> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
-> - npm: `npm install -g @launchdarkly/ldcli`
-> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
->
-> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+> **Requires `ldcli`.** Run `which ldcli` to check. If missing, use `/ld-setup` for install and auth instructions.
 
 Update flag targeting rules, percentage rollouts, individual user/context targets, and default variations using semantic patch.
 

--- a/skills/flag-targeting.md
+++ b/skills/flag-targeting.md
@@ -1,0 +1,268 @@
+# Skill: Flag Targeting
+
+Update flag targeting rules, percentage rollouts, individual user/context targets, and default variations using semantic patch.
+
+## How Flag Updates Work
+
+`ldcli flags update` supports three patch formats. **Semantic patch is recommended** for agents because it uses readable, intent-based instructions rather than JSON pointer paths.
+
+```bash
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json \
+  -d '<semantic-patch-json>'
+```
+
+A semantic patch body has this structure:
+
+```json
+{
+  "comment": "Optional description of the change",
+  "environmentKey": "environment-key",
+  "instructions": [
+    { "kind": "instructionName", ...params }
+  ]
+}
+```
+
+**Important**: To find variation IDs and rule IDs needed for targeting, first get the flag:
+
+```bash
+ldcli flags get --project <project-key> --flag <flag-key> --env <env-key> -o json
+```
+
+The response contains:
+- `variations[].\_id` - variation IDs
+- `environments.<env>.rules[].\_id` - rule IDs
+- `environments.<env>.rules[].clauses[].\_id` - clause IDs
+
+## Toggle Flag On/Off
+
+The simplest way:
+
+```bash
+ldcli flags toggle-on --project <project-key> --flag <flag-key> --environment <env-key>
+ldcli flags toggle-off --project <project-key> --flag <flag-key> --environment <env-key>
+```
+
+Or via semantic patch:
+
+```bash
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{ "kind": "turnFlagOn" }]
+}'
+```
+
+## Individual Context Targeting
+
+Add specific contexts to receive a particular variation:
+
+```bash
+# Add individual targets
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "addTargets",
+    "contextKind": "user",
+    "variationId": "<variation-id>",
+    "values": ["user-key-1", "user-key-2"]
+  }]
+}'
+
+# Remove individual targets
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "removeTargets",
+    "contextKind": "user",
+    "variationId": "<variation-id>",
+    "values": ["user-key-1"]
+  }]
+}'
+```
+
+## Add a Targeting Rule
+
+Targeting rules let you serve specific variations based on context attributes:
+
+```bash
+# Serve a variation to users in specific countries
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "addRule",
+    "variationId": "<variation-id>",
+    "clauses": [{
+      "contextKind": "user",
+      "attribute": "country",
+      "op": "in",
+      "negate": false,
+      "values": ["US", "CA"]
+    }]
+  }]
+}'
+
+# Serve a percentage rollout based on a rule
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "addRule",
+    "clauses": [{
+      "contextKind": "user",
+      "attribute": "plan",
+      "op": "in",
+      "negate": false,
+      "values": ["enterprise"]
+    }],
+    "rolloutContextKind": "user",
+    "rolloutWeights": {
+      "<true-variation-id>": 50000,
+      "<false-variation-id>": 50000
+    }
+  }]
+}'
+```
+
+### Clause Operators
+
+| Operator | Description |
+|----------|-------------|
+| `in` | Matches if attribute value is in the list |
+| `endsWith` | String ends with |
+| `startsWith` | String starts with |
+| `matches` | Regex match |
+| `contains` | String contains |
+| `lessThan` | Numeric less than |
+| `lessThanOrEqual` | Numeric less than or equal |
+| `greaterThan` | Numeric greater than |
+| `greaterThanOrEqual` | Numeric greater than or equal |
+| `before` | Date is before |
+| `after` | Date is after |
+| `segmentMatch` | Context is in a segment |
+| `semVerEqual` | Semantic version equals |
+| `semVerLessThan` | Semantic version less than |
+| `semVerGreaterThan` | Semantic version greater than |
+
+Set `"negate": true` to invert any operator.
+
+## Modify Existing Rules
+
+```bash
+# Add clauses to an existing rule
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "addClauses",
+    "ruleId": "<rule-id>",
+    "clauses": [{
+      "contextKind": "user",
+      "attribute": "email",
+      "op": "endsWith",
+      "negate": false,
+      "values": ["@example.com"]
+    }]
+  }]
+}'
+
+# Remove a rule
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "removeRule",
+    "ruleId": "<rule-id>"
+  }]
+}'
+
+# Reorder rules
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "reorderRules",
+    "ruleIds": ["<rule-id-1>", "<rule-id-2>", "<rule-id-3>"]
+  }]
+}'
+```
+
+## Change Default Variations
+
+The "fallthrough" is what's served when targeting is ON but no rules match:
+
+```bash
+# Set fallthrough to a specific variation
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "updateFallthroughVariationOrRollout",
+    "variationId": "<variation-id>"
+  }]
+}'
+
+# Set fallthrough to a percentage rollout
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "updateFallthroughVariationOrRollout",
+    "rolloutWeights": {
+      "<variation-id-true>": 20000,
+      "<variation-id-false>": 80000
+    },
+    "rolloutContextKind": "user"
+  }]
+}'
+
+# Change the off variation (served when flag is OFF)
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "updateOffVariation",
+    "variationId": "<variation-id>"
+  }]
+}'
+```
+
+## Add Prerequisites
+
+Require another flag to be serving a specific variation before this flag evaluates:
+
+```bash
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "addPrerequisite",
+    "key": "prerequisite-flag-key",
+    "variationId": "<variation-id-of-prerequisite>"
+  }]
+}'
+```
+
+## Multiple Instructions in One Patch
+
+You can combine multiple instructions in a single update:
+
+```bash
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "comment": "Enable flag with 20% rollout for beta users",
+  "environmentKey": "production",
+  "instructions": [
+    { "kind": "turnFlagOn" },
+    {
+      "kind": "addRule",
+      "variationId": "<variation-id>",
+      "clauses": [{
+        "contextKind": "user",
+        "attribute": "beta",
+        "op": "in",
+        "negate": false,
+        "values": [true]
+      }]
+    }
+  ]
+}'
+```
+
+## Notes
+
+- Rollout weights are in thousandths of a percent (0-100000). So 50000 = 50%.
+- All rollout weights for a rule must sum to 100000.
+- When adding individual targets, a context key cannot appear in multiple variations.
+- Rule evaluation is ordered: the first matching rule wins. Use `reorderRules` to change priority.
+- Semantic patch requires `--semantic-patch` flag on the CLI command.

--- a/skills/flag-targeting.md
+++ b/skills/flag-targeting.md
@@ -1,5 +1,12 @@
 # Skill: Flag Targeting
 
+> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
+> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
+> - npm: `npm install -g @launchdarkly/ldcli`
+> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
+>
+> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+
 Update flag targeting rules, percentage rollouts, individual user/context targets, and default variations using semantic patch.
 
 ## How Flag Updates Work

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -81,6 +81,41 @@ echo "LaunchDarkly CLI Skills for Claude Code"
 echo "========================================"
 echo ""
 
+# --- Step 0: Check for ldcli ---
+print_step "Checking for ldcli..."
+if command -v ldcli &>/dev/null; then
+  ldcli_version=$(ldcli --version 2>&1 || true)
+  print_success "Found ldcli (${ldcli_version})"
+else
+  echo ""
+  echo "  WARNING: ldcli is not installed or not on your PATH."
+  echo ""
+  echo "  The skills will be installed, but Claude won't be able to run"
+  echo "  ldcli commands until it's installed. Install options:"
+  echo ""
+  echo "    macOS (Homebrew):"
+  echo "      brew tap launchdarkly/homebrew-tap"
+  echo "      brew install ldcli"
+  echo ""
+  echo "    npm:"
+  echo "      npm install -g @launchdarkly/ldcli"
+  echo ""
+  echo "    Docker:"
+  echo "      docker pull launchdarkly/ldcli"
+  echo ""
+  echo "    Binary downloads (Linux/Windows):"
+  echo "      https://github.com/launchdarkly/ldcli/releases"
+  echo ""
+  read -r -p "  Continue installing skills anyway? [Y/n] " response
+  case "$response" in
+    [nN]*)
+      echo "  Aborted."
+      exit 0
+      ;;
+  esac
+  echo ""
+fi
+
 # --- Step 1: Create commands directory ---
 print_step "Checking ${COMMANDS_DIR}..."
 if [ ! -d "$COMMANDS_DIR" ]; then
@@ -128,7 +163,14 @@ print_step "Configuring ${CLAUDE_MD}..."
 CLAUDE_MD_BLOCK="${CLAUDE_MD_MARKER}
 ## LaunchDarkly CLI (ldcli)
 
-You have access to \`ldcli\`, the LaunchDarkly CLI, for managing feature flags, projects, environments, segments, and more. Always use \`-o json\` for parseable output.
+When the user asks about feature flags, environments, projects, segments, or other LaunchDarkly resources, use \`ldcli\` to fulfill the request. Always use \`-o json\` for parseable output.
+
+**Before your first ldcli command in a session**, verify it is available by running \`which ldcli\`. If ldcli is not found, tell the user and offer to install it:
+- macOS: \`brew tap launchdarkly/homebrew-tap && brew install ldcli\`
+- npm: \`npm install -g @launchdarkly/ldcli\`
+- Docker: \`docker pull launchdarkly/ldcli\`
+- Binary downloads: https://github.com/launchdarkly/ldcli/releases
+After installing, the user must authenticate with \`ldcli login\` or set \`LD_ACCESS_TOKEN\`.
 
 **Skill commands available:** Use \`/ld-feature-flags\`, \`/ld-flag-targeting\`, \`/ld-projects-and-environments\`, \`/ld-segments\`, \`/ld-members-and-teams\`, \`/ld-dev-server\`, or \`/ld-audit-and-observability\` to load detailed usage reference for a specific area.
 

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# LaunchDarkly CLI Skills Installer for Claude Code
+# Installs ldcli agent skills as slash commands and passive context.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_DIR="${HOME}/.claude"
+COMMANDS_DIR="${CLAUDE_DIR}/commands"
+CLAUDE_MD="${CLAUDE_DIR}/CLAUDE.md"
+CONVENTIONS_FILE="${CLAUDE_DIR}/launchdarkly-conventions.md"
+
+# Skill files to install (everything except non-skill files)
+SKILL_FILES=(
+  "feature-flags.md"
+  "flag-targeting.md"
+  "projects-and-environments.md"
+  "segments.md"
+  "members-and-teams.md"
+  "dev-server.md"
+  "audit-and-observability.md"
+)
+
+# The block we add to CLAUDE.md (used for detection and content)
+CLAUDE_MD_MARKER="<!-- ldcli-skills -->"
+
+print_step() {
+  echo "  → $1"
+}
+
+print_success() {
+  echo "  OK: $1"
+}
+
+print_skip() {
+  echo "  skip: $1"
+}
+
+# --- Uninstall mode ---
+if [ "${1:-}" = "--uninstall" ]; then
+  echo ""
+  echo "Uninstalling LaunchDarkly CLI Skills"
+  echo "====================================="
+  echo ""
+
+  print_step "Removing slash commands..."
+  for file in "${SKILL_FILES[@]}"; do
+    cmd_name="${file%.md}"
+    dest="${COMMANDS_DIR}/ld-${cmd_name}.md"
+    if [ -L "$dest" ] || [ -f "$dest" ]; then
+      rm "$dest"
+      print_success "Removed /ld-${cmd_name}"
+    fi
+  done
+
+  print_step "Removing ldcli block from CLAUDE.md..."
+  if [ -f "$CLAUDE_MD" ] && grep -q "$CLAUDE_MD_MARKER" "$CLAUDE_MD"; then
+    tmp_file=$(mktemp)
+    awk -v marker="$CLAUDE_MD_MARKER" '
+      BEGIN { skip=0 }
+      $0 == marker { skip=!skip; next }
+      !skip { print }
+    ' "$CLAUDE_MD" > "$tmp_file"
+    # Remove trailing blank lines left behind
+    sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$tmp_file" > "$CLAUDE_MD"
+    rm "$tmp_file"
+    print_success "Removed ldcli block from CLAUDE.md"
+  else
+    print_skip "No ldcli block found in CLAUDE.md"
+  fi
+
+  echo ""
+  echo "Note: ${CONVENTIONS_FILE} was NOT removed (preserving your customizations)."
+  echo "      Delete it manually if you no longer need it."
+  echo ""
+  exit 0
+fi
+
+echo ""
+echo "LaunchDarkly CLI Skills for Claude Code"
+echo "========================================"
+echo ""
+
+# --- Step 1: Create commands directory ---
+print_step "Checking ${COMMANDS_DIR}..."
+if [ ! -d "$COMMANDS_DIR" ]; then
+  mkdir -p "$COMMANDS_DIR"
+  print_success "Created ${COMMANDS_DIR}"
+else
+  print_skip "Already exists"
+fi
+
+# --- Step 2: Symlink skill files ---
+echo ""
+print_step "Installing skill commands..."
+for file in "${SKILL_FILES[@]}"; do
+  src="${SCRIPT_DIR}/${file}"
+  # Strip .md extension for the command name
+  cmd_name="${file%.md}"
+  dest="${COMMANDS_DIR}/ld-${cmd_name}.md"
+
+  if [ ! -f "$src" ]; then
+    echo "  WARN: ${file} not found in ${SCRIPT_DIR}, skipping"
+    continue
+  fi
+
+  if [ -L "$dest" ]; then
+    # Already a symlink - check if it points to the right place
+    current_target="$(readlink "$dest")"
+    if [ "$current_target" = "$src" ]; then
+      print_skip "/ld-${cmd_name} already linked"
+      continue
+    fi
+    rm "$dest"
+  elif [ -f "$dest" ]; then
+    echo "  WARN: ${dest} exists as a regular file, skipping (remove it manually to install)"
+    continue
+  fi
+
+  ln -s "$src" "$dest"
+  print_success "/ld-${cmd_name} → ${file}"
+done
+
+# --- Step 3: Add CLAUDE.md block ---
+echo ""
+print_step "Configuring ${CLAUDE_MD}..."
+
+CLAUDE_MD_BLOCK="${CLAUDE_MD_MARKER}
+## LaunchDarkly CLI (ldcli)
+
+You have access to \`ldcli\`, the LaunchDarkly CLI, for managing feature flags, projects, environments, segments, and more. Always use \`-o json\` for parseable output.
+
+**Skill commands available:** Use \`/ld-feature-flags\`, \`/ld-flag-targeting\`, \`/ld-projects-and-environments\`, \`/ld-segments\`, \`/ld-members-and-teams\`, \`/ld-dev-server\`, or \`/ld-audit-and-observability\` to load detailed usage reference for a specific area.
+
+**Before making changes:** Always list/get resources first to confirm keys exist. Use \`ldcli <resource> --help\` to check available flags for any command.
+
+**Conventions:** See ${CONVENTIONS_FILE} for organization-specific naming, tagging, and safety conventions.
+${CLAUDE_MD_MARKER}"
+
+if [ -f "$CLAUDE_MD" ] && grep -q "$CLAUDE_MD_MARKER" "$CLAUDE_MD"; then
+  # Replace existing block: remove from first marker to second marker, write new block
+  tmp_file=$(mktemp)
+  awk -v marker="$CLAUDE_MD_MARKER" '
+    BEGIN { skip=0 }
+    $0 == marker { skip=!skip; next }
+    !skip { print }
+  ' "$CLAUDE_MD" > "$tmp_file"
+  mv "$tmp_file" "$CLAUDE_MD"
+  # Now append the fresh block
+  echo "" >> "$CLAUDE_MD"
+  echo "$CLAUDE_MD_BLOCK" >> "$CLAUDE_MD"
+  print_success "Updated existing ldcli block in CLAUDE.md"
+else
+  # Append new block
+  if [ -f "$CLAUDE_MD" ]; then
+    echo "" >> "$CLAUDE_MD"
+  fi
+  echo "$CLAUDE_MD_BLOCK" >> "$CLAUDE_MD"
+  print_success "Added ldcli block to CLAUDE.md"
+fi
+
+# --- Step 4: Install conventions template ---
+echo ""
+print_step "Checking conventions file..."
+if [ ! -f "$CONVENTIONS_FILE" ]; then
+  cp "${SCRIPT_DIR}/conventions.md.example" "$CONVENTIONS_FILE"
+  print_success "Created ${CONVENTIONS_FILE}"
+  echo "         Edit this file to add your org's naming, tagging, and safety conventions."
+else
+  print_skip "Already exists (your customizations are preserved)"
+fi
+
+# --- Done ---
+echo ""
+echo "Installation complete!"
+echo ""
+echo "What was installed:"
+echo "  1. Slash commands: /ld-feature-flags, /ld-flag-targeting, etc."
+echo "  2. Passive context in ~/.claude/CLAUDE.md (agent auto-discovers ldcli)"
+echo "  3. Conventions file at ${CONVENTIONS_FILE}"
+echo ""
+echo "Next steps:"
+echo "  - Edit ${CONVENTIONS_FILE} to match your org's conventions"
+echo "  - Start a Claude Code session and try: \"list all flags in my project\""
+echo "  - Or use a slash command: /ld-feature-flags"
+echo ""
+echo "To uninstall, run: $0 --uninstall"
+echo ""

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -12,6 +12,7 @@ CONVENTIONS_FILE="${CLAUDE_DIR}/launchdarkly-conventions.md"
 
 # Skill files to install (everything except non-skill files)
 SKILL_FILES=(
+  "setup.md"
   "feature-flags.md"
   "flag-targeting.md"
   "projects-and-environments.md"
@@ -165,12 +166,7 @@ CLAUDE_MD_BLOCK="${CLAUDE_MD_MARKER}
 
 When the user asks about feature flags, environments, projects, segments, or other LaunchDarkly resources, use \`ldcli\` to fulfill the request. Always use \`-o json\` for parseable output.
 
-**Before your first ldcli command in a session**, verify it is available by running \`which ldcli\`. If ldcli is not found, tell the user and offer to install it:
-- macOS: \`brew tap launchdarkly/homebrew-tap && brew install ldcli\`
-- npm: \`npm install -g @launchdarkly/ldcli\`
-- Docker: \`docker pull launchdarkly/ldcli\`
-- Binary downloads: https://github.com/launchdarkly/ldcli/releases
-After installing, the user must authenticate with \`ldcli login\` or set \`LD_ACCESS_TOKEN\`.
+**Before your first ldcli command in a session**, verify it is available by running \`which ldcli\`. If ldcli is not found, tell the user and use \`/ld-setup\` for install and auth instructions.
 
 **Skill commands available:** Use \`/ld-feature-flags\`, \`/ld-flag-targeting\`, \`/ld-projects-and-environments\`, \`/ld-segments\`, \`/ld-members-and-teams\`, \`/ld-dev-server\`, or \`/ld-audit-and-observability\` to load detailed usage reference for a specific area.
 

--- a/skills/members-and-teams.md
+++ b/skills/members-and-teams.md
@@ -1,11 +1,6 @@
 # Skill: Members and Teams
 
-> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
-> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
-> - npm: `npm install -g @launchdarkly/ldcli`
-> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
->
-> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+> **Requires `ldcli`.** Run `which ldcli` to check. If missing, use `/ld-setup` for install and auth instructions.
 
 Manage account members, invite new users, and organize them into teams with custom roles.
 

--- a/skills/members-and-teams.md
+++ b/skills/members-and-teams.md
@@ -1,5 +1,12 @@
 # Skill: Members and Teams
 
+> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
+> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
+> - npm: `npm install -g @launchdarkly/ldcli`
+> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
+>
+> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+
 Manage account members, invite new users, and organize them into teams with custom roles.
 
 ## Members

--- a/skills/members-and-teams.md
+++ b/skills/members-and-teams.md
@@ -1,0 +1,167 @@
+# Skill: Members and Teams
+
+Manage account members, invite new users, and organize them into teams with custom roles.
+
+## Members
+
+### List Members
+
+```bash
+ldcli members list -o json
+```
+
+### Get a Member
+
+```bash
+ldcli members get --id <member-id> -o json
+```
+
+### Invite New Members
+
+```bash
+# Invite with default role (reader)
+ldcli members invite --emails "alice@example.com,bob@example.com"
+
+# Invite with a specific role
+ldcli members invite --emails "carol@example.com" --role writer
+
+# Available built-in roles: reader, writer, admin
+```
+
+### Update a Member
+
+```bash
+ldcli members update --id <member-id> -o json -d '[
+  {"op": "replace", "path": "/role", "value": "writer"}
+]'
+```
+
+### Delete a Member
+
+```bash
+ldcli members delete --id <member-id>
+```
+
+## Teams (Enterprise)
+
+### List Teams
+
+```bash
+ldcli teams list -o json
+```
+
+### Get a Team
+
+```bash
+ldcli teams get --team <team-key> -o json
+```
+
+### Create a Team
+
+```bash
+ldcli teams create -o json -d '{
+  "name": "Platform Team",
+  "key": "platform-team",
+  "description": "Manages platform infrastructure flags"
+}'
+```
+
+### Add Members to a Team
+
+```bash
+ldcli teams create-members --team <team-key> -o json -d '[
+  {"memberId": "<member-id-1>"},
+  {"memberId": "<member-id-2>"}
+]'
+```
+
+### List Team Maintainers and Roles
+
+```bash
+ldcli teams list-maintainers --team <team-key> -o json
+ldcli teams list-roles --team <team-key> -o json
+```
+
+### Update a Team
+
+```bash
+ldcli teams update --team <team-key> -o json --semantic-patch -d '{
+  "instructions": [{
+    "kind": "addCustomRoles",
+    "values": ["<custom-role-key>"]
+  }]
+}'
+```
+
+### Delete a Team
+
+```bash
+ldcli teams delete --team <team-key>
+```
+
+## Custom Roles (Enterprise)
+
+### List Custom Roles
+
+```bash
+ldcli custom-roles list -o json
+```
+
+### Get a Custom Role
+
+```bash
+ldcli custom-roles get --id <role-id> -o json
+```
+
+### Create a Custom Role
+
+```bash
+ldcli custom-roles create -o json -d '{
+  "name": "Flag Manager",
+  "key": "flag-manager",
+  "description": "Can manage flags but not projects",
+  "policy": [
+    {
+      "effect": "allow",
+      "actions": ["*"],
+      "resources": ["proj/*:env/*:flag/*"]
+    },
+    {
+      "effect": "deny",
+      "actions": ["deleteProject"],
+      "resources": ["proj/*"]
+    }
+  ]
+}'
+```
+
+### Delete a Custom Role
+
+```bash
+ldcli custom-roles delete --id <role-id>
+```
+
+## Common Workflows
+
+### Invite a new team member with a custom role
+
+```bash
+# 1. Invite the member
+ldcli members invite --emails "newuser@example.com" --role reader
+
+# 2. Find their member ID
+ldcli members list -o json
+# Look for the member in the response
+
+# 3. Add them to a team (which may grant additional roles)
+ldcli teams create-members --team platform-team -o json -d '[
+  {"memberId": "<member-id>"}
+]'
+```
+
+## Notes
+
+- Member IDs are returned in the `_id` field of member responses.
+- Teams and custom roles are Enterprise features.
+- Built-in roles: `reader` (view only), `writer` (can modify), `admin` (full access).
+- Custom role policies use a resource specifier syntax: `proj/<key>:env/<key>:flag/<key>`.

--- a/skills/projects-and-environments.md
+++ b/skills/projects-and-environments.md
@@ -1,11 +1,6 @@
 # Skill: Projects and Environments
 
-> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
-> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
-> - npm: `npm install -g @launchdarkly/ldcli`
-> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
->
-> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+> **Requires `ldcli`.** Run `which ldcli` to check. If missing, use `/ld-setup` for install and auth instructions.
 
 Manage LaunchDarkly projects and their environments. Projects contain feature flags; environments (e.g., production, staging, development) contain the flag configurations and targeting rules.
 

--- a/skills/projects-and-environments.md
+++ b/skills/projects-and-environments.md
@@ -1,0 +1,180 @@
+# Skill: Projects and Environments
+
+Manage LaunchDarkly projects and their environments. Projects contain feature flags; environments (e.g., production, staging, development) contain the flag configurations and targeting rules.
+
+## Projects
+
+### List Projects
+
+```bash
+# List all projects
+ldcli projects list -o json
+
+# Search by name or key
+ldcli projects list --filter "query:my-project" -o json
+
+# Include environments in the response
+ldcli projects list --expand "environments" -o json
+
+# Paginate
+ldcli projects list --limit 10 --offset 0 -o json
+
+# Sort
+ldcli projects list --sort "name" -o json
+ldcli projects list --sort "-createdOn" -o json   # descending
+```
+
+### Get a Project
+
+```bash
+ldcli projects get --project <project-key> -o json
+```
+
+### Create a Project
+
+```bash
+ldcli projects create -o json -d '{
+  "name": "My Project",
+  "key": "my-project",
+  "tags": ["team-platform"]
+}'
+
+# Create with custom default environments
+ldcli projects create -o json -d '{
+  "name": "My Project",
+  "key": "my-project",
+  "environments": [
+    {"name": "Development", "key": "development", "color": "339933"},
+    {"name": "Staging", "key": "staging", "color": "FF9900"},
+    {"name": "Production", "key": "production", "color": "CC0000"}
+  ]
+}'
+```
+
+### Update a Project
+
+```bash
+# Uses JSON Patch format
+ldcli projects update --project <project-key> -o json -d '[
+  {"op": "replace", "path": "/name", "value": "Updated Project Name"},
+  {"op": "replace", "path": "/tags", "value": ["new-tag"]}
+]'
+```
+
+### Delete a Project
+
+```bash
+ldcli projects delete --project <project-key>
+```
+
+### Flag Defaults
+
+```bash
+# Get flag defaults for a project
+ldcli projects get-flag-defaults --project <project-key> -o json
+
+# Update flag defaults
+ldcli projects update-flag-defaults --project <project-key> -o json -d '[
+  {"op": "replace", "path": "/defaultClientSideAvailability/usingMobileKey", "value": true}
+]'
+```
+
+## Environments
+
+### List Environments
+
+```bash
+ldcli environments list --project <project-key> -o json
+```
+
+### Get an Environment
+
+```bash
+ldcli environments get --project <project-key> --environment <env-key> -o json
+```
+
+### Create an Environment
+
+```bash
+ldcli environments create --project <project-key> -o json -d '{
+  "name": "Staging",
+  "key": "staging",
+  "color": "FF9900"
+}'
+
+# With additional options
+ldcli environments create --project <project-key> -o json -d '{
+  "name": "Production",
+  "key": "production",
+  "color": "CC0000",
+  "defaultTtl": 60,
+  "secureMode": true,
+  "confirmChanges": true,
+  "requireComments": true,
+  "tags": ["critical"]
+}'
+```
+
+### Update an Environment
+
+```bash
+# Uses JSON Patch format
+ldcli environments update --project <project-key> --environment <env-key> -o json -d '[
+  {"op": "replace", "path": "/name", "value": "New Environment Name"},
+  {"op": "replace", "path": "/color", "value": "0000CC"}
+]'
+```
+
+### Delete an Environment
+
+```bash
+ldcli environments delete --project <project-key> --environment <env-key>
+```
+
+### Reset SDK Keys
+
+```bash
+# Reset server-side SDK key
+ldcli environments reset-sdk-key --project <project-key> --environment <env-key> -o json
+
+# Reset mobile SDK key
+ldcli environments reset-mobile-key --project <project-key> --environment <env-key> -o json
+```
+
+## Common Workflows
+
+### Set up a new project with standard environments
+
+```bash
+# Create the project with environments
+ldcli projects create -o json -d '{
+  "name": "Payment Service",
+  "key": "payment-service",
+  "tags": ["backend"],
+  "environments": [
+    {"name": "Development", "key": "dev", "color": "339933"},
+    {"name": "QA", "key": "qa", "color": "0066FF"},
+    {"name": "Staging", "key": "staging", "color": "FF9900"},
+    {"name": "Production", "key": "production", "color": "CC0000", "confirmChanges": true, "requireComments": true}
+  ]
+}'
+```
+
+### Discover project keys
+
+When you don't know the project key, list projects first:
+
+```bash
+ldcli projects list -o json
+```
+
+Then use the `key` field from the response.
+
+## Notes
+
+- Project keys must be unique within an account.
+- Environment keys must be unique within a project.
+- Color is a 6-character hex string (no `#` prefix).
+- `defaultTtl` is in minutes: how long the SDK can cache flag values.
+- `secureMode` ensures context keys are not exposed client-side (requires SDK support).
+- `confirmChanges` and `requireComments` enforce a safety workflow in the UI.

--- a/skills/projects-and-environments.md
+++ b/skills/projects-and-environments.md
@@ -1,5 +1,12 @@
 # Skill: Projects and Environments
 
+> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
+> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
+> - npm: `npm install -g @launchdarkly/ldcli`
+> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
+>
+> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+
 Manage LaunchDarkly projects and their environments. Projects contain feature flags; environments (e.g., production, staging, development) contain the flag configurations and targeting rules.
 
 ## Projects

--- a/skills/segments.md
+++ b/skills/segments.md
@@ -1,11 +1,6 @@
 # Skill: Segments
 
-> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
-> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
-> - npm: `npm install -g @launchdarkly/ldcli`
-> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
->
-> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+> **Requires `ldcli`.** Run `which ldcli` to check. If missing, use `/ld-setup` for install and auth instructions.
 
 Manage audience segments. Segments are reusable groups of contexts that can be referenced in flag targeting rules. They are scoped to a project and environment.
 

--- a/skills/segments.md
+++ b/skills/segments.md
@@ -1,0 +1,128 @@
+# Skill: Segments
+
+Manage audience segments. Segments are reusable groups of contexts that can be referenced in flag targeting rules. They are scoped to a project and environment.
+
+## List Segments
+
+```bash
+ldcli segments list --project <project-key> --environment <env-key> -o json
+```
+
+## Get a Segment
+
+```bash
+ldcli segments get --project <project-key> --environment <env-key> --segment <segment-key> -o json
+```
+
+## Create a Segment
+
+```bash
+# Create a rule-based segment
+ldcli segments create --project <project-key> --environment <env-key> -o json -d '{
+  "name": "Beta Users",
+  "key": "beta-users",
+  "description": "Users opted into the beta program",
+  "tags": ["beta"]
+}'
+
+# Create a segment with included/excluded keys
+ldcli segments create --project <project-key> --environment <env-key> -o json -d '{
+  "name": "VIP Customers",
+  "key": "vip-customers",
+  "included": ["user-key-1", "user-key-2"],
+  "excluded": ["user-key-3"]
+}'
+```
+
+## Update a Segment
+
+Uses JSON Patch or semantic patch. Semantic patch is recommended:
+
+```bash
+# Add individual targets to a segment
+ldcli segments update --project <project-key> --environment <env-key> --segment <segment-key> --semantic-patch -o json -d '{
+  "instructions": [{
+    "kind": "addIncludedTargets",
+    "contextKind": "user",
+    "values": ["user-key-4", "user-key-5"]
+  }]
+}'
+
+# Remove individual targets
+ldcli segments update --project <project-key> --environment <env-key> --segment <segment-key> --semantic-patch -o json -d '{
+  "instructions": [{
+    "kind": "removeIncludedTargets",
+    "contextKind": "user",
+    "values": ["user-key-4"]
+  }]
+}'
+
+# Add excluded targets
+ldcli segments update --project <project-key> --environment <env-key> --segment <segment-key> --semantic-patch -o json -d '{
+  "instructions": [{
+    "kind": "addExcludedTargets",
+    "contextKind": "user",
+    "values": ["user-key-6"]
+  }]
+}'
+
+# Add a targeting rule to the segment
+ldcli segments update --project <project-key> --environment <env-key> --segment <segment-key> --semantic-patch -o json -d '{
+  "instructions": [{
+    "kind": "addRule",
+    "clauses": [{
+      "contextKind": "user",
+      "attribute": "email",
+      "op": "endsWith",
+      "negate": false,
+      "values": ["@example.com"]
+    }]
+  }]
+}'
+```
+
+## Delete a Segment
+
+```bash
+ldcli segments delete --project <project-key> --environment <env-key> --segment <segment-key>
+```
+
+## Check Segment Membership
+
+```bash
+# Check if a specific context is in a big segment
+ldcli segments get-membership-for-context \
+  --project <project-key> \
+  --environment <env-key> \
+  --segment <segment-key> \
+  --context <context-key> \
+  -o json
+```
+
+## Using Segments in Flag Targeting
+
+Segments are referenced in flag targeting rules via the `segmentMatch` operator. See [flag-targeting.md](./flag-targeting.md):
+
+```bash
+ldcli flags update --project <project-key> --flag <flag-key> --semantic-patch -o json -d '{
+  "environmentKey": "production",
+  "instructions": [{
+    "kind": "addRule",
+    "variationId": "<variation-id>",
+    "clauses": [{
+      "contextKind": "user",
+      "attribute": "",
+      "op": "segmentMatch",
+      "negate": false,
+      "values": ["beta-users"]
+    }]
+  }]
+}'
+```
+
+## Notes
+
+- Segments are scoped to a specific project AND environment.
+- A "big segment" is a synced segment or a list-based segment with more than 15,000 entries.
+- Segment keys must be unique within a project/environment pair.
+- Use segments to DRY up flag targeting: define the audience once, reference it in many flags.

--- a/skills/segments.md
+++ b/skills/segments.md
@@ -1,5 +1,12 @@
 # Skill: Segments
 
+> **Prerequisites:** This skill requires `ldcli`. Before running any command below, verify it's available (`which ldcli`). If not found, offer to install it:
+> - macOS: `brew tap launchdarkly/homebrew-tap && brew install ldcli`
+> - npm: `npm install -g @launchdarkly/ldcli`
+> - Binary downloads: https://github.com/launchdarkly/ldcli/releases
+>
+> After install, authenticate with `ldcli login` or by setting `LD_ACCESS_TOKEN`. Use `-o json` on all commands for parseable output.
+
 Manage audience segments. Segments are reusable groups of contexts that can be referenced in flag targeting rules. They are scoped to a project and environment.
 
 ## List Segments

--- a/skills/setup.md
+++ b/skills/setup.md
@@ -1,0 +1,73 @@
+# Skill: LaunchDarkly CLI Setup
+
+Install and configure `ldcli`, the LaunchDarkly CLI.
+
+## Check if ldcli is installed
+
+```bash
+which ldcli && ldcli --version
+```
+
+If `ldcli` is not found, help the user install it using one of the methods below.
+
+## Install ldcli
+
+### macOS (Homebrew)
+
+```bash
+brew tap launchdarkly/homebrew-tap
+brew install ldcli
+```
+
+### npm
+
+```bash
+npm install -g @launchdarkly/ldcli
+```
+
+### Docker
+
+```bash
+docker pull launchdarkly/ldcli
+```
+
+### Binary downloads (Linux/Windows)
+
+Download the latest release from https://github.com/launchdarkly/ldcli/releases
+
+## Authenticate
+
+After installing, the user must authenticate. There are two options:
+
+### Interactive login (recommended)
+
+```bash
+ldcli login
+```
+
+This opens a browser for OAuth authentication and saves the token to the local config.
+
+### Access token
+
+Set an API access token as an environment variable:
+
+```bash
+export LD_ACCESS_TOKEN="<your-token>"
+```
+
+Or pass it per-command with `--access-token <token>`.
+
+## Verify
+
+```bash
+ldcli projects list -o json
+```
+
+If this returns a list of projects, everything is working.
+
+## Notes
+
+- Always use `-o json` on commands for parseable output.
+- Use `ldcli --help` or `ldcli <command> --help` to explore available commands.
+- See `ldcli resources` for a full list of resource types you can manage.
+- Configuration is stored in `~/.config/ldcli/config.yml` (XDG standard path).


### PR DESCRIPTION

<img width="300" height="168" alt="image" src="https://github.com/user-attachments/assets/fdb27088-9fda-4db9-8df1-68f1124de696" />

Asked Claude to explore `ldcli` (interactively and direct via repo) and generate skills it could use.

As the branch name implies: *experimental* - I've done some basic tire-kicking but have definitely not fully vetted.
Preliminary results are encouraging though. Was able to pretty easily get it to successfully:
- recognize my personal test project
- find a flag in that project 
- add a relatively complex targeting rule with a custom context kind+attribute

[edit] updated to now support bootstrapping the `ldcli` installation itself. 🤯 


**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
