### PR TITLE
feat: add --json flag as shorthand for --output json

### DIFF
--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -1,5 +1,18 @@
 package cliflags
 
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// GetOutputKind returns the effective output kind, giving precedence to --json over --output.
+func GetOutputKind(cmd *cobra.Command) string {
+	if jsonFlag, err := cmd.Root().PersistentFlags().GetBool(JSONFlag); err == nil && jsonFlag {
+		return "json"
+	}
+	return viper.GetString(OutputFlag)
+}
+
 const (
 	BaseURIDefault      = "https://app.launchdarkly.com"
 	DevStreamURIDefault = "https://stream.launchdarkly.com"
@@ -15,6 +28,7 @@ const (
 	EmailsFlag       = "emails"
 	EnvironmentFlag  = "environment"
 	FlagFlag         = "flag"
+	JSONFlag         = "json"
 	OutputFlag       = "output"
 	PortFlag         = "port"
 	ProjectFlag      = "project"
@@ -29,6 +43,7 @@ const (
 	DevStreamURIDescription    = "Streaming service endpoint that the dev server uses to obtain authoritative flag data. This may be a LaunchDarkly or Relay Proxy endpoint"
 	EnvironmentFlagDescription = "Default environment key"
 	FlagFlagDescription        = "Default feature flag key"
+	JSONFlagDescription        = "Output JSON format (shorthand for --output json)"
 	OutputFlagDescription      = "Command response output format in either JSON or plain text"
 	PortFlagDescription        = "Port for the dev server to run on"
 	ProjectFlagDescription     = "Default project key"

--- a/cmd/config/testdata/help.golden
+++ b/cmd/config/testdata/help.golden
@@ -27,4 +27,5 @@ Global Flags:
       --access-token string   LaunchDarkly access token with write-level access
       --analytics-opt-out     Opt out of analytics tracking
       --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
+      --json                  Output JSON format (shorthand for --output json)
   -o, --output string         Command response output format in either JSON or plain text (default "plaintext")

--- a/cmd/dev_server/overrides.go
+++ b/cmd/dev_server/overrides.go
@@ -64,7 +64,7 @@ func addOverride(client resources.Client) func(*cobra.Command, []string) error {
 			jsonData,
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
 		fmt.Fprint(cmd.OutOrStdout(), string(res))
@@ -102,7 +102,7 @@ func deleteOverrides(client resources.Client) func(*cobra.Command, []string) err
 			nil,
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
 		fmt.Fprint(cmd.OutOrStdout(), string(res))
@@ -145,7 +145,7 @@ func removeOverride(client resources.Client) func(*cobra.Command, []string) erro
 			nil,
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
 		fmt.Fprint(cmd.OutOrStdout(), string(res))

--- a/cmd/dev_server/projects.go
+++ b/cmd/dev_server/projects.go
@@ -39,7 +39,7 @@ func listProjects(client resources.Client) func(*cobra.Command, []string) error 
 			nil,
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
 		fmt.Fprint(cmd.OutOrStdout(), string(res))
@@ -107,7 +107,7 @@ func getProject(client resources.Client) func(*cobra.Command, []string) error {
 			false,   // not beta
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 		fmt.Fprint(cmd.OutOrStdout(), string(res))
 
@@ -146,7 +146,7 @@ func syncProject(client resources.Client) func(*cobra.Command, []string) error {
 			[]byte("{}"),
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 		_, err = fmt.Fprintf(cmd.OutOrStdout(), "'%s' project synced successfully\n", project)
 		if err != nil {
@@ -187,7 +187,7 @@ func deleteProject(client resources.Client) func(*cobra.Command, []string) error
 			nil,
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
 		fmt.Fprint(cmd.OutOrStdout(), string(res))
@@ -248,7 +248,7 @@ func addProject(client resources.Client) func(*cobra.Command, []string) error {
 			jsonData,
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
 		fmt.Fprint(cmd.OutOrStdout(), string(res))
@@ -320,7 +320,7 @@ func updateProject(client resources.Client) func(*cobra.Command, []string) error
 			jsonData,
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
 		var response patchResponse

--- a/cmd/flags/archive.go
+++ b/cmd/flags/archive.go
@@ -48,10 +48,10 @@ func makeArchiveRequest(client resources.Client) func(*cobra.Command, []string) 
 			false,
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", viper.GetString(cliflags.OutputFlag), res)
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res)
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/flags/toggle.go
+++ b/cmd/flags/toggle.go
@@ -70,10 +70,10 @@ func runE(client resources.Client) func(*cobra.Command, []string) error {
 			false,
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", viper.GetString(cliflags.OutputFlag), res)
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res)
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/members/invite.go
+++ b/cmd/members/invite.go
@@ -60,10 +60,10 @@ func runE(client resources.Client) func(*cobra.Command, []string) error {
 			false,
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", viper.GetString(cliflags.OutputFlag), res)
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res)
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -340,7 +340,7 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 		op.IsBeta,
 	)
 	if err != nil {
-		return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+		return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 	}
 
 	if string(res) == "" {
@@ -349,7 +349,7 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 		res = []byte(fmt.Sprintf(`{"key": %q}`, urlParms[len(urlParms)-1]))
 	}
 
-	output, err := output.CmdOutput(cmd.Use, viper.GetString(cliflags.OutputFlag), res)
+	output, err := output.CmdOutput(cmd.Use, cliflags.GetOutputKind(cmd), res)
 	if err != nil {
 		return errors.NewError(err.Error())
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,6 @@ import (
 	memberscmd "github.com/launchdarkly/ldcli/cmd/members"
 	resourcecmd "github.com/launchdarkly/ldcli/cmd/resources"
 	sourcemapscmd "github.com/launchdarkly/ldcli/cmd/sourcemaps"
-	whoamicmd "github.com/launchdarkly/ldcli/cmd/whoami"
 	"github.com/launchdarkly/ldcli/internal/analytics"
 	"github.com/launchdarkly/ldcli/internal/config"
 	"github.com/launchdarkly/ldcli/internal/dev_server"
@@ -213,7 +212,6 @@ func NewRootCommand(
 	cmd.AddCommand(resourcecmd.NewResourcesCmd())
 	cmd.AddCommand(devcmd.NewDevServerCmd(clients.ResourcesClient, analyticsTrackerFn, clients.DevClient))
 	cmd.AddCommand(sourcemapscmd.NewSourcemapsCmd(clients.ResourcesClient, analyticsTrackerFn))
-	cmd.AddCommand(whoamicmd.NewWhoAmICmd(clients.ResourcesClient))
 	resourcecmd.AddAllResourceCmds(cmd, clients.ResourcesClient, analyticsTrackerFn)
 
 	// add non-generated commands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	memberscmd "github.com/launchdarkly/ldcli/cmd/members"
 	resourcecmd "github.com/launchdarkly/ldcli/cmd/resources"
 	sourcemapscmd "github.com/launchdarkly/ldcli/cmd/sourcemaps"
+	whoamicmd "github.com/launchdarkly/ldcli/cmd/whoami"
 	"github.com/launchdarkly/ldcli/internal/analytics"
 	"github.com/launchdarkly/ldcli/internal/config"
 	"github.com/launchdarkly/ldcli/internal/dev_server"
@@ -108,6 +109,7 @@ func NewRootCommand(
 					cmd.DisableFlagParsing = true
 				}
 			}
+
 		},
 		Annotations: make(map[string]string),
 		// Handle errors differently based on type.
@@ -198,6 +200,12 @@ func NewRootCommand(
 		return nil, err
 	}
 
+	cmd.PersistentFlags().Bool(
+		cliflags.JSONFlag,
+		false,
+		cliflags.JSONFlagDescription,
+	)
+
 	configCmd := configcmd.NewConfigCmd(configService, analyticsTrackerFn)
 	cmd.AddCommand(configCmd.Cmd())
 	cmd.AddCommand(NewQuickStartCmd(analyticsTrackerFn, clients.EnvironmentsClient, clients.FlagsClient))
@@ -205,6 +213,7 @@ func NewRootCommand(
 	cmd.AddCommand(resourcecmd.NewResourcesCmd())
 	cmd.AddCommand(devcmd.NewDevServerCmd(resources.NewClient(version), analyticsTrackerFn, dev_server.NewClient(version)))
 	cmd.AddCommand(sourcemapscmd.NewSourcemapsCmd(resources.NewClient(version), analyticsTrackerFn))
+	cmd.AddCommand(whoamicmd.NewWhoAmICmd(clients.ResourcesClient))
 	resourcecmd.AddAllResourceCmds(cmd, clients.ResourcesClient, analyticsTrackerFn)
 
 	// add non-generated commands

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,12 +1,14 @@
 package cmd_test
 
 import (
-	"github.com/launchdarkly/ldcli/cmd"
-	"github.com/launchdarkly/ldcli/internal/analytics"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/launchdarkly/ldcli/cmd"
+	"github.com/launchdarkly/ldcli/internal/analytics"
+	"github.com/launchdarkly/ldcli/internal/resources"
 )
 
 func TestCreate(t *testing.T) {
@@ -24,5 +26,33 @@ func TestCreate(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Contains(t, string(output), `ldcli version test`)
+	})
+}
+
+func TestJSONFlag(t *testing.T) {
+	mockClient := &resources.MockClient{
+		Response: []byte(`{"key": "test-key", "name": "test-name"}`),
+	}
+
+	t.Run("--json returns raw JSON output", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-on",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--json",
+		}
+
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{ResourcesClient: mockClient},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(output), `"key": "test-key"`)
+		assert.NotContains(t, string(output), "Successfully updated")
 	})
 }

--- a/cmd/sourcemaps/upload.go
+++ b/cmd/sourcemaps/upload.go
@@ -114,14 +114,14 @@ func runE(client resources.Client) func(cmd *cobra.Command, args []string) error
 			false,
 		)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
 		var projectResult struct {
 			ID string `json:"_id"`
 		}
 		if err = json.Unmarshal(res, &projectResult); err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 		if projectResult.ID == "" {
 			return fmt.Errorf("project %s not found", projectKey)

--- a/cmd/validators/validators.go
+++ b/cmd/validators/validators.go
@@ -30,7 +30,7 @@ func Validate() cobra.PositionalArgs {
 			return CmdError(err, cmd.CommandPath(), viper.GetString(cliflags.BaseURIFlag))
 		}
 
-		err = validateOutput(viper.GetString(cliflags.OutputFlag))
+		err = validateOutput(cliflags.GetOutputKind(cmd))
 		if err != nil {
 			return CmdError(err, cmd.CommandPath(), viper.GetString(cliflags.BaseURIFlag))
 		}


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

AI agents commonly try `--json` to get machine-readable output (it's the convention in `gh`, `kubectl`, `aws`, etc.). We already had `--output json` but that's not discoverable if you don't know to look for it — you just get `unknown flag: --json`.

This adds `--json` as a persistent flag on all commands that sets the output format to JSON.

**Describe alternatives you've considered**

Documenting `--output json` better. But since `--json` is a widely established convention, adding the alias is lower friction than expecting agents and users to discover `--output`.

**Additional context**

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new persistent flag and routes existing output/validation logic through a small helper to prefer JSON when requested.
> 
> **Overview**
> Adds a new persistent `--json` flag (documented in help output) that acts as a shorthand for `--output json`.
> 
> Introduces `cliflags.GetOutputKind(cmd)` and updates command implementations and validators to use it so `--json` takes precedence over the `--output` setting, plus adds a root-level test asserting raw JSON output for `--json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbfa50b81a868fa7558127b0bcc1fdc59102de9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->