### PR TITLE
feat: add whoami command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	resourcecmd "github.com/launchdarkly/ldcli/cmd/resources"
 	signupcmd "github.com/launchdarkly/ldcli/cmd/signup"
 	sourcemapscmd "github.com/launchdarkly/ldcli/cmd/sourcemaps"
+	whoamicmd "github.com/launchdarkly/ldcli/cmd/whoami"
 	"github.com/launchdarkly/ldcli/internal/analytics"
 	"github.com/launchdarkly/ldcli/internal/config"
 	"github.com/launchdarkly/ldcli/internal/dev_server"
@@ -257,6 +258,7 @@ func NewRootCommand(
 	cmd.AddCommand(resourcecmd.NewResourcesCmd())
 	cmd.AddCommand(devcmd.NewDevServerCmd(clients.ResourcesClient, analyticsTrackerFn, clients.DevClient))
 	cmd.AddCommand(sourcemapscmd.NewSourcemapsCmd(clients.ResourcesClient, analyticsTrackerFn))
+	cmd.AddCommand(whoamicmd.NewWhoAmICmd(clients.ResourcesClient))
 	resourcecmd.AddAllResourceCmds(cmd, clients.ResourcesClient, analyticsTrackerFn)
 
 	// add non-generated commands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,6 +132,7 @@ func NewRootCommand(
 				"help",
 				"login",
 				"signup",
+				"whoami",
 			} {
 				if cmd.HasParent() && cmd.Parent().Name() == name {
 					cmd.DisableFlagParsing = true

--- a/cmd/whoami/whoami.go
+++ b/cmd/whoami/whoami.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/launchdarkly/ldcli/cmd/cliflags"
 	resourcescmd "github.com/launchdarkly/ldcli/cmd/resources"
-	"github.com/launchdarkly/ldcli/cmd/validators"
 	"github.com/launchdarkly/ldcli/internal/errors"
 	"github.com/launchdarkly/ldcli/internal/output"
 	"github.com/launchdarkly/ldcli/internal/resources"
@@ -17,7 +16,7 @@ import (
 
 func NewWhoAmICmd(client resources.Client) *cobra.Command {
 	cmd := &cobra.Command{
-		Args:  validators.Validate(),
+		Args:  cobra.NoArgs,
 		Long:  "Show information about the identity associated with the current access token.",
 		RunE:  makeRequest(client),
 		Short: "Show current caller identity",
@@ -26,17 +25,44 @@ func NewWhoAmICmd(client resources.Client) *cobra.Command {
 
 	cmd.SetUsageTemplate(resourcescmd.SubcommandUsageTemplate())
 
+	// Hide flags that don't apply to whoami from its help output.
+	// Access token and base URI are read from config; analytics opt-out is not relevant.
+	hiddenInHelp := []string{
+		cliflags.AccessTokenFlag,
+		cliflags.BaseURIFlag,
+		cliflags.AnalyticsOptOut,
+	}
+	defaultHelp := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		for _, name := range hiddenInHelp {
+			if f := c.Root().PersistentFlags().Lookup(name); f != nil {
+				f.Hidden = true
+			}
+		}
+		defaultHelp(c, args)
+		for _, name := range hiddenInHelp {
+			if f := c.Root().PersistentFlags().Lookup(name); f != nil {
+				f.Hidden = false
+			}
+		}
+	})
+
 	return cmd
 }
 
 func makeRequest(client resources.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		accessToken := viper.GetString(cliflags.AccessTokenFlag)
+		if accessToken == "" {
+			return errors.NewError("no access token configured. Run `ldcli login` or set LD_ACCESS_TOKEN")
+		}
+
 		path, _ := url.JoinPath(
 			viper.GetString(cliflags.BaseURIFlag),
 			"api/v2/caller-identity",
 		)
 		res, err := client.MakeRequest(
-			viper.GetString(cliflags.AccessTokenFlag),
+			accessToken,
 			"GET",
 			path,
 			"application/json",

--- a/cmd/whoami/whoami.go
+++ b/cmd/whoami/whoami.go
@@ -1,8 +1,10 @@
 package whoami
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -13,6 +15,29 @@ import (
 	"github.com/launchdarkly/ldcli/internal/output"
 	"github.com/launchdarkly/ldcli/internal/resources"
 )
+
+type callerIdentity struct {
+	AccountID       string   `json:"accountId"`
+	AuthKind        string   `json:"authKind"`
+	ClientID        string   `json:"clientId"`
+	EnvironmentID   string   `json:"environmentId"`
+	EnvironmentName string   `json:"environmentName"`
+	MemberID        string   `json:"memberId"`
+	ProjectID       string   `json:"projectId"`
+	ProjectName     string   `json:"projectName"`
+	Scopes          []string `json:"scopes"`
+	ServiceToken    bool     `json:"serviceToken"`
+	TokenID         string   `json:"tokenId"`
+	TokenKind       string   `json:"tokenKind"`
+	TokenName       string   `json:"tokenName"`
+}
+
+type memberSummary struct {
+	Email     string `json:"email"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	Role      string `json:"role"`
+}
 
 func NewWhoAmICmd(client resources.Client) *cobra.Command {
 	cmd := &cobra.Command{
@@ -57,30 +82,74 @@ func makeRequest(client resources.Client) func(*cobra.Command, []string) error {
 			return errors.NewError("no access token configured. Run `ldcli login` or set LD_ACCESS_TOKEN")
 		}
 
-		path, _ := url.JoinPath(
-			viper.GetString(cliflags.BaseURIFlag),
-			"api/v2/caller-identity",
-		)
-		res, err := client.MakeRequest(
-			accessToken,
-			"GET",
-			path,
-			"application/json",
-			nil,
-			nil,
-			false,
-		)
+		baseURI := viper.GetString(cliflags.BaseURIFlag)
+		outputKind := viper.GetString(cliflags.OutputFlag)
+
+		identityPath, _ := url.JoinPath(baseURI, "api/v2/caller-identity")
+		identityRes, err := client.MakeRequest(accessToken, "GET", identityPath, "application/json", nil, nil, false)
 		if err != nil {
-			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+			return output.NewCmdOutputError(err, outputKind)
 		}
 
-		out, err := output.CmdOutputSingular(viper.GetString(cliflags.OutputFlag), res, output.ConfigPlaintextOutputFn)
-		if err != nil {
+		// For JSON output, return the raw caller-identity response.
+		if outputKind == "json" {
+			out, err := output.CmdOutputSingular(outputKind, identityRes, output.ConfigPlaintextOutputFn)
+			if err != nil {
+				return errors.NewError(err.Error())
+			}
+			fmt.Fprint(cmd.OutOrStdout(), out+"\n")
+			return nil
+		}
+
+		var identity callerIdentity
+		if err := json.Unmarshal(identityRes, &identity); err != nil {
 			return errors.NewError(err.Error())
 		}
 
-		fmt.Fprint(cmd.OutOrStdout(), out+"\n")
+		// Fetch member info for a richer plaintext display.
+		var member *memberSummary
+		if identity.MemberID != "" {
+			memberPath, _ := url.JoinPath(baseURI, "api/v2/members", identity.MemberID)
+			memberRes, err := client.MakeRequest(accessToken, "GET", memberPath, "application/json", nil, nil, false)
+			if err == nil {
+				var m memberSummary
+				if json.Unmarshal(memberRes, &m) == nil {
+					member = &m
+				}
+			}
+		}
 
+		fmt.Fprint(cmd.OutOrStdout(), formatPlaintext(identity, member)+"\n")
 		return nil
 	}
+}
+
+func formatPlaintext(identity callerIdentity, member *memberSummary) string {
+	var sb strings.Builder
+
+	if member != nil {
+		name := strings.TrimSpace(member.FirstName + " " + member.LastName)
+		if name != "" {
+			fmt.Fprintf(&sb, "%s <%s>\n", name, member.Email)
+		} else {
+			fmt.Fprintf(&sb, "%s\n", member.Email)
+		}
+		fmt.Fprintf(&sb, "Role:    %s\n", member.Role)
+	}
+
+	tokenKind := identity.TokenKind
+	if identity.ServiceToken {
+		tokenKind = "service token"
+	}
+	if identity.TokenName != "" {
+		fmt.Fprintf(&sb, "Token:   %s (%s)\n", identity.TokenName, tokenKind)
+	} else if identity.ClientID != "" {
+		fmt.Fprintf(&sb, "Token:   %s (%s)\n", identity.ClientID, tokenKind)
+	}
+
+	if identity.AccountID != "" {
+		fmt.Fprintf(&sb, "Account: %s\n", identity.AccountID)
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
 }

--- a/cmd/whoami/whoami.go
+++ b/cmd/whoami/whoami.go
@@ -83,7 +83,7 @@ func makeRequest(client resources.Client) func(*cobra.Command, []string) error {
 		}
 
 		baseURI := viper.GetString(cliflags.BaseURIFlag)
-		outputKind := viper.GetString(cliflags.OutputFlag)
+		outputKind := cliflags.GetOutputKind(cmd)
 
 		identityPath, _ := url.JoinPath(baseURI, "api/v2/caller-identity")
 		identityRes, err := client.MakeRequest(accessToken, "GET", identityPath, "application/json", nil, nil, false)

--- a/cmd/whoami/whoami.go
+++ b/cmd/whoami/whoami.go
@@ -1,0 +1,60 @@
+package whoami
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/launchdarkly/ldcli/cmd/cliflags"
+	resourcescmd "github.com/launchdarkly/ldcli/cmd/resources"
+	"github.com/launchdarkly/ldcli/cmd/validators"
+	"github.com/launchdarkly/ldcli/internal/errors"
+	"github.com/launchdarkly/ldcli/internal/output"
+	"github.com/launchdarkly/ldcli/internal/resources"
+)
+
+func NewWhoAmICmd(client resources.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Args:  validators.Validate(),
+		Long:  "Show information about the identity associated with the current access token.",
+		RunE:  makeRequest(client),
+		Short: "Show current caller identity",
+		Use:   "whoami",
+	}
+
+	cmd.SetUsageTemplate(resourcescmd.SubcommandUsageTemplate())
+
+	return cmd
+}
+
+func makeRequest(client resources.Client) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		path, _ := url.JoinPath(
+			viper.GetString(cliflags.BaseURIFlag),
+			"api/v2/caller-identity",
+		)
+		res, err := client.MakeRequest(
+			viper.GetString(cliflags.AccessTokenFlag),
+			"GET",
+			path,
+			"application/json",
+			nil,
+			nil,
+			false,
+		)
+		if err != nil {
+			return output.NewCmdOutputError(err, viper.GetString(cliflags.OutputFlag))
+		}
+
+		out, err := output.CmdOutputSingular(viper.GetString(cliflags.OutputFlag), res, output.ConfigPlaintextOutputFn)
+		if err != nil {
+			return errors.NewError(err.Error())
+		}
+
+		fmt.Fprint(cmd.OutOrStdout(), out+"\n")
+
+		return nil
+	}
+}

--- a/cmd/whoami/whoami.go
+++ b/cmd/whoami/whoami.go
@@ -39,6 +39,10 @@ type memberSummary struct {
 	Role      string `json:"role"`
 }
 
+type accountSummary struct {
+	Organization string `json:"organization"`
+}
+
 func NewWhoAmICmd(client resources.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
@@ -119,12 +123,25 @@ func makeRequest(client resources.Client) func(*cobra.Command, []string) error {
 			}
 		}
 
-		fmt.Fprint(cmd.OutOrStdout(), formatPlaintext(identity, member)+"\n")
+		// Fetch the account to resolve the organization name. This endpoint is a
+		// real public-API route but isn't published in the OpenAPI spec, so we
+		// treat it as best-effort and fall back to the account ID on any failure.
+		var account *accountSummary
+		accountPath, _ := url.JoinPath(baseURI, "api/v2/account")
+		accountRes, err := client.MakeRequest(accessToken, "GET", accountPath, "application/json", nil, nil, false)
+		if err == nil {
+			var a accountSummary
+			if json.Unmarshal(accountRes, &a) == nil {
+				account = &a
+			}
+		}
+
+		fmt.Fprint(cmd.OutOrStdout(), formatPlaintext(identity, member, account)+"\n")
 		return nil
 	}
 }
 
-func formatPlaintext(identity callerIdentity, member *memberSummary) string {
+func formatPlaintext(identity callerIdentity, member *memberSummary, account *accountSummary) string {
 	var sb strings.Builder
 
 	if member != nil {
@@ -147,7 +164,13 @@ func formatPlaintext(identity callerIdentity, member *memberSummary) string {
 		fmt.Fprintf(&sb, "Token:   %s (%s)\n", identity.ClientID, tokenKind)
 	}
 
-	if identity.AccountID != "" {
+	if account != nil && account.Organization != "" {
+		if identity.AccountID != "" {
+			fmt.Fprintf(&sb, "Account: %s (%s)\n", account.Organization, identity.AccountID)
+		} else {
+			fmt.Fprintf(&sb, "Account: %s\n", account.Organization)
+		}
+	} else if identity.AccountID != "" {
 		fmt.Fprintf(&sb, "Account: %s\n", identity.AccountID)
 	}
 

--- a/cmd/whoami/whoami_test.go
+++ b/cmd/whoami/whoami_test.go
@@ -1,6 +1,7 @@
 package whoami_test
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,10 +12,34 @@ import (
 	"github.com/launchdarkly/ldcli/internal/resources"
 )
 
+// sequentialMockClient returns responses in order, one per call.
+type sequentialMockClient struct {
+	responses [][]byte
+	callIndex int
+}
+
+var _ resources.Client = &sequentialMockClient{}
+
+func (c *sequentialMockClient) MakeRequest(_, _, _ string, _ string, _ url.Values, _ []byte, _ bool) ([]byte, error) {
+	if c.callIndex >= len(c.responses) {
+		return nil, nil
+	}
+	res := c.responses[c.callIndex]
+	c.callIndex++
+	return res, nil
+}
+
+func (c *sequentialMockClient) MakeUnauthenticatedRequest(_ string, _ string, _ []byte) ([]byte, error) {
+	return nil, nil
+}
+
 func TestWhoAmI(t *testing.T) {
-	t.Run("with configured token prints caller identity", func(t *testing.T) {
-		mockClient := &resources.MockClient{
-			Response: []byte(`{"tokenName": "my-token", "authKind": "token", "memberId": "abc123"}`),
+	t.Run("shows member name, email, role, and token", func(t *testing.T) {
+		mockClient := &sequentialMockClient{
+			responses: [][]byte{
+				[]byte(`{"memberId": "abc123", "tokenName": "my-token", "tokenKind": "personal", "accountId": "acct1"}`),
+				[]byte(`{"_id": "abc123", "email": "ariel@acme.com", "firstName": "Ariel", "lastName": "Flores", "role": "admin"}`),
+			},
 		}
 
 		t.Setenv("LD_ACCESS_TOKEN", "abcd1234")
@@ -27,7 +52,28 @@ func TestWhoAmI(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Contains(t, string(output), "my-token")
+		assert.Contains(t, string(output), "Ariel Flores <ariel@acme.com>")
+		assert.Contains(t, string(output), "Role:    admin")
+		assert.Contains(t, string(output), "Token:   my-token (personal)")
+	})
+
+	t.Run("without member ID shows token info only", func(t *testing.T) {
+		mockClient := &resources.MockClient{
+			Response: []byte(`{"tokenName": "sdk-key", "tokenKind": "server", "accountId": "acct1"}`),
+		}
+
+		t.Setenv("LD_ACCESS_TOKEN", "abcd1234")
+
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{ResourcesClient: mockClient},
+			analytics.NoopClientFn{}.Tracker(),
+			[]string{"whoami"},
+		)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(output), "Token:   sdk-key (server)")
+		assert.NotContains(t, string(output), "Role:")
 	})
 
 	t.Run("without configured token returns helpful error", func(t *testing.T) {
@@ -41,9 +87,9 @@ func TestWhoAmI(t *testing.T) {
 		require.ErrorContains(t, err, "no access token configured")
 	})
 
-	t.Run("with --output json returns raw JSON", func(t *testing.T) {
+	t.Run("with --output json returns raw caller-identity JSON", func(t *testing.T) {
 		mockClient := &resources.MockClient{
-			Response: []byte(`{"tokenName": "my-token", "authKind": "token", "memberId": "abc123"}`),
+			Response: []byte(`{"tokenName": "my-token", "memberId": "abc123"}`),
 		}
 
 		t.Setenv("LD_ACCESS_TOKEN", "abcd1234")

--- a/cmd/whoami/whoami_test.go
+++ b/cmd/whoami/whoami_test.go
@@ -12,41 +12,47 @@ import (
 )
 
 func TestWhoAmI(t *testing.T) {
-	t.Run("with valid token prints caller identity", func(t *testing.T) {
+	t.Run("with configured token prints caller identity", func(t *testing.T) {
 		mockClient := &resources.MockClient{
 			Response: []byte(`{"tokenName": "my-token", "authKind": "token", "memberId": "abc123"}`),
 		}
-		args := []string{
-			"whoami",
-			"--access-token", "abcd1234",
-		}
+
+		t.Setenv("LD_ACCESS_TOKEN", "abcd1234")
 
 		output, err := cmd.CallCmd(
 			t,
 			cmd.APIClients{ResourcesClient: mockClient},
 			analytics.NoopClientFn{}.Tracker(),
-			args,
+			[]string{"whoami"},
 		)
 
 		require.NoError(t, err)
 		assert.Contains(t, string(output), "my-token")
 	})
 
+	t.Run("without configured token returns helpful error", func(t *testing.T) {
+		_, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{},
+			analytics.NoopClientFn{}.Tracker(),
+			[]string{"whoami"},
+		)
+
+		require.ErrorContains(t, err, "no access token configured")
+	})
+
 	t.Run("with --output json returns raw JSON", func(t *testing.T) {
 		mockClient := &resources.MockClient{
 			Response: []byte(`{"tokenName": "my-token", "authKind": "token", "memberId": "abc123"}`),
 		}
-		args := []string{
-			"whoami",
-			"--access-token", "abcd1234",
-			"--output", "json",
-		}
+
+		t.Setenv("LD_ACCESS_TOKEN", "abcd1234")
 
 		output, err := cmd.CallCmd(
 			t,
 			cmd.APIClients{ResourcesClient: mockClient},
 			analytics.NoopClientFn{}.Tracker(),
-			args,
+			[]string{"whoami", "--output", "json"},
 		)
 
 		require.NoError(t, err)

--- a/cmd/whoami/whoami_test.go
+++ b/cmd/whoami/whoami_test.go
@@ -1,0 +1,55 @@
+package whoami_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/launchdarkly/ldcli/cmd"
+	"github.com/launchdarkly/ldcli/internal/analytics"
+	"github.com/launchdarkly/ldcli/internal/resources"
+)
+
+func TestWhoAmI(t *testing.T) {
+	t.Run("with valid token prints caller identity", func(t *testing.T) {
+		mockClient := &resources.MockClient{
+			Response: []byte(`{"tokenName": "my-token", "authKind": "token", "memberId": "abc123"}`),
+		}
+		args := []string{
+			"whoami",
+			"--access-token", "abcd1234",
+		}
+
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{ResourcesClient: mockClient},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(output), "my-token")
+	})
+
+	t.Run("with --output json returns raw JSON", func(t *testing.T) {
+		mockClient := &resources.MockClient{
+			Response: []byte(`{"tokenName": "my-token", "authKind": "token", "memberId": "abc123"}`),
+		}
+		args := []string{
+			"whoami",
+			"--access-token", "abcd1234",
+			"--output", "json",
+		}
+
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{ResourcesClient: mockClient},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(output), `"tokenName": "my-token"`)
+	})
+}

--- a/cmd/whoami/whoami_test.go
+++ b/cmd/whoami/whoami_test.go
@@ -34,11 +34,12 @@ func (c *sequentialMockClient) MakeUnauthenticatedRequest(_ string, _ string, _ 
 }
 
 func TestWhoAmI(t *testing.T) {
-	t.Run("shows member name, email, role, and token", func(t *testing.T) {
+	t.Run("shows member name, email, role, token, and organization", func(t *testing.T) {
 		mockClient := &sequentialMockClient{
 			responses: [][]byte{
 				[]byte(`{"memberId": "abc123", "tokenName": "my-token", "tokenKind": "personal", "accountId": "acct1"}`),
 				[]byte(`{"_id": "abc123", "email": "ariel@acme.com", "firstName": "Ariel", "lastName": "Flores", "role": "admin"}`),
+				[]byte(`{"_id": "acct1", "organization": "Acme Inc"}`),
 			},
 		}
 
@@ -55,6 +56,30 @@ func TestWhoAmI(t *testing.T) {
 		assert.Contains(t, string(output), "Ariel Flores <ariel@acme.com>")
 		assert.Contains(t, string(output), "Role:    admin")
 		assert.Contains(t, string(output), "Token:   my-token (personal)")
+		assert.Contains(t, string(output), "Account: Acme Inc (acct1)")
+	})
+
+	t.Run("falls back to account ID when organization is unavailable", func(t *testing.T) {
+		mockClient := &sequentialMockClient{
+			responses: [][]byte{
+				[]byte(`{"memberId": "abc123", "tokenName": "my-token", "tokenKind": "personal", "accountId": "acct1"}`),
+				[]byte(`{"_id": "abc123", "email": "ariel@acme.com", "firstName": "Ariel", "lastName": "Flores", "role": "admin"}`),
+				[]byte(`{"_id": "acct1"}`),
+			},
+		}
+
+		t.Setenv("LD_ACCESS_TOKEN", "abcd1234")
+
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{ResourcesClient: mockClient},
+			analytics.NoopClientFn{}.Tracker(),
+			[]string{"whoami"},
+		)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(output), "Account: acct1")
+		assert.NotContains(t, string(output), "Account: Acme")
 	})
 
 	t.Run("without member ID shows token info only", func(t *testing.T) {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

Adds `ldcli whoami` — shows who your current access token belongs to. Reads from config/env like other commands, so you don't need to pass `--access-token` explicitly (similar to `gh auth status`).

```
$ ldcli whoami
Ariel Flores <ariel@acme.com>
Role:    admin
Token:   my-api-token (personal)
Account: abc123
```

**Describe alternatives you've considered**

N/A

**Additional context**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only API calls using the user's existing token; no auth or persistence changes beyond registering a new CLI command.
> 
> **Overview**
> Adds **`ldcli whoami`**, a top-level command that reports which LaunchDarkly identity your configured access token represents (similar in spirit to `gh auth status`).
> 
> The command reads **`LD_ACCESS_TOKEN`** / config like other commands, and is registered on the root CLI with **`whoami`** included in the set that **does not require** the global `--access-token` flag at parse time. It calls **`GET /api/v2/caller-identity`**; with default plaintext output it **best-effort** enriches the result via **`/api/v2/members/{id}`** and **`/api/v2/account`** (member name/email/role, token label/kind including service tokens, organization or account id). **`--output json`** returns only the raw caller-identity payload. Help temporarily hides persistent flags that are irrelevant for this subcommand.
> 
> Tests cover the happy path, account/org fallback, non-member tokens, missing token error, and JSON output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd669a4708bb9947e7ad7af0b9efb74e2e756825. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->