### PR TITLE
feat(REL-12753): adding agent flag for agent telemetry

### DIFF
--- a/cmd/analytics/analytics.go
+++ b/cmd/analytics/analytics.go
@@ -1,6 +1,8 @@
 package analytics
 
 import (
+	_ "embed"
+	"encoding/json"
 	"os"
 
 	"github.com/launchdarkly/ldcli/cmd/cliflags"
@@ -20,29 +22,36 @@ type envChecker interface {
 
 type osEnvChecker struct{}
 
-func (osEnvChecker) Getenv(key string) string  { return os.Getenv(key) }
-func (osEnvChecker) IsTerminal(fd int) bool    { return term.IsTerminal(fd) }
-func (osEnvChecker) StdinFd() int              { return int(os.Stdin.Fd()) }
-func (osEnvChecker) StdoutFd() int             { return int(os.Stdout.Fd()) }
+func (osEnvChecker) Getenv(key string) string { return os.Getenv(key) }
+func (osEnvChecker) IsTerminal(fd int) bool   { return term.IsTerminal(fd) }
+func (osEnvChecker) StdinFd() int             { return int(os.Stdin.Fd()) }
+func (osEnvChecker) StdoutFd() int            { return int(os.Stdout.Fd()) }
+
+//go:embed known_agents.json
+var knownAgentsJSON []byte
 
 type agentEnvVar struct {
-	envVar string
-	label  string
+	EnvVar string `json:"env_var"`
+	Label  string `json:"label"`
 }
 
-// Ordered list so detection priority is deterministic.
-var knownAgentEnvVars = []agentEnvVar{
-	{"CURSOR_SESSION_ID", "cursor"},
-	{"CURSOR_TRACE_ID", "cursor"},
-	{"CLAUDE_CODE", "claude-code"},
-	{"CLAUDE_CODE_SESSION", "claude-code"},
-	{"CODEX_SESSION", "codex"},
-	{"CODEX_SANDBOX_ID", "codex"},
-	{"DEVIN_SESSION", "devin"},
-	{"GITHUB_COPILOT", "copilot"},
-	{"WINDSURF_SESSION", "windsurf"},
-	{"CLINE_TASK_ID", "cline"},
-	{"AIDER_MODEL", "aider"},
+type knownAgentsConfig struct {
+	Agents    []agentEnvVar `json:"agents"`
+	CIEnvVars []string      `json:"ci_env_vars"`
+}
+
+var (
+	knownAgentEnvVars []agentEnvVar
+	knownCIEnvVars    []string
+)
+
+func init() {
+	var cfg knownAgentsConfig
+	if err := json.Unmarshal(knownAgentsJSON, &cfg); err != nil {
+		panic("failed to parse embedded known_agents.json: " + err.Error())
+	}
+	knownAgentEnvVars = cfg.Agents
+	knownCIEnvVars = cfg.CIEnvVars
 }
 
 // DetectAgentContext returns a label identifying the agent environment, or ""
@@ -57,16 +66,22 @@ func detectAgentContext(env envChecker) string {
 	}
 
 	for _, a := range knownAgentEnvVars {
-		if env.Getenv(a.envVar) != "" {
-			return a.label
+		if env.Getenv(a.EnvVar) != "" {
+			return a.Label
 		}
 	}
 
-	if !env.IsTerminal(env.StdinFd()) && !env.IsTerminal(env.StdoutFd()) {
-		return "no-tty"
+	if env.IsTerminal(env.StdinFd()) || env.IsTerminal(env.StdoutFd()) {
+		return ""
 	}
 
-	return ""
+	for _, ciVar := range knownCIEnvVars {
+		if env.Getenv(ciVar) != "" {
+			return "ci"
+		}
+	}
+
+	return "unknown-non-interactive"
 }
 
 func CmdRunEventProperties(

--- a/cmd/analytics/analytics.go
+++ b/cmd/analytics/analytics.go
@@ -1,12 +1,73 @@
 package analytics
 
 import (
+	"os"
+
 	"github.com/launchdarkly/ldcli/cmd/cliflags"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"golang.org/x/term"
 )
+
+type envChecker interface {
+	Getenv(key string) string
+	IsTerminal(fd int) bool
+	StdinFd() int
+	StdoutFd() int
+}
+
+type osEnvChecker struct{}
+
+func (osEnvChecker) Getenv(key string) string  { return os.Getenv(key) }
+func (osEnvChecker) IsTerminal(fd int) bool    { return term.IsTerminal(fd) }
+func (osEnvChecker) StdinFd() int              { return int(os.Stdin.Fd()) }
+func (osEnvChecker) StdoutFd() int             { return int(os.Stdout.Fd()) }
+
+type agentEnvVar struct {
+	envVar string
+	label  string
+}
+
+// Ordered list so detection priority is deterministic.
+var knownAgentEnvVars = []agentEnvVar{
+	{"CURSOR_SESSION_ID", "cursor"},
+	{"CURSOR_TRACE_ID", "cursor"},
+	{"CLAUDE_CODE", "claude-code"},
+	{"CLAUDE_CODE_SESSION", "claude-code"},
+	{"CODEX_SESSION", "codex"},
+	{"CODEX_SANDBOX_ID", "codex"},
+	{"DEVIN_SESSION", "devin"},
+	{"GITHUB_COPILOT", "copilot"},
+	{"WINDSURF_SESSION", "windsurf"},
+	{"CLINE_TASK_ID", "cline"},
+	{"AIDER_MODEL", "aider"},
+}
+
+// DetectAgentContext returns a label identifying the agent environment, or ""
+// if the CLI appears to be running in an interactive human terminal.
+func DetectAgentContext() string {
+	return detectAgentContext(osEnvChecker{})
+}
+
+func detectAgentContext(env envChecker) string {
+	if v := env.Getenv("LD_CLI_AGENT"); v != "" {
+		return "explicit:" + v
+	}
+
+	for _, a := range knownAgentEnvVars {
+		if env.Getenv(a.envVar) != "" {
+			return a.label
+		}
+	}
+
+	if !env.IsTerminal(env.StdinFd()) && !env.IsTerminal(env.StdoutFd()) {
+		return "no-tty"
+	}
+
+	return ""
+}
 
 func CmdRunEventProperties(
 	cmd *cobra.Command,

--- a/cmd/analytics/analytics_test.go
+++ b/cmd/analytics/analytics_test.go
@@ -1,0 +1,170 @@
+package analytics
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockEnvChecker struct {
+	envVars       map[string]string
+	stdinTerminal bool
+	stdoutTerminal bool
+}
+
+func newMockEnv(envVars map[string]string, bothTerminal bool) mockEnvChecker {
+	return mockEnvChecker{envVars: envVars, stdinTerminal: bothTerminal, stdoutTerminal: bothTerminal}
+}
+
+func (m mockEnvChecker) Getenv(key string) string { return m.envVars[key] }
+func (m mockEnvChecker) IsTerminal(fd int) bool {
+	if fd == 0 {
+		return m.stdinTerminal
+	}
+	return m.stdoutTerminal
+}
+func (m mockEnvChecker) StdinFd() int  { return 0 }
+func (m mockEnvChecker) StdoutFd() int { return 1 }
+
+func TestDetectAgentContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      mockEnvChecker
+		expected string
+	}{
+		{
+			name:     "explicit LD_CLI_AGENT",
+			env:      newMockEnv(map[string]string{"LD_CLI_AGENT": "my-skill"}, false),
+			expected: "explicit:my-skill",
+		},
+		{
+			name:     "explicit LD_CLI_AGENT takes precedence over known env vars",
+			env:      newMockEnv(map[string]string{"LD_CLI_AGENT": "custom", "CURSOR_SESSION_ID": "abc"}, false),
+			expected: "explicit:custom",
+		},
+		{
+			name:     "CURSOR_SESSION_ID detected",
+			env:      newMockEnv(map[string]string{"CURSOR_SESSION_ID": "abc"}, false),
+			expected: "cursor",
+		},
+		{
+			name:     "CURSOR_TRACE_ID detected",
+			env:      newMockEnv(map[string]string{"CURSOR_TRACE_ID": "xyz"}, false),
+			expected: "cursor",
+		},
+		{
+			name:     "CLAUDE_CODE detected",
+			env:      newMockEnv(map[string]string{"CLAUDE_CODE": "1"}, false),
+			expected: "claude-code",
+		},
+		{
+			name:     "CLAUDE_CODE_SESSION detected",
+			env:      newMockEnv(map[string]string{"CLAUDE_CODE_SESSION": "sess"}, false),
+			expected: "claude-code",
+		},
+		{
+			name:     "CODEX_SESSION detected",
+			env:      newMockEnv(map[string]string{"CODEX_SESSION": "s"}, false),
+			expected: "codex",
+		},
+		{
+			name:     "CODEX_SANDBOX_ID detected",
+			env:      newMockEnv(map[string]string{"CODEX_SANDBOX_ID": "sb"}, false),
+			expected: "codex",
+		},
+		{
+			name:     "DEVIN_SESSION detected",
+			env:      newMockEnv(map[string]string{"DEVIN_SESSION": "d"}, false),
+			expected: "devin",
+		},
+		{
+			name:     "GITHUB_COPILOT detected",
+			env:      newMockEnv(map[string]string{"GITHUB_COPILOT": "1"}, false),
+			expected: "copilot",
+		},
+		{
+			name:     "WINDSURF_SESSION detected",
+			env:      newMockEnv(map[string]string{"WINDSURF_SESSION": "w"}, false),
+			expected: "windsurf",
+		},
+		{
+			name:     "CLINE_TASK_ID detected",
+			env:      newMockEnv(map[string]string{"CLINE_TASK_ID": "t"}, false),
+			expected: "cline",
+		},
+		{
+			name:     "AIDER_MODEL detected",
+			env:      newMockEnv(map[string]string{"AIDER_MODEL": "gpt-4"}, false),
+			expected: "aider",
+		},
+		{
+			name:     "no TTY and no env vars returns no-tty",
+			env:      newMockEnv(map[string]string{}, false),
+			expected: "no-tty",
+		},
+		{
+			name:     "interactive terminal with no agent env vars returns empty",
+			env:      newMockEnv(map[string]string{}, true),
+			expected: "",
+		},
+		{
+			name:     "first matching env var wins by priority order",
+			env:      newMockEnv(map[string]string{"CURSOR_SESSION_ID": "c", "CLAUDE_CODE": "1"}, false),
+			expected: "cursor",
+		},
+		{
+			name:     "stdin is TTY but stdout is not still counts as interactive",
+			env:      mockEnvChecker{envVars: map[string]string{}, stdinTerminal: true, stdoutTerminal: false},
+			expected: "",
+		},
+		{
+			name:     "stdout is TTY but stdin is not still counts as interactive",
+			env:      mockEnvChecker{envVars: map[string]string{}, stdinTerminal: false, stdoutTerminal: true},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectAgentContext(tt.env)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCmdRunEventProperties(t *testing.T) {
+	t.Run("does not set agent_context itself", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.SetArgs([]string{})
+		_ = cmd.Execute()
+
+		props := CmdRunEventProperties(cmd, "test-resource", nil)
+
+		_, hasAgentCtx := props["agent_context"]
+		assert.False(t, hasAgentCtx, "agent_context is injected by sendEvent, not CmdRunEventProperties")
+	})
+
+	t.Run("overrides can still set agent_context", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.SetArgs([]string{})
+		_ = cmd.Execute()
+
+		overrides := map[string]interface{}{"agent_context": "explicit:test-agent"}
+		props := CmdRunEventProperties(cmd, "test-resource", overrides)
+
+		assert.Equal(t, "explicit:test-agent", props["agent_context"])
+	})
+
+	t.Run("returns expected base properties", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.SetArgs([]string{})
+		_ = cmd.Execute()
+
+		props := CmdRunEventProperties(cmd, "flags", nil)
+
+		assert.Equal(t, "flags", props["name"])
+		assert.Contains(t, props, "action")
+		assert.Contains(t, props, "flags")
+	})
+}

--- a/cmd/analytics/analytics_test.go
+++ b/cmd/analytics/analytics_test.go
@@ -99,13 +99,38 @@ func TestDetectAgentContext(t *testing.T) {
 			expected: "aider",
 		},
 		{
-			name:     "no TTY and no env vars returns no-tty",
+			name:     "no TTY and no env vars returns unknown-non-interactive",
 			env:      newMockEnv(map[string]string{}, false),
-			expected: "no-tty",
+			expected: "unknown-non-interactive",
+		},
+		{
+			name:     "CI env var returns ci",
+			env:      newMockEnv(map[string]string{"CI": "true"}, false),
+			expected: "ci",
+		},
+		{
+			name:     "GITHUB_ACTIONS env var returns ci",
+			env:      newMockEnv(map[string]string{"GITHUB_ACTIONS": "true"}, false),
+			expected: "ci",
+		},
+		{
+			name:     "GITLAB_CI env var returns ci",
+			env:      newMockEnv(map[string]string{"GITLAB_CI": "true"}, false),
+			expected: "ci",
+		},
+		{
+			name:     "agent env var takes precedence over CI env var",
+			env:      newMockEnv(map[string]string{"CURSOR_SESSION_ID": "abc", "CI": "true"}, false),
+			expected: "cursor",
 		},
 		{
 			name:     "interactive terminal with no agent env vars returns empty",
 			env:      newMockEnv(map[string]string{}, true),
+			expected: "",
+		},
+		{
+			name:     "CI env var in interactive terminal returns empty",
+			env:      newMockEnv(map[string]string{"CI": "true"}, true),
 			expected: "",
 		},
 		{

--- a/cmd/analytics/known_agents.json
+++ b/cmd/analytics/known_agents.json
@@ -1,0 +1,24 @@
+{
+  "agents": [
+    {"env_var": "CURSOR_SESSION_ID", "label": "cursor"},
+    {"env_var": "CURSOR_TRACE_ID", "label": "cursor"},
+    {"env_var": "CLAUDE_CODE", "label": "claude-code"},
+    {"env_var": "CLAUDE_CODE_SESSION", "label": "claude-code"},
+    {"env_var": "CODEX_SESSION", "label": "codex"},
+    {"env_var": "CODEX_SANDBOX_ID", "label": "codex"},
+    {"env_var": "DEVIN_SESSION", "label": "devin"},
+    {"env_var": "GITHUB_COPILOT", "label": "copilot"},
+    {"env_var": "WINDSURF_SESSION", "label": "windsurf"},
+    {"env_var": "CLINE_TASK_ID", "label": "cline"},
+    {"env_var": "AIDER_MODEL", "label": "aider"}
+  ],
+  "ci_env_vars": [
+    "CI",
+    "GITHUB_ACTIONS",
+    "JENKINS_URL",
+    "CIRCLECI",
+    "BUILDKITE",
+    "GITLAB_CI",
+    "TF_BUILD"
+  ]
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -242,8 +242,9 @@ func Execute(version string) {
 	}
 	configService := config.NewService(resources.NewClient(version))
 	trackerFn := analytics.ClientFn{
-		ID:      uuid.New().String(),
-		Version: version,
+		ID:           uuid.New().String(),
+		Version:      version,
+		AgentContext: cmdAnalytics.DetectAgentContext(),
 	}
 	rootCmd, err := NewRootCommand(
 		configService,

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -12,8 +12,9 @@ import (
 )
 
 type ClientFn struct {
-	ID      string
-	Version string
+	ID           string
+	Version      string
+	AgentContext string
 }
 
 func (fn ClientFn) Tracker(accessToken string, baseURI string, optOut bool) Tracker {
@@ -25,25 +26,30 @@ func (fn ClientFn) Tracker(accessToken string, baseURI string, optOut bool) Trac
 		httpClient: &http.Client{
 			Timeout: time.Second * 3,
 		},
-		id:          fn.ID,
-		version:     fn.Version,
-		accessToken: accessToken,
-		baseURI:     baseURI,
+		id:           fn.ID,
+		version:      fn.Version,
+		accessToken:  accessToken,
+		baseURI:      baseURI,
+		agentContext: fn.AgentContext,
 	}
 }
 
 type Client struct {
-	accessToken string
-	baseURI     string
-	httpClient  *http.Client
-	id          string
-	version     string
-	wg          sync.WaitGroup
+	accessToken  string
+	agentContext string
+	baseURI      string
+	httpClient   *http.Client
+	id           string
+	version      string
+	wg           sync.WaitGroup
 }
 
-// SendEvent makes an async request to track the given event with properties.
+// sendEvent makes an async request to track the given event with properties.
 func (c *Client) sendEvent(eventName string, properties map[string]interface{}) {
 	properties["id"] = c.id
+	if c.agentContext != "" {
+		properties["agent_context"] = c.agentContext
+	}
 	input := struct {
 		Event      string                 `json:"event"`
 		Properties map[string]interface{} `json:"properties"`

--- a/internal/analytics/client_test.go
+++ b/internal/analytics/client_test.go
@@ -1,0 +1,180 @@
+package analytics
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientFn_Tracker(t *testing.T) {
+	t.Run("returns NoopClient when opted out", func(t *testing.T) {
+		fn := ClientFn{ID: "test-id", Version: "1.0.0"}
+		tracker := fn.Tracker("token", "https://app.launchdarkly.com", true)
+
+		_, ok := tracker.(*NoopClient)
+		assert.True(t, ok, "expected NoopClient when optOut is true")
+	})
+
+	t.Run("returns Client when not opted out", func(t *testing.T) {
+		fn := ClientFn{ID: "test-id", Version: "1.0.0"}
+		tracker := fn.Tracker("token", "https://app.launchdarkly.com", false)
+
+		c, ok := tracker.(*Client)
+		require.True(t, ok, "expected *Client when optOut is false")
+		assert.Equal(t, "test-id", c.id)
+		assert.Equal(t, "1.0.0", c.version)
+		assert.Equal(t, "token", c.accessToken)
+		assert.Equal(t, "https://app.launchdarkly.com", c.baseURI)
+	})
+
+	t.Run("passes AgentContext to Client", func(t *testing.T) {
+		fn := ClientFn{ID: "test-id", Version: "1.0.0", AgentContext: "cursor"}
+		tracker := fn.Tracker("token", "https://app.launchdarkly.com", false)
+
+		c, ok := tracker.(*Client)
+		require.True(t, ok)
+		assert.Equal(t, "cursor", c.agentContext)
+	})
+
+	t.Run("AgentContext ignored when opted out", func(t *testing.T) {
+		fn := ClientFn{ID: "test-id", Version: "1.0.0", AgentContext: "cursor"}
+		tracker := fn.Tracker("token", "https://app.launchdarkly.com", true)
+
+		_, ok := tracker.(*NoopClient)
+		assert.True(t, ok, "expected NoopClient regardless of AgentContext when optOut is true")
+	})
+}
+
+type trackingPayload struct {
+	Event      string                 `json:"event"`
+	Properties map[string]interface{} `json:"properties"`
+}
+
+func TestClient_SendEvent(t *testing.T) {
+	t.Run("includes agent_context when set", func(t *testing.T) {
+		var received trackingPayload
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &received)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		fn := ClientFn{ID: "test-id", Version: "1.0.0", AgentContext: "cursor"}
+		tracker := fn.Tracker("test-token", server.URL, false)
+
+		tracker.SendCommandRunEvent(map[string]interface{}{
+			"name":   "flags",
+			"action": "list",
+		})
+		tracker.Wait()
+
+		assert.Equal(t, "CLI Command Run", received.Event)
+		assert.Equal(t, "cursor", received.Properties["agent_context"])
+		assert.Equal(t, "test-id", received.Properties["id"])
+		assert.Equal(t, "flags", received.Properties["name"])
+	})
+
+	t.Run("omits agent_context when empty", func(t *testing.T) {
+		var received trackingPayload
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &received)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		fn := ClientFn{ID: "test-id", Version: "1.0.0"}
+		tracker := fn.Tracker("test-token", server.URL, false)
+
+		tracker.SendCommandRunEvent(map[string]interface{}{
+			"name":   "flags",
+			"action": "list",
+		})
+		tracker.Wait()
+
+		assert.Equal(t, "CLI Command Run", received.Event)
+		_, hasAgentCtx := received.Properties["agent_context"]
+		assert.False(t, hasAgentCtx, "agent_context should not be present when empty")
+		assert.Equal(t, "test-id", received.Properties["id"])
+	})
+
+	t.Run("SendCommandCompletedEvent includes agent_context", func(t *testing.T) {
+		var received trackingPayload
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &received)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		fn := ClientFn{ID: "test-id", Version: "1.0.0", AgentContext: "claude-code"}
+		tracker := fn.Tracker("test-token", server.URL, false)
+
+		tracker.SendCommandCompletedEvent("success")
+		tracker.Wait()
+
+		assert.Equal(t, "CLI Command Completed", received.Event)
+		assert.Equal(t, "claude-code", received.Properties["agent_context"])
+		assert.Equal(t, "success", received.Properties["outcome"])
+	})
+
+	t.Run("sends correct HTTP headers", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "test-token", r.Header.Get("Authorization"))
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			assert.Equal(t, "launchdarkly-cli/1.0.0", r.Header.Get("User-Agent"))
+			assert.Equal(t, "POST", r.Method)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		fn := ClientFn{ID: "test-id", Version: "1.0.0"}
+		tracker := fn.Tracker("test-token", server.URL, false)
+
+		tracker.SendCommandRunEvent(map[string]interface{}{"name": "test"})
+		tracker.Wait()
+	})
+
+	t.Run("posts to /internal/tracking path", func(t *testing.T) {
+		var requestPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		fn := ClientFn{ID: "test-id", Version: "1.0.0"}
+		tracker := fn.Tracker("test-token", server.URL, false)
+
+		tracker.SendCommandRunEvent(map[string]interface{}{"name": "test"})
+		tracker.Wait()
+
+		assert.Equal(t, "/internal/tracking", requestPath)
+	})
+
+	t.Run("SendSetupStepStartedEvent sends correct event name", func(t *testing.T) {
+		var received trackingPayload
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &received)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		fn := ClientFn{ID: "test-id", Version: "1.0.0", AgentContext: "codex"}
+		tracker := fn.Tracker("test-token", server.URL, false)
+
+		tracker.SendSetupStepStartedEvent("connect")
+		tracker.Wait()
+
+		assert.Equal(t, "CLI Setup Step Started", received.Event)
+		assert.Equal(t, "connect", received.Properties["step"])
+		assert.Equal(t, "codex", received.Properties["agent_context"])
+	})
+}


### PR DESCRIPTION
Adds an agent_context property to CLI analytics events that indicates whether the CLI is being used by an agent or a human. Detection checks for known agent environment variables (Cursor, Claude Code, Codex, Devin, Windsurf, Cline, Aider) and TTY status. An explicit LD_CLI_AGENT env var allows unknown agents and skills to self-identify. This is telemetry only. The CLI works identically regardless of detection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk telemetry-only change that adds an extra property to analytics payloads; main risk is misclassification or unexpected init panic if the embedded `known_agents.json` were malformed.
> 
> **Overview**
> Adds automatic agent/CI detection for analytics by introducing `DetectAgentContext()` (backed by embedded `known_agents.json` plus TTY checks and an overriding `LD_CLI_AGENT` env var).
> 
> Threads the resulting `AgentContext` from `cmd/root.go` into `internal/analytics.ClientFn` and injects `agent_context` into all tracked event payloads when non-empty, with new unit tests covering detection precedence and payload inclusion/omission.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a4f7c71ab4f45a06a82a3727c53180b6c57dcdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ld-jira-link -->
---
Related Jira issue: [REL-12753: Agent vs human usage telemetry](https://launchdarkly.atlassian.net/browse/REL-12753)
<!-- end-ld-jira-link -->