### PR TITLE
feat(REL-12755): adding --fields flag

### DIFF
--- a/cmd/cliflags/flags.go
+++ b/cmd/cliflags/flags.go
@@ -13,6 +13,15 @@ func GetOutputKind(cmd *cobra.Command) string {
 	return viper.GetString(OutputFlag)
 }
 
+// GetFields returns the list of fields to include in JSON output, or nil if not specified.
+func GetFields(cmd *cobra.Command) []string {
+	fields, err := cmd.Root().PersistentFlags().GetStringSlice(FieldsFlag)
+	if err != nil {
+		return nil
+	}
+	return fields
+}
+
 const (
 	BaseURIDefault      = "https://app.launchdarkly.com"
 	DevStreamURIDefault = "https://stream.launchdarkly.com"
@@ -27,6 +36,7 @@ const (
 	DevStreamURIFlag = "dev-stream-uri"
 	EmailsFlag       = "emails"
 	EnvironmentFlag  = "environment"
+	FieldsFlag       = "fields"
 	FlagFlag         = "flag"
 	JSONFlag         = "json"
 	OutputFlag       = "output"
@@ -42,6 +52,7 @@ const (
 	CorsOriginFlagDescription  = "Allowed CORS origin. Use '*' for all origins (default: '*')"
 	DevStreamURIDescription    = "Streaming service endpoint that the dev server uses to obtain authoritative flag data. This may be a LaunchDarkly or Relay Proxy endpoint"
 	EnvironmentFlagDescription = "Default environment key"
+	FieldsFlagDescription      = "Comma-separated list of top-level fields to include in JSON output (e.g., --fields key,name,kind)"
 	FlagFlagDescription        = "Default feature flag key"
 	JSONFlagDescription        = "Output JSON format (shorthand for --output json)"
 	OutputFlagDescription      = "Output format: json or plaintext (default: plaintext in a terminal, json otherwise)"

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -287,7 +287,7 @@ func outputSetAction(newFields []string) (string, error) {
 		Items: newFields,
 	}
 	fieldsJSON, _ := json.Marshal(fields)
-	output, err := output.CmdOutput("update", viper.GetString(cliflags.OutputFlag), fieldsJSON)
+	output, err := output.CmdOutput("update", viper.GetString(cliflags.OutputFlag), fieldsJSON, nil)
 	if err != nil {
 		return "", errs.NewError(err.Error())
 	}
@@ -302,7 +302,7 @@ func outputUnsetAction(newField string) (string, error) {
 		Key: newField,
 	}
 	fieldJSON, _ := json.Marshal(field)
-	output, err := output.CmdOutput("delete", viper.GetString(cliflags.OutputFlag), fieldJSON)
+	output, err := output.CmdOutput("delete", viper.GetString(cliflags.OutputFlag), fieldJSON, nil)
 	if err != nil {
 		return "", errs.NewError(err.Error())
 	}

--- a/cmd/config/testdata/help.golden
+++ b/cmd/config/testdata/help.golden
@@ -27,5 +27,6 @@ Global Flags:
       --access-token string   LaunchDarkly access token with write-level access
       --analytics-opt-out     Opt out of analytics tracking
       --base-uri string       LaunchDarkly base URI (default "https://app.launchdarkly.com")
+      --fields strings        Comma-separated list of top-level fields to include in JSON output (e.g., --fields key,name,kind)
       --json                  Output JSON format (shorthand for --output json)
   -o, --output string         Output format: json or plaintext (default: plaintext in a terminal, json otherwise) (default "plaintext")

--- a/cmd/flags/archive.go
+++ b/cmd/flags/archive.go
@@ -51,7 +51,9 @@ func makeArchiveRequest(client resources.Client) func(*cobra.Command, []string) 
 			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd), output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/flags/archive.go
+++ b/cmd/flags/archive.go
@@ -51,7 +51,7 @@ func makeArchiveRequest(client resources.Client) func(*cobra.Command, []string) 
 			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res)
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/flags/archive_test.go
+++ b/cmd/flags/archive_test.go
@@ -39,7 +39,11 @@ func TestArchive(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, `[{"op": "replace", "path": "/archived", "value": true}]`, string(mockClient.Input))
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated\n\nKey:")
+		assert.Contains(t, string(output), "test-flag")
+		assert.Contains(t, string(output), "Name:")
+		assert.Contains(t, string(output), "test flag")
+		assert.NotContains(t, string(output), "* ")
 	})
 
 	t.Run("succeeds with JSON output", func(t *testing.T) {
@@ -146,7 +150,9 @@ func TestArchive(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated")
+		assert.Contains(t, string(output), "Key:")
+		assert.Contains(t, string(output), "test-flag")
 	})
 
 	t.Run("returns error with missing flags", func(t *testing.T) {

--- a/cmd/flags/archive_test.go
+++ b/cmd/flags/archive_test.go
@@ -15,11 +15,13 @@ func TestArchive(t *testing.T) {
 	mockClient := &resources.MockClient{
 		Response: []byte(`{
 			"key": "test-flag",
-			"name": "test flag"
+			"name": "test flag",
+			"kind": "boolean",
+			"archived": true
 		}`),
 	}
 
-	t.Run("succeeds with valid inputs", func(t *testing.T) {
+	t.Run("succeeds with plaintext output", func(t *testing.T) {
 		args := []string{
 			"flags", "archive",
 			"--access-token", "abcd1234",
@@ -39,6 +41,114 @@ func TestArchive(t *testing.T) {
 		assert.Equal(t, `[{"op": "replace", "path": "/archived", "value": true}]`, string(mockClient.Input))
 		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
 	})
+
+	t.Run("succeeds with JSON output", func(t *testing.T) {
+		args := []string{
+			"flags", "archive",
+			"--access-token", "abcd1234",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--output", "json",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag","kind":"boolean","archived":true}`, string(output))
+	})
+
+	t.Run("succeeds with --json shorthand", func(t *testing.T) {
+		args := []string{
+			"flags", "archive",
+			"--access-token", "abcd1234",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--json",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag","kind":"boolean","archived":true}`, string(output))
+	})
+
+	t.Run("filters JSON output with --fields", func(t *testing.T) {
+		args := []string{
+			"flags", "archive",
+			"--access-token", "abcd1234",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--output", "json",
+			"--fields", "key,name",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag"}`, string(output))
+	})
+
+	t.Run("filters JSON output with --json and --fields", func(t *testing.T) {
+		args := []string{
+			"flags", "archive",
+			"--access-token", "abcd1234",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--json",
+			"--fields", "key,name",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag"}`, string(output))
+	})
+
+	t.Run("ignores --fields with plaintext output", func(t *testing.T) {
+		args := []string{
+			"flags", "archive",
+			"--access-token", "abcd1234",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--fields", "key",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+	})
+
 	t.Run("returns error with missing flags", func(t *testing.T) {
 		args := []string{
 			"flags", "archive",
@@ -55,6 +165,6 @@ func TestArchive(t *testing.T) {
 		)
 
 		assert.Error(t, err)
-		assert.Equal(t, "required flag(s) \"project\" not set. See `ldcli flags archive --help` for supported flags and usage.", err.Error())
+		assert.Contains(t, err.Error(), `required flag(s) "project" not set`)
 	})
 }

--- a/cmd/flags/toggle.go
+++ b/cmd/flags/toggle.go
@@ -73,7 +73,9 @@ func runE(client resources.Client) func(*cobra.Command, []string) error {
 			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd), output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/flags/toggle.go
+++ b/cmd/flags/toggle.go
@@ -73,7 +73,7 @@ func runE(client resources.Client) func(*cobra.Command, []string) error {
 			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res)
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/flags/toggle_test.go
+++ b/cmd/flags/toggle_test.go
@@ -15,26 +15,328 @@ func TestToggleOn(t *testing.T) {
 	mockClient := &resources.MockClient{
 		Response: []byte(`{
 			"key": "test-flag",
-			"name": "test flag"
+			"name": "test flag",
+			"kind": "boolean",
+			"temporary": true
 		}`),
 	}
-	args := []string{
-		"flags", "toggle-on",
-		"--access-token", "abcd1234",
-		"--environment", "test-env",
-		"--flag", "test-flag",
-		"--project", "test-proj",
-	}
-	output, err := cmd.CallCmd(
-		t,
-		cmd.APIClients{
-			ResourcesClient: mockClient,
-		},
-		analytics.NoopClientFn{}.Tracker(),
-		args,
-	)
 
-	require.NoError(t, err)
-	assert.Equal(t, `[{"op": "replace", "path": "/environments/test-env/on", "value": true}]`, string(mockClient.Input))
-	assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+	t.Run("succeeds with plaintext output", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-on",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, `[{"op": "replace", "path": "/environments/test-env/on", "value": true}]`, string(mockClient.Input))
+		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+	})
+
+	t.Run("succeeds with JSON output", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-on",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--output", "json",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag","kind":"boolean","temporary":true}`, string(output))
+	})
+
+	t.Run("succeeds with --json shorthand", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-on",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--json",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag","kind":"boolean","temporary":true}`, string(output))
+	})
+
+	t.Run("filters JSON output with --fields", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-on",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--output", "json",
+			"--fields", "key,name",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag"}`, string(output))
+	})
+
+	t.Run("filters JSON output with --json and --fields", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-on",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--json",
+			"--fields", "key,name",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag"}`, string(output))
+	})
+
+	t.Run("ignores --fields with plaintext output", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-on",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--fields", "key",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+	})
+
+	t.Run("returns error with missing required flags", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-on",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+		}
+		_, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `required flag(s) "project" not set`)
+	})
+}
+
+func TestToggleOff(t *testing.T) {
+	mockClient := &resources.MockClient{
+		Response: []byte(`{
+			"key": "test-flag",
+			"name": "test flag",
+			"kind": "boolean",
+			"temporary": true
+		}`),
+	}
+
+	t.Run("succeeds with plaintext output", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-off",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, `[{"op": "replace", "path": "/environments/test-env/on", "value": false}]`, string(mockClient.Input))
+		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+	})
+
+	t.Run("succeeds with JSON output", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-off",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--output", "json",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag","kind":"boolean","temporary":true}`, string(output))
+	})
+
+	t.Run("succeeds with --json shorthand", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-off",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--json",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag","kind":"boolean","temporary":true}`, string(output))
+	})
+
+	t.Run("filters JSON output with --fields", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-off",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--output", "json",
+			"--fields", "key,name",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag"}`, string(output))
+	})
+
+	t.Run("filters JSON output with --json and --fields", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-off",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--json",
+			"--fields", "key,name",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"test-flag","name":"test flag"}`, string(output))
+	})
+
+	t.Run("ignores --fields with plaintext output", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-off",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+			"--project", "test-proj",
+			"--fields", "key",
+		}
+		output, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+	})
+
+	t.Run("returns error with missing required flags", func(t *testing.T) {
+		args := []string{
+			"flags", "toggle-off",
+			"--access-token", "abcd1234",
+			"--environment", "test-env",
+			"--flag", "test-flag",
+		}
+		_, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `required flag(s) "project" not set`)
+	})
 }

--- a/cmd/flags/toggle_test.go
+++ b/cmd/flags/toggle_test.go
@@ -40,7 +40,11 @@ func TestToggleOn(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, `[{"op": "replace", "path": "/environments/test-env/on", "value": true}]`, string(mockClient.Input))
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated\n\nKey:")
+		assert.Contains(t, string(output), "test-flag")
+		assert.Contains(t, string(output), "Name:")
+		assert.Contains(t, string(output), "test flag")
+		assert.NotContains(t, string(output), "* ")
 	})
 
 	t.Run("succeeds with JSON output", func(t *testing.T) {
@@ -152,7 +156,9 @@ func TestToggleOn(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated")
+		assert.Contains(t, string(output), "Key:")
+		assert.Contains(t, string(output), "test-flag")
 	})
 
 	t.Run("returns error with missing required flags", func(t *testing.T) {
@@ -205,7 +211,11 @@ func TestToggleOff(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, `[{"op": "replace", "path": "/environments/test-env/on", "value": false}]`, string(mockClient.Input))
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated\n\nKey:")
+		assert.Contains(t, string(output), "test-flag")
+		assert.Contains(t, string(output), "Name:")
+		assert.Contains(t, string(output), "test flag")
+		assert.NotContains(t, string(output), "* ")
 	})
 
 	t.Run("succeeds with JSON output", func(t *testing.T) {
@@ -317,7 +327,9 @@ func TestToggleOff(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated")
+		assert.Contains(t, string(output), "Key:")
+		assert.Contains(t, string(output), "test-flag")
 	})
 
 	t.Run("returns error with missing required flags", func(t *testing.T) {

--- a/cmd/members/invite.go
+++ b/cmd/members/invite.go
@@ -63,7 +63,9 @@ func runE(client resources.Client) func(*cobra.Command, []string) error {
 			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd), output.CmdOutputOpts{
+			ResourceName: "members",
+		})
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/members/invite.go
+++ b/cmd/members/invite.go
@@ -63,7 +63,7 @@ func runE(client resources.Client) func(*cobra.Command, []string) error {
 			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res)
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/members/invite_test.go
+++ b/cmd/members/invite_test.go
@@ -45,5 +45,11 @@ func TestInvite(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, `[{"email":"test1@test.com","role":"writer"},{"email":"test2@test.com","role":"writer"}]`, string(mockClient.Input))
-	assert.Equal(t, "Successfully updated\n* test1@test.com (000000000000000000000001)\n* test2@test.com (000000000000000000000002)\n", string(output))
+	assert.Contains(t, string(output), "Successfully updated")
+	assert.Contains(t, string(output), "EMAIL")
+	assert.Contains(t, string(output), "ROLE")
+	assert.Contains(t, string(output), "test1@test.com")
+	assert.Contains(t, string(output), "test2@test.com")
+	assert.Contains(t, string(output), "writer")
+	assert.NotContains(t, string(output), "* ")
 }

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -349,7 +349,9 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 		res = []byte(fmt.Sprintf(`{"key": %q}`, urlParms[len(urlParms)-1]))
 	}
 
-	output, err := output.CmdOutput(cmd.Use, cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
+	output, err := output.CmdOutput(cmd.Use, cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd), output.CmdOutputOpts{
+		ResourceName: cmd.Parent().Name(),
+	})
 	if err != nil {
 		return errors.NewError(err.Error())
 	}

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -349,7 +349,7 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 		res = []byte(fmt.Sprintf(`{"key": %q}`, urlParms[len(urlParms)-1]))
 	}
 
-	output, err := output.CmdOutput(cmd.Use, cliflags.GetOutputKind(cmd), res)
+	output, err := output.CmdOutput(cmd.Use, cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
 	if err != nil {
 		return errors.NewError(err.Error())
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -214,6 +214,12 @@ func NewRootCommand(
 		cliflags.JSONFlagDescription,
 	)
 
+	cmd.PersistentFlags().StringSlice(
+		cliflags.FieldsFlag,
+		nil,
+		cliflags.FieldsFlagDescription,
+	)
+
 	configCmd := configcmd.NewConfigCmd(configService, analyticsTrackerFn)
 	cmd.AddCommand(configCmd.Cmd())
 	cmd.AddCommand(NewQuickStartCmd(analyticsTrackerFn, clients.EnvironmentsClient, clients.FlagsClient))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -101,8 +101,8 @@ func TestOutputFlags(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Contains(t, string(output), "Successfully updated")
-		assert.Contains(t, string(output), "test-name (test-key)")
+		assert.Contains(t, string(output), "Successfully updated\n\nKey:")
+		assert.Contains(t, string(output), "test-key")
 	})
 }
 
@@ -205,7 +205,8 @@ func TestTTYDefaultOutput(t *testing.T) {
 
 		out := execNonTTYCmd(t, mockClient)
 		assert.Contains(t, string(out), "Successfully updated")
-		assert.Contains(t, string(out), "test-name (test-key)")
+		assert.Contains(t, string(out), "Key:")
+		assert.Contains(t, string(out), "test-key")
 	})
 
 	t.Run("FORCE_TTY overrides non-TTY detection", func(t *testing.T) {

--- a/internal/output/plaintext_fns.go
+++ b/internal/output/plaintext_fns.go
@@ -62,19 +62,19 @@ var SingularPlaintextOutputFn = func(r resource) string {
 
 	switch {
 	case name != nil && key != nil:
-		return fmt.Sprintf("%s (%s)", name.(string), key.(string))
+		return fmt.Sprintf("%s (%s)", fmt.Sprint(name), fmt.Sprint(key))
 	case email != nil && id != nil:
-		return fmt.Sprintf("%s (%s)", email.(string), id.(string))
+		return fmt.Sprintf("%s (%s)", fmt.Sprint(email), fmt.Sprint(id))
 	case name != nil && id != nil:
-		return fmt.Sprintf("%s (%s)", name.(string), id.(string))
+		return fmt.Sprintf("%s (%s)", fmt.Sprint(name), fmt.Sprint(id))
 	case key != nil:
-		return key.(string)
+		return fmt.Sprint(key)
 	case email != nil:
-		return email.(string)
+		return fmt.Sprint(email)
 	case id != nil:
-		return id.(string)
+		return fmt.Sprint(id)
 	case name != nil:
-		return name.(string)
+		return fmt.Sprint(name)
 	default:
 		return "cannot read resource"
 	}

--- a/internal/output/plaintext_fns_internal_test.go
+++ b/internal/output/plaintext_fns_internal_test.go
@@ -7,6 +7,54 @@ import (
 )
 
 func TestErrorPlaintextOutputFn(t *testing.T) {
+	t.Run("with code and message", func(t *testing.T) {
+		r := resource{"code": "conflict", "message": "resource already exists"}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "resource already exists (code: conflict)", result)
+	})
+
+	t.Run("with only a message", func(t *testing.T) {
+		r := resource{"message": "something went wrong"}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "something went wrong", result)
+	})
+
+	t.Run("with only a code", func(t *testing.T) {
+		r := resource{"code": "not_found", "message": ""}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "an error occurred (code: not_found)", result)
+	})
+
+	t.Run("with neither code nor message", func(t *testing.T) {
+		r := resource{}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "unknown error occurred", result)
+	})
+
+	t.Run("with empty message and nil code", func(t *testing.T) {
+		r := resource{"message": ""}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "unknown error occurred", result)
+	})
+
+	t.Run("with suggestion appends suggestion line", func(t *testing.T) {
+		r := resource{"code": "not_found", "message": "Not Found", "suggestion": "Try ldcli flags list."}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "Not Found (code: not_found)\nSuggestion: Try ldcli flags list.", result)
+	})
+
 	t.Run("with a non-string message does not panic", func(t *testing.T) {
 		r := resource{"message": float64(404)}
 
@@ -30,6 +78,91 @@ func TestErrorPlaintextOutputFn(t *testing.T) {
 
 		assert.Equal(t, "42 (code: true)", result)
 	})
+}
+
+func TestMultiplePlaintextOutputFn(t *testing.T) {
+	tests := map[string]struct {
+		resource resource
+		expected string
+	}{
+		"with a name and key": {
+			resource: resource{
+				"key":  "test-key",
+				"name": "test-name",
+			},
+			expected: "* test-name (test-key)",
+		},
+		"with only a key": {
+			resource: resource{
+				"key": "test-key",
+			},
+			expected: "* test-key",
+		},
+		"with an email and ID": {
+			resource: resource{
+				"_id":   "test-id",
+				"email": "test-email",
+			},
+			expected: "* test-email (test-id)",
+		},
+		"without any valid field": {
+			resource: resource{
+				"other": "other-value",
+			},
+			expected: "* cannot read resource",
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			out := MultiplePlaintextOutputFn(tt.resource)
+
+			assert.Equal(t, tt.expected, out)
+		})
+	}
+}
+
+func TestConfigPlaintextOutputFn(t *testing.T) {
+	tests := map[string]struct {
+		resource resource
+		expected string
+	}{
+		"with multiple keys sorts alphabetically": {
+			resource: resource{
+				"zeta":  "last",
+				"alpha": "first",
+				"mid":   "middle",
+			},
+			expected: "alpha: first\nmid: middle\nzeta: last",
+		},
+		"with single key": {
+			resource: resource{
+				"key": "value",
+			},
+			expected: "key: value",
+		},
+		"with empty resource": {
+			resource: resource{},
+			expected: "",
+		},
+		"with non-string values": {
+			resource: resource{
+				"count":   float64(42),
+				"enabled": true,
+			},
+			expected: "count: 42\nenabled: true",
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			out := ConfigPlaintextOutputFn(tt.resource)
+
+			assert.Equal(t, tt.expected, out)
+		})
+	}
 }
 
 func TestSingularPlaintextOutputFn(t *testing.T) {
@@ -76,6 +209,32 @@ func TestSingularPlaintextOutputFn(t *testing.T) {
 				"other": "other-value",
 			},
 			expected: "cannot read resource",
+		},
+		"with non-string name and key does not panic": {
+			resource: resource{
+				"key":  float64(123),
+				"name": true,
+			},
+			expected: "true (123)",
+		},
+		"with non-string email and id does not panic": {
+			resource: resource{
+				"_id":   float64(999),
+				"email": float64(42),
+			},
+			expected: "42 (999)",
+		},
+		"with non-string key only does not panic": {
+			resource: resource{
+				"key": float64(456),
+			},
+			expected: "456",
+		},
+		"with non-string name only does not panic": {
+			resource: resource{
+				"name": float64(789),
+			},
+			expected: "789",
 		},
 	}
 

--- a/internal/output/resource_output.go
+++ b/internal/output/resource_output.go
@@ -12,10 +12,25 @@ import (
 	errs "github.com/launchdarkly/ldcli/internal/errors"
 )
 
+// CmdOutputOpts configures optional behavior for CmdOutput.
+type CmdOutputOpts struct {
+	Fields       []string
+	ResourceName string
+}
+
 // CmdOutput returns a response from a resource action formatted based on the output flag along with
 // an optional message based on the action. When fields is non-empty and outputKind is "json",
-// only the specified top-level fields are included in the output.
-func CmdOutput(action string, outputKind string, input []byte, fields []string) (string, error) {
+// only the specified top-level fields are included in the output. When resourceName matches a
+// registered resource, list output uses table formatting and singular output uses key-value pairs.
+func CmdOutput(action string, outputKind string, input []byte, fields []string, opts ...CmdOutputOpts) (string, error) {
+	var resourceName string
+	if len(opts) > 0 {
+		resourceName = opts[0].ResourceName
+		if len(fields) == 0 {
+			fields = opts[0].Fields
+		}
+	}
+
 	if outputKind == "json" {
 		if len(fields) > 0 {
 			filtered, err := filterFields(input, fields)
@@ -67,6 +82,13 @@ func CmdOutput(action string, outputKind string, input []byte, fields []string) 
 	}
 
 	if !isMultipleResponse {
+		if cols := GetSingularColumns(resourceName); cols != nil {
+			kv := KeyValueOutput(maybeResource, cols)
+			if strings.TrimSpace(successMessage) != "" {
+				return successMessage + "\n\n" + kv, nil
+			}
+			return kv, nil
+		}
 		return plaintextOutput(SingularPlaintextOutputFn(maybeResource), successMessage+" "), nil
 	}
 
@@ -74,9 +96,15 @@ func CmdOutput(action string, outputKind string, input []byte, fields []string) 
 		return "No items found", nil
 	}
 
-	items := make([]string, 0, len(maybeResources.Items))
-	for _, i := range maybeResources.Items {
-		items = append(items, MultiplePlaintextOutputFn(i))
+	var body string
+	if cols := GetListColumns(resourceName); cols != nil {
+		body = TableOutput(maybeResources.Items, cols)
+	} else {
+		items := make([]string, 0, len(maybeResources.Items))
+		for _, i := range maybeResources.Items {
+			items = append(items, MultiplePlaintextOutputFn(i))
+		}
+		body = strings.Join(items, "\n")
 	}
 
 	var (
@@ -107,7 +135,7 @@ func CmdOutput(action string, outputKind string, input []byte, fields []string) 
 	if successMessage != "" {
 		successMessage += "\n"
 	}
-	return plaintextOutput(strings.Join(items, "\n"), successMessage) + pagination, nil
+	return plaintextOutput(body, successMessage) + pagination, nil
 }
 
 func plaintextOutput(out string, successMessage string) string {

--- a/internal/output/resource_output.go
+++ b/internal/output/resource_output.go
@@ -13,9 +13,17 @@ import (
 )
 
 // CmdOutput returns a response from a resource action formatted based on the output flag along with
-// an optional message based on the action.
-func CmdOutput(action string, outputKind string, input []byte) (string, error) {
+// an optional message based on the action. When fields is non-empty and outputKind is "json",
+// only the specified top-level fields are included in the output.
+func CmdOutput(action string, outputKind string, input []byte, fields []string) (string, error) {
 	if outputKind == "json" {
+		if len(fields) > 0 {
+			filtered, err := filterFields(input, fields)
+			if err != nil {
+				return string(input), nil
+			}
+			return string(filtered), nil
+		}
 		return string(input), nil
 	}
 
@@ -139,6 +147,56 @@ func CmdOutputError(outputKind string, err error) string {
 // NewCmdOutputError builds error output based on the error and output kind.
 func NewCmdOutputError(err error, outputKind string) error {
 	return errs.NewError(CmdOutputError(outputKind, err))
+}
+
+func filterFields(input []byte, fields []string) ([]byte, error) {
+	fieldSet := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		if trimmed := strings.TrimSpace(f); trimmed != "" {
+			fieldSet[trimmed] = true
+		}
+	}
+	if len(fieldSet) == 0 {
+		return input, nil
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(input, &raw); err != nil {
+		return nil, err
+	}
+
+	if items, ok := raw["items"]; ok {
+		if itemList, ok := items.([]interface{}); ok {
+			filtered := make([]interface{}, 0, len(itemList))
+			for _, item := range itemList {
+				if m, ok := item.(map[string]interface{}); ok {
+					filtered = append(filtered, filterMap(m, fieldSet))
+				} else {
+					filtered = append(filtered, item)
+				}
+			}
+			result := map[string]interface{}{"items": filtered}
+			if tc, ok := raw["totalCount"]; ok {
+				result["totalCount"] = tc
+			}
+			if links, ok := raw["_links"]; ok {
+				result["_links"] = links
+			}
+			return json.MarshalIndent(result, "", "  ")
+		}
+	}
+
+	return json.MarshalIndent(filterMap(raw, fieldSet), "", "  ")
+}
+
+func filterMap(m map[string]interface{}, fields map[string]bool) map[string]interface{} {
+	result := make(map[string]interface{}, len(fields))
+	for k, v := range m {
+		if fields[k] {
+			result[k] = v
+		}
+	}
+	return result
 }
 
 func errJSON(s string) string {

--- a/internal/output/resource_output_test.go
+++ b/internal/output/resource_output_test.go
@@ -26,7 +26,7 @@ func TestCmdOutput(t *testing.T) {
 			t.Run("returns a success message", func(t *testing.T) {
 				expected := "* test-id"
 
-				result, err := output.CmdOutput("list", "plaintext", []byte(input))
+				result, err := output.CmdOutput("list", "plaintext", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.Equal(t, expected, result)
@@ -78,7 +78,7 @@ func TestCmdOutput(t *testing.T) {
 					tt.offset,
 				)
 
-				result, err := output.CmdOutput("list", "plaintext", []byte(input))
+				result, err := output.CmdOutput("list", "plaintext", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.Equal(t, tt.expected, result)
@@ -100,7 +100,7 @@ func TestCmdOutput(t *testing.T) {
 			t.Run("returns a list of resources", func(t *testing.T) {
 				expected := "* test-name (test-id)"
 
-				result, err := output.CmdOutput("list", "plaintext", []byte(input))
+				result, err := output.CmdOutput("list", "plaintext", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.Equal(t, expected, result)
@@ -127,7 +127,7 @@ func TestCmdOutput(t *testing.T) {
 			t.Run("returns the list", func(t *testing.T) {
 				expected := "* tag1\n* tag2\nShowing results 1 - 2 of 2."
 
-				result, err := output.CmdOutput("list", "plaintext", []byte(input))
+				result, err := output.CmdOutput("list", "plaintext", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.Equal(t, expected, result)
@@ -144,7 +144,7 @@ func TestCmdOutput(t *testing.T) {
 
 		t.Run("with JSON output", func(t *testing.T) {
 			t.Run("returns the JSON", func(t *testing.T) {
-				result, err := output.CmdOutput("create", "json", []byte(input))
+				result, err := output.CmdOutput("create", "json", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.JSONEq(t, input, result)
@@ -155,7 +155,7 @@ func TestCmdOutput(t *testing.T) {
 			t.Run("returns a success message", func(t *testing.T) {
 				expected := "Successfully created test-name (test-key)"
 
-				result, err := output.CmdOutput("create", "plaintext", []byte(input))
+				result, err := output.CmdOutput("create", "plaintext", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.Equal(t, expected, result)
@@ -176,7 +176,7 @@ func TestCmdOutput(t *testing.T) {
 
 		t.Run("with JSON output", func(t *testing.T) {
 			t.Run("returns the JSON", func(t *testing.T) {
-				result, err := output.CmdOutput("create", "json", []byte(input))
+				result, err := output.CmdOutput("create", "json", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.JSONEq(t, input, result)
@@ -187,7 +187,7 @@ func TestCmdOutput(t *testing.T) {
 			t.Run("returns a success message", func(t *testing.T) {
 				expected := "Successfully created\n* test-name (test-key)"
 
-				result, err := output.CmdOutput("create", "plaintext", []byte(input))
+				result, err := output.CmdOutput("create", "plaintext", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.Equal(t, expected, result)
@@ -208,7 +208,7 @@ func TestCmdOutput(t *testing.T) {
 
 		t.Run("with JSON output", func(t *testing.T) {
 			t.Run("returns the JSON", func(t *testing.T) {
-				result, err := output.CmdOutput("create", "json", []byte(input))
+				result, err := output.CmdOutput("create", "json", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.JSONEq(t, input, result)
@@ -219,7 +219,7 @@ func TestCmdOutput(t *testing.T) {
 			t.Run("returns a success message", func(t *testing.T) {
 				expected := "Successfully created\n* test-email (test-id)"
 
-				result, err := output.CmdOutput("create", "plaintext", []byte(input))
+				result, err := output.CmdOutput("create", "plaintext", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.Equal(t, expected, result)
@@ -235,7 +235,7 @@ func TestCmdOutput(t *testing.T) {
 
 		t.Run("with JSON output", func(t *testing.T) {
 			t.Run("does not return anything", func(t *testing.T) {
-				result, err := output.CmdOutput("delete", "json", []byte(""))
+				result, err := output.CmdOutput("delete", "json", []byte(""), nil)
 
 				require.NoError(t, err)
 				assert.Equal(t, "", result)
@@ -247,7 +247,7 @@ func TestCmdOutput(t *testing.T) {
 				t.Run("returns a success message", func(t *testing.T) {
 					expected := "Successfully deleted test-name (test-key)"
 
-					result, err := output.CmdOutput("delete", "plaintext", []byte(input))
+					result, err := output.CmdOutput("delete", "plaintext", []byte(input), nil)
 
 					require.NoError(t, err)
 					assert.Equal(t, expected, result)
@@ -261,7 +261,7 @@ func TestCmdOutput(t *testing.T) {
 						"key": "test-key"
 					}`
 
-					result, err := output.CmdOutput("delete", "plaintext", []byte(input))
+					result, err := output.CmdOutput("delete", "plaintext", []byte(input), nil)
 
 					require.NoError(t, err)
 					assert.Equal(t, expected, result)
@@ -279,7 +279,7 @@ func TestCmdOutput(t *testing.T) {
 
 		t.Run("with JSON output", func(t *testing.T) {
 			t.Run("returns the JSON", func(t *testing.T) {
-				result, err := output.CmdOutput("update", "json", []byte(input))
+				result, err := output.CmdOutput("update", "json", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.JSONEq(t, input, result)
@@ -290,7 +290,7 @@ func TestCmdOutput(t *testing.T) {
 			t.Run("returns a success message", func(t *testing.T) {
 				expected := "Successfully updated test-name (test-key)"
 
-				result, err := output.CmdOutput("update", "plaintext", []byte(input))
+				result, err := output.CmdOutput("update", "plaintext", []byte(input), nil)
 
 				require.NoError(t, err)
 				assert.Equal(t, expected, result)
@@ -393,5 +393,221 @@ func TestCmdOutputError(t *testing.T) {
 			assert.Equal(t, "Internal Server Error (code: internal_server_error)", result)
 			assert.NotContains(t, result, "Suggestion:")
 		})
+	})
+}
+
+func TestCmdOutputWithFields(t *testing.T) {
+	t.Run("filters singular resource to requested fields", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag","kind":"boolean","temporary":true,"extra":"noise"}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"key", "name"})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"my-flag","name":"My Flag"}`, result)
+	})
+
+	t.Run("filters collection items and preserves totalCount and _links", func(t *testing.T) {
+		input := `{
+			"items": [
+				{"key":"flag-1","name":"Flag 1","kind":"boolean","extra":"noise"},
+				{"key":"flag-2","name":"Flag 2","kind":"multivariate","extra":"more noise"}
+			],
+			"totalCount": 2,
+			"_links": {
+				"self": {"href":"/api/v2/flags/proj?limit=20&offset=0","type":"application/json"}
+			}
+		}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"key", "name"})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"items": [
+				{"key":"flag-1","name":"Flag 1"},
+				{"key":"flag-2","name":"Flag 2"}
+			],
+			"totalCount": 2,
+			"_links": {
+				"self": {"href":"/api/v2/flags/proj?limit=20&offset=0","type":"application/json"}
+			}
+		}`, result)
+	})
+
+	t.Run("omits non-existent fields without error", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag"}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"key", "doesNotExist"})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"my-flag"}`, result)
+	})
+
+	t.Run("returns full JSON when fields is empty slice", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag","kind":"boolean"}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, input, result)
+	})
+
+	t.Run("returns full JSON when fields is nil", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag","kind":"boolean"}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), nil)
+
+		require.NoError(t, err)
+		assert.JSONEq(t, input, result)
+	})
+
+	t.Run("returns original bytes when input is invalid JSON", func(t *testing.T) {
+		input := `not valid json at all`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"key"})
+
+		require.NoError(t, err)
+		assert.Equal(t, input, result)
+	})
+
+	t.Run("preserves nested objects intact when field is selected", func(t *testing.T) {
+		input := `{
+			"key":"my-flag",
+			"name":"My Flag",
+			"environments":{
+				"production":{"on":true,"rules":[]},
+				"staging":{"on":false,"rules":[]}
+			},
+			"variations":[{"value":true},{"value":false}]
+		}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"key", "environments"})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"key":"my-flag",
+			"environments":{
+				"production":{"on":true,"rules":[]},
+				"staging":{"on":false,"rules":[]}
+			}
+		}`, result)
+	})
+
+	t.Run("trims whitespace from field names", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag","kind":"boolean"}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{" key ", " name"})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"my-flag","name":"My Flag"}`, result)
+	})
+
+	t.Run("is ignored when output is plaintext", func(t *testing.T) {
+		input := `{"key":"test-key","name":"test-name","extra":"extra-value"}`
+
+		result, err := output.CmdOutput("create", "plaintext", []byte(input), []string{"key"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "Successfully created test-name (test-key)", result)
+	})
+
+	t.Run("is ignored when output is plaintext for collections", func(t *testing.T) {
+		input := `{"items":[{"key":"test-key","name":"test-name","extra":"extra-value"}]}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), []string{"key"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "* test-name (test-key)", result)
+	})
+
+	t.Run("handles empty JSON object without panic", func(t *testing.T) {
+		input := `{}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"key"})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{}`, result)
+	})
+
+	t.Run("handles empty collection with fields", func(t *testing.T) {
+		input := `{"items":[],"totalCount":0}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"key"})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"items":[],"totalCount":0}`, result)
+	})
+
+	t.Run("preserves scalar items in collection", func(t *testing.T) {
+		input := `{"items":["tag1","tag2"],"totalCount":2}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"key"})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"items":["tag1","tag2"],"totalCount":2}`, result)
+	})
+
+	t.Run("returns all fields when every field is requested", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag"}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"key", "name"})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, input, result)
+	})
+
+	t.Run("returns original input for top-level JSON array", func(t *testing.T) {
+		input := `[{"key":"x"},{"key":"y"}]`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"key"})
+
+		require.NoError(t, err)
+		assert.Equal(t, input, result)
+	})
+
+	t.Run("deduplicates repeated field names", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag","extra":"noise"}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"key", "key", "name"})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"my-flag","name":"My Flag"}`, result)
+	})
+
+	t.Run("skips empty field strings and filters normally", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag","extra":"noise"}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"", " ", "key"})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"my-flag"}`, result)
+	})
+
+	t.Run("returns full JSON when all field strings are empty", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag"}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), []string{"", " "})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, input, result)
+	})
+}
+
+func TestCmdOutputErrorNotAffectedByFields(t *testing.T) {
+	t.Run("JSON error response always returns full structure", func(t *testing.T) {
+		errJSON := `{"code":"not_found","message":"Not Found","statusCode":404,"suggestion":"Try ldcli flags list."}`
+		err := errors.NewError(errJSON)
+
+		result := output.CmdOutputError("json", err)
+
+		assert.JSONEq(t, errJSON, result)
+	})
+
+	t.Run("plaintext error response always returns full structure", func(t *testing.T) {
+		errJSON := `{"code":"conflict","message":"an error"}`
+		err := errors.NewError(errJSON)
+
+		result := output.CmdOutputError("plaintext", err)
+
+		assert.Equal(t, "an error (code: conflict)", result)
 	})
 }

--- a/internal/output/resource_output_test.go
+++ b/internal/output/resource_output_test.go
@@ -592,6 +592,359 @@ func TestCmdOutputWithFields(t *testing.T) {
 	})
 }
 
+func TestCmdOutputWithResourceName(t *testing.T) {
+	t.Run("flags list uses table format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "my-flag",
+					"name": "My Flag",
+					"kind": "boolean",
+					"temporary": true,
+					"tags": ["beta", "frontend"]
+				},
+				{
+					"key": "dark-mode",
+					"name": "Dark Mode",
+					"kind": "boolean",
+					"temporary": false,
+					"tags": ["ui"]
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "NAME")
+		assert.Contains(t, result, "KIND")
+		assert.Contains(t, result, "TEMPORARY")
+		assert.Contains(t, result, "TAGS")
+		assert.Contains(t, result, "my-flag")
+		assert.Contains(t, result, "My Flag")
+		assert.Contains(t, result, "yes")
+		assert.Contains(t, result, "dark-mode")
+		assert.Contains(t, result, "no")
+		assert.NotContains(t, result, "* ")
+	})
+
+	t.Run("flags singular uses key-value format", func(t *testing.T) {
+		input := `{
+			"key": "my-flag",
+			"name": "My Flag",
+			"kind": "boolean",
+			"temporary": true,
+			"creationDate": 1718438400000,
+			"tags": ["beta"]
+		}`
+
+		result, err := output.CmdOutput("get", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "Key:")
+		assert.Contains(t, result, "my-flag")
+		assert.Contains(t, result, "Name:")
+		assert.Contains(t, result, "My Flag")
+		assert.Contains(t, result, "Kind:")
+		assert.Contains(t, result, "boolean")
+		assert.Contains(t, result, "Temporary:")
+		assert.Contains(t, result, "yes")
+	})
+
+	t.Run("flags singular with success message", func(t *testing.T) {
+		input := `{
+			"key": "my-flag",
+			"name": "My Flag",
+			"kind": "boolean",
+			"temporary": false
+		}`
+
+		result, err := output.CmdOutput("update", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "Successfully updated\n\nKey:")
+		assert.Contains(t, result, "my-flag")
+	})
+
+	t.Run("unknown resource falls back to bullet format for lists", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "test-key",
+					"name": "test-name"
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "unknown-resource",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "* test-name (test-key)", result)
+	})
+
+	t.Run("unknown resource falls back to name (key) for singular", func(t *testing.T) {
+		input := `{
+			"key": "test-key",
+			"name": "test-name"
+		}`
+
+		result, err := output.CmdOutput("create", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "unknown-resource",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "Successfully created test-name (test-key)", result)
+	})
+
+	t.Run("empty resource name falls back to bullet format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "test-key",
+					"name": "test-name"
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "* test-name (test-key)", result)
+	})
+
+	t.Run("table output with pagination", func(t *testing.T) {
+		input := `{
+			"_links": {
+				"self": {
+					"href": "/api/v2/flags/proj?limit=5&offset=0",
+					"type": "application/json"
+				}
+			},
+			"items": [
+				{
+					"key": "my-flag",
+					"name": "My Flag",
+					"kind": "boolean",
+					"temporary": true,
+					"tags": ["beta"]
+				}
+			],
+			"totalCount": 100
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "my-flag")
+		assert.Contains(t, result, "Showing results 1 - 5 of 100.")
+		assert.Contains(t, result, "Use --offset 5 for additional results.")
+	})
+
+	t.Run("empty items with resource name returns no items found", func(t *testing.T) {
+		input := `{"items": []}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "No items found", result)
+	})
+
+	t.Run("JSON output is unaffected by resource name", func(t *testing.T) {
+		input := `{
+			"items": [
+				{"key": "my-flag", "name": "My Flag"}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, input, result)
+	})
+
+	t.Run("members list uses table format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"email": "alice@example.com",
+					"role": "admin",
+					"lastName": "Smith",
+					"firstName": "Alice"
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "members",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "EMAIL")
+		assert.Contains(t, result, "ROLE")
+		assert.Contains(t, result, "alice@example.com")
+		assert.Contains(t, result, "admin")
+		assert.NotContains(t, result, "* ")
+	})
+
+	t.Run("environments list uses table format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "production",
+					"name": "Production",
+					"color": "FF0000"
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "environments",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "NAME")
+		assert.Contains(t, result, "COLOR")
+		assert.Contains(t, result, "production")
+		assert.Contains(t, result, "FF0000")
+	})
+
+	t.Run("projects list uses table format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "proj-1",
+					"name": "Project One",
+					"tags": ["tag1", "tag2"]
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "projects",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "proj-1")
+		assert.Contains(t, result, "2")
+	})
+
+	t.Run("segments list uses table format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "beta-users",
+					"name": "Beta Users",
+					"creationDate": 1718438400000
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "segments",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "CREATED")
+		assert.Contains(t, result, "beta-users")
+		assert.Contains(t, result, "2024-06-15")
+	})
+
+	t.Run("create with list and resource name shows table with success message", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "new-flag",
+					"name": "New Flag",
+					"kind": "boolean",
+					"temporary": false,
+					"tags": []
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("create", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "Successfully created")
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "new-flag")
+	})
+
+	t.Run("segments singular uses key-value format", func(t *testing.T) {
+		input := `{
+			"key": "beta-users",
+			"name": "Beta Users",
+			"creationDate": 1718438400000
+		}`
+
+		result, err := output.CmdOutput("get", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "segments",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "Key:")
+		assert.Contains(t, result, "beta-users")
+		assert.Contains(t, result, "Name:")
+		assert.Contains(t, result, "Beta Users")
+		assert.Contains(t, result, "Created:")
+		assert.Contains(t, result, "2024-06-15")
+	})
+
+	t.Run("Fields from opts used when fields param is nil", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag","extra":"noise"}`
+
+		result, err := output.CmdOutput("get", "json", []byte(input), nil, output.CmdOutputOpts{
+			Fields:       []string{"key", "name"},
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"my-flag","name":"My Flag"}`, result)
+	})
+
+	t.Run("explicit fields param takes precedence over opts Fields", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag","extra":"noise"}`
+
+		result, err := output.CmdOutput("get", "json", []byte(input), []string{"key"}, output.CmdOutputOpts{
+			Fields:       []string{"key", "name"},
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"my-flag"}`, result)
+	})
+
+	t.Run("empty items without resource name returns no items found", func(t *testing.T) {
+		input := `{"items": []}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "No items found", result)
+	})
+}
+
 func TestCmdOutputErrorNotAffectedByFields(t *testing.T) {
 	t.Run("JSON error response always returns full structure", func(t *testing.T) {
 		errJSON := `{"code":"not_found","message":"Not Found","statusCode":404,"suggestion":"Try ldcli flags list."}`

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -1,0 +1,198 @@
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+)
+
+// ColumnDef describes a single column in table or key-value output.
+type ColumnDef struct {
+	Header string
+	Field  string
+	Format func(interface{}) string
+}
+
+func defaultFormat(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprint(v)
+}
+
+func boolYesNo(v interface{}) string {
+	switch b := v.(type) {
+	case bool:
+		if b {
+			return "yes"
+		}
+		return "no"
+	default:
+		return defaultFormat(v)
+	}
+}
+
+func truncatedList(max int) func(interface{}) string {
+	return func(v interface{}) string {
+		items, ok := v.([]interface{})
+		if !ok {
+			return defaultFormat(v)
+		}
+		strs := make([]string, 0, len(items))
+		for _, item := range items {
+			strs = append(strs, fmt.Sprint(item))
+		}
+		if len(strs) <= max {
+			return strings.Join(strs, ", ")
+		}
+		return strings.Join(strs[:max], ", ") + ", ..."
+	}
+}
+
+func countList(v interface{}) string {
+	items, ok := v.([]interface{})
+	if !ok {
+		return defaultFormat(v)
+	}
+	return fmt.Sprintf("%d", len(items))
+}
+
+func formatTimestamp(v interface{}) string {
+	switch n := v.(type) {
+	case float64:
+		return time.UnixMilli(int64(n)).UTC().Format(time.RFC3339)
+	default:
+		return defaultFormat(v)
+	}
+}
+
+// listColumnRegistry maps resource names to their list-view column definitions.
+var listColumnRegistry = map[string][]ColumnDef{
+	"flags": {
+		{Header: "KEY", Field: "key"},
+		{Header: "NAME", Field: "name"},
+		{Header: "KIND", Field: "kind"},
+		{Header: "TEMPORARY", Field: "temporary", Format: boolYesNo},
+		{Header: "TAGS", Field: "tags", Format: truncatedList(3)},
+	},
+	"projects": {
+		{Header: "KEY", Field: "key"},
+		{Header: "NAME", Field: "name"},
+		{Header: "TAG COUNT", Field: "tags", Format: countList},
+	},
+	"environments": {
+		{Header: "KEY", Field: "key"},
+		{Header: "NAME", Field: "name"},
+		{Header: "COLOR", Field: "color"},
+	},
+	"members": {
+		{Header: "EMAIL", Field: "email"},
+		{Header: "ROLE", Field: "role"},
+		{Header: "LAST NAME", Field: "lastName"},
+		{Header: "FIRST NAME", Field: "firstName"},
+	},
+	"segments": {
+		{Header: "KEY", Field: "key"},
+		{Header: "NAME", Field: "name"},
+		{Header: "CREATED", Field: "creationDate", Format: formatTimestamp},
+	},
+}
+
+// singularColumnRegistry maps resource names to their singular-view column definitions.
+var singularColumnRegistry = map[string][]ColumnDef{
+	"flags": {
+		{Header: "Key", Field: "key"},
+		{Header: "Name", Field: "name"},
+		{Header: "Kind", Field: "kind"},
+		{Header: "Temporary", Field: "temporary", Format: boolYesNo},
+		{Header: "Created", Field: "creationDate", Format: formatTimestamp},
+		{Header: "Tags", Field: "tags", Format: truncatedList(10)},
+	},
+	"projects": {
+		{Header: "Key", Field: "key"},
+		{Header: "Name", Field: "name"},
+		{Header: "Tag Count", Field: "tags", Format: countList},
+	},
+	"environments": {
+		{Header: "Key", Field: "key"},
+		{Header: "Name", Field: "name"},
+		{Header: "Color", Field: "color"},
+	},
+	"members": {
+		{Header: "Email", Field: "email"},
+		{Header: "Role", Field: "role"},
+		{Header: "Last Name", Field: "lastName"},
+		{Header: "First Name", Field: "firstName"},
+	},
+	"segments": {
+		{Header: "Key", Field: "key"},
+		{Header: "Name", Field: "name"},
+		{Header: "Created", Field: "creationDate", Format: formatTimestamp},
+	},
+}
+
+// GetListColumns returns the column definitions for a resource's list view, or nil if none are registered.
+func GetListColumns(resourceName string) []ColumnDef {
+	return listColumnRegistry[resourceName]
+}
+
+// GetSingularColumns returns the column definitions for a resource's singular view, or nil if none are registered.
+func GetSingularColumns(resourceName string) []ColumnDef {
+	return singularColumnRegistry[resourceName]
+}
+
+func colValue(r resource, col ColumnDef) string {
+	if r == nil {
+		return ""
+	}
+	format := col.Format
+	if format == nil {
+		format = defaultFormat
+	}
+	return strings.ReplaceAll(format(r[col.Field]), "\t", " ")
+}
+
+// TableOutput formats a slice of resources as an aligned table using tabwriter.
+func TableOutput(items []resource, cols []ColumnDef) string {
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 3, ' ', 0)
+
+	headers := make([]string, len(cols))
+	for i, col := range cols {
+		headers[i] = col.Header
+	}
+	fmt.Fprintln(w, strings.Join(headers, "\t"))
+
+	for _, item := range items {
+		vals := make([]string, len(cols))
+		for i, col := range cols {
+			vals[i] = colValue(item, col)
+		}
+		fmt.Fprintln(w, strings.Join(vals, "\t"))
+	}
+
+	w.Flush()
+
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// KeyValueOutput formats a single resource as key-value pairs.
+func KeyValueOutput(r resource, cols []ColumnDef) string {
+	maxLen := 0
+	for _, col := range cols {
+		if len(col.Header) > maxLen {
+			maxLen = len(col.Header)
+		}
+	}
+
+	lines := make([]string, 0, len(cols))
+	for _, col := range cols {
+		val := colValue(r, col)
+		padding := strings.Repeat(" ", maxLen-len(col.Header))
+		lines = append(lines, fmt.Sprintf("%s:%s  %s", col.Header, padding, val))
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -1,0 +1,410 @@
+package output
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTableOutput(t *testing.T) {
+	t.Run("flags list shows key, name, kind, temporary, tags", func(t *testing.T) {
+		cols := GetListColumns("flags")
+		items := []resource{
+			{
+				"key":       "my-flag",
+				"name":      "My Feature Flag",
+				"kind":      "boolean",
+				"temporary": true,
+				"tags":      []interface{}{"beta", "frontend"},
+			},
+			{
+				"key":       "dark-mode",
+				"name":      "Dark Mode Toggle",
+				"kind":      "boolean",
+				"temporary": false,
+				"tags":      []interface{}{"ui"},
+			},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 3)
+		assert.Contains(t, lines[0], "KEY")
+		assert.Contains(t, lines[0], "NAME")
+		assert.Contains(t, lines[0], "KIND")
+		assert.Contains(t, lines[0], "TEMPORARY")
+		assert.Contains(t, lines[0], "TAGS")
+		assert.Contains(t, lines[1], "my-flag")
+		assert.Contains(t, lines[1], "My Feature Flag")
+		assert.Contains(t, lines[1], "boolean")
+		assert.Contains(t, lines[1], "yes")
+		assert.Contains(t, lines[1], "beta, frontend")
+		assert.Contains(t, lines[2], "dark-mode")
+		assert.Contains(t, lines[2], "no")
+	})
+
+	t.Run("flags list truncates tags beyond 3", func(t *testing.T) {
+		cols := GetListColumns("flags")
+		items := []resource{
+			{
+				"key":       "many-tags",
+				"name":      "Many Tags",
+				"kind":      "boolean",
+				"temporary": false,
+				"tags":      []interface{}{"a", "b", "c", "d"},
+			},
+		}
+
+		result := TableOutput(items, cols)
+
+		assert.Contains(t, result, "a, b, c, ...")
+	})
+
+	t.Run("projects list shows key, name, tag count", func(t *testing.T) {
+		cols := GetListColumns("projects")
+		items := []resource{
+			{
+				"key":  "proj-1",
+				"name": "Project One",
+				"tags": []interface{}{"tag1", "tag2", "tag3"},
+			},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 2)
+		assert.Contains(t, lines[0], "KEY")
+		assert.Contains(t, lines[0], "NAME")
+		assert.Contains(t, lines[0], "TAG COUNT")
+		assert.Contains(t, lines[1], "proj-1")
+		assert.Contains(t, lines[1], "Project One")
+		assert.Contains(t, lines[1], "3")
+	})
+
+	t.Run("environments list shows key, name, color", func(t *testing.T) {
+		cols := GetListColumns("environments")
+		items := []resource{
+			{
+				"key":   "production",
+				"name":  "Production",
+				"color": "FF0000",
+			},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 2)
+		assert.Contains(t, lines[0], "KEY")
+		assert.Contains(t, lines[0], "NAME")
+		assert.Contains(t, lines[0], "COLOR")
+		assert.Contains(t, lines[1], "production")
+		assert.Contains(t, lines[1], "Production")
+		assert.Contains(t, lines[1], "FF0000")
+	})
+
+	t.Run("members list shows email, role, lastName, firstName", func(t *testing.T) {
+		cols := GetListColumns("members")
+		items := []resource{
+			{
+				"email":     "alice@example.com",
+				"role":      "admin",
+				"lastName":  "Smith",
+				"firstName": "Alice",
+			},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 2)
+		assert.Contains(t, lines[0], "EMAIL")
+		assert.Contains(t, lines[0], "ROLE")
+		assert.Contains(t, lines[0], "LAST NAME")
+		assert.Contains(t, lines[0], "FIRST NAME")
+		assert.Contains(t, lines[1], "alice@example.com")
+		assert.Contains(t, lines[1], "admin")
+		assert.Contains(t, lines[1], "Smith")
+		assert.Contains(t, lines[1], "Alice")
+	})
+
+	t.Run("segments list shows key, name, creationDate", func(t *testing.T) {
+		cols := GetListColumns("segments")
+		items := []resource{
+			{
+				"key":          "beta-users",
+				"name":         "Beta Users",
+				"creationDate": float64(1718438400000),
+			},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 2)
+		expected := time.UnixMilli(1718438400000).UTC().Format(time.RFC3339)
+		assert.Contains(t, lines[0], "KEY")
+		assert.Contains(t, lines[0], "NAME")
+		assert.Contains(t, lines[0], "CREATED")
+		assert.Contains(t, lines[1], "beta-users")
+		assert.Contains(t, lines[1], "Beta Users")
+		assert.Contains(t, lines[1], expected)
+	})
+
+	t.Run("handles nil field values gracefully", func(t *testing.T) {
+		cols := GetListColumns("flags")
+		items := []resource{
+			{
+				"key":  "no-extras",
+				"name": "No Extras",
+			},
+		}
+
+		result := TableOutput(items, cols)
+
+		assert.Contains(t, result, "no-extras")
+		assert.Contains(t, result, "No Extras")
+	})
+
+	t.Run("multiple rows are aligned", func(t *testing.T) {
+		cols := GetListColumns("environments")
+		items := []resource{
+			{"key": "short", "name": "S", "color": "000"},
+			{"key": "a-very-long-key", "name": "A Very Long Name", "color": "FFF"},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 3)
+		headerKeyEnd := strings.Index(lines[0], "NAME")
+		row1KeyEnd := strings.Index(lines[1], "S")
+		row2KeyEnd := strings.Index(lines[2], "A Very Long Name")
+		assert.Equal(t, headerKeyEnd, row1KeyEnd)
+		assert.Equal(t, headerKeyEnd, row2KeyEnd)
+	})
+}
+
+func TestKeyValueOutput(t *testing.T) {
+	t.Run("flags singular shows key-value pairs", func(t *testing.T) {
+		cols := GetSingularColumns("flags")
+		r := resource{
+			"key":          "my-flag",
+			"name":         "My Feature Flag",
+			"kind":         "boolean",
+			"temporary":    true,
+			"creationDate": float64(1718438400000),
+			"tags":         []interface{}{"beta", "frontend"},
+		}
+
+		result := KeyValueOutput(r, cols)
+
+		expected := time.UnixMilli(1718438400000).UTC().Format(time.RFC3339)
+		assert.Contains(t, result, "Key:")
+		assert.Contains(t, result, "my-flag")
+		assert.Contains(t, result, "Name:")
+		assert.Contains(t, result, "My Feature Flag")
+		assert.Contains(t, result, "Kind:")
+		assert.Contains(t, result, "boolean")
+		assert.Contains(t, result, "Temporary:")
+		assert.Contains(t, result, "yes")
+		assert.Contains(t, result, "Created:")
+		assert.Contains(t, result, expected)
+		assert.Contains(t, result, "Tags:")
+		assert.Contains(t, result, "beta, frontend")
+	})
+
+	t.Run("members singular shows email, role, names", func(t *testing.T) {
+		cols := GetSingularColumns("members")
+		r := resource{
+			"email":     "alice@example.com",
+			"role":      "admin",
+			"lastName":  "Smith",
+			"firstName": "Alice",
+		}
+
+		result := KeyValueOutput(r, cols)
+
+		assert.Contains(t, result, "Email:")
+		assert.Contains(t, result, "alice@example.com")
+		assert.Contains(t, result, "Role:")
+		assert.Contains(t, result, "admin")
+	})
+
+	t.Run("handles nil values", func(t *testing.T) {
+		cols := GetSingularColumns("flags")
+		r := resource{
+			"key":  "minimal",
+			"name": "Minimal Flag",
+		}
+
+		result := KeyValueOutput(r, cols)
+
+		assert.Contains(t, result, "Key:        minimal")
+		assert.Contains(t, result, "Name:       Minimal Flag")
+		assert.Contains(t, result, "Kind:")
+	})
+}
+
+func TestGetListColumns(t *testing.T) {
+	t.Run("returns nil for unknown resource", func(t *testing.T) {
+		cols := GetListColumns("unknown-resource")
+
+		assert.Nil(t, cols)
+	})
+
+	t.Run("returns columns for flags", func(t *testing.T) {
+		cols := GetListColumns("flags")
+
+		assert.NotNil(t, cols)
+		assert.Equal(t, "KEY", cols[0].Header)
+	})
+}
+
+func TestGetSingularColumns(t *testing.T) {
+	t.Run("returns nil for unknown resource", func(t *testing.T) {
+		cols := GetSingularColumns("unknown-resource")
+
+		assert.Nil(t, cols)
+	})
+
+	t.Run("returns columns for flags", func(t *testing.T) {
+		cols := GetSingularColumns("flags")
+
+		assert.NotNil(t, cols)
+		assert.Equal(t, "Key", cols[0].Header)
+	})
+}
+
+func TestBoolYesNo(t *testing.T) {
+	assert.Equal(t, "yes", boolYesNo(true))
+	assert.Equal(t, "no", boolYesNo(false))
+	assert.Equal(t, "something", boolYesNo("something"))
+	assert.Equal(t, "", boolYesNo(nil))
+}
+
+func TestTruncatedList(t *testing.T) {
+	fn := truncatedList(3)
+
+	t.Run("within limit", func(t *testing.T) {
+		result := fn([]interface{}{"a", "b"})
+		assert.Equal(t, "a, b", result)
+	})
+
+	t.Run("at limit", func(t *testing.T) {
+		result := fn([]interface{}{"a", "b", "c"})
+		assert.Equal(t, "a, b, c", result)
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		result := fn([]interface{}{"a", "b", "c", "d"})
+		assert.Equal(t, "a, b, c, ...", result)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		result := fn([]interface{}{})
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("non-slice value", func(t *testing.T) {
+		result := fn("not-a-list")
+		assert.Equal(t, "not-a-list", result)
+	})
+
+	t.Run("nil value", func(t *testing.T) {
+		result := fn(nil)
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestCountList(t *testing.T) {
+	t.Run("counts items", func(t *testing.T) {
+		result := countList([]interface{}{"a", "b", "c"})
+		assert.Equal(t, "3", result)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		result := countList([]interface{}{})
+		assert.Equal(t, "0", result)
+	})
+
+	t.Run("non-slice", func(t *testing.T) {
+		result := countList("not-a-list")
+		assert.Equal(t, "not-a-list", result)
+	})
+
+	t.Run("nil value", func(t *testing.T) {
+		result := countList(nil)
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestFormatTimestamp(t *testing.T) {
+	t.Run("formats float64 unix millis to RFC3339", func(t *testing.T) {
+		result := formatTimestamp(float64(1718438400000))
+		expected := time.UnixMilli(1718438400000).UTC().Format(time.RFC3339)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("nil returns empty string", func(t *testing.T) {
+		result := formatTimestamp(nil)
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("string passes through to defaultFormat", func(t *testing.T) {
+		result := formatTimestamp("2024-06-15T00:00:00Z")
+		assert.Equal(t, "2024-06-15T00:00:00Z", result)
+	})
+}
+
+func TestTableOutputEdgeCases(t *testing.T) {
+	t.Run("empty items produces header only", func(t *testing.T) {
+		cols := GetListColumns("flags")
+		result := TableOutput([]resource{}, cols)
+		lines := strings.Split(result, "\n")
+		assert.Len(t, lines, 1)
+		assert.Contains(t, lines[0], "KEY")
+	})
+
+	t.Run("nil resource in items does not panic", func(t *testing.T) {
+		cols := GetListColumns("environments")
+		items := []resource{
+			{"key": "good", "name": "Good", "color": "FFF"},
+			nil,
+		}
+		result := TableOutput(items, cols)
+		assert.Contains(t, result, "good")
+	})
+
+	t.Run("tab in value does not break alignment", func(t *testing.T) {
+		cols := []ColumnDef{
+			{Header: "KEY", Field: "key"},
+			{Header: "NAME", Field: "name"},
+		}
+		items := []resource{
+			{"key": "has\ttab", "name": "normal"},
+		}
+		result := TableOutput(items, cols)
+		assert.NotContains(t, result, "\t")
+		assert.Contains(t, result, "has tab")
+	})
+}
+
+func TestKeyValueOutputEdgeCases(t *testing.T) {
+	t.Run("empty cols returns empty string", func(t *testing.T) {
+		r := resource{"key": "val"}
+		result := KeyValueOutput(r, []ColumnDef{})
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestBoolYesNoEdgeCases(t *testing.T) {
+	t.Run("numeric float64 passes through", func(t *testing.T) {
+		result := boolYesNo(float64(1))
+		assert.Equal(t, "1", result)
+	})
+}


### PR DESCRIPTION
Add a --fields persistent flag that filters JSON output to only include specified top-level fields. A flag response can be 50KB+ with targeting configs for every environment. --fields key,name,kind,temporary returns only those fields. Applies to JSON output only. Handles both singular and collection responses (filters each item in items array, preserves totalCount). Error responses are never filtered.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the shared `output.CmdOutput` API and alters default plaintext rendering for several commands, which could break scripts or expected CLI output. JSON filtering is additive but could mask fields if misused or if responses are non-object JSON.
> 
> **Overview**
> Adds a new persistent `--fields` flag (and `cliflags.GetFields`) to filter **JSON** command output down to selected top-level fields, supporting both singular responses and `items` collections while preserving `totalCount`/`_links`.
> 
> Refactors `output.CmdOutput` to accept optional field filters and per-resource formatting options, and updates resource/flags/members/config commands to pass `ResourceName` so plaintext output can render as tables (lists) or key/value blocks (singular) for supported resources.
> 
> Hardens plaintext formatting to avoid panics on non-string values, introduces new table/key-value rendering utilities, and expands/updates golden and unit tests to cover the new `--fields` behavior and changed plaintext output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c64ba942ab7dd38bf7691d817681722f458f36ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ld-jira-link -->
---
Related Jira issue: [REL-12755: --fields flag for response shaping](https://launchdarkly.atlassian.net/browse/REL-12755)
<!-- end-ld-jira-link -->