### PR TITLE
feat(REL-15756): updating agent friendly and improved rich text output

### DIFF
--- a/cmd/flags/archive.go
+++ b/cmd/flags/archive.go
@@ -51,7 +51,9 @@ func makeArchiveRequest(client resources.Client) func(*cobra.Command, []string) 
 			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd), output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/flags/archive_test.go
+++ b/cmd/flags/archive_test.go
@@ -39,7 +39,11 @@ func TestArchive(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, `[{"op": "replace", "path": "/archived", "value": true}]`, string(mockClient.Input))
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated\n\nKey:")
+		assert.Contains(t, string(output), "test-flag")
+		assert.Contains(t, string(output), "Name:")
+		assert.Contains(t, string(output), "test flag")
+		assert.NotContains(t, string(output), "* ")
 	})
 
 	t.Run("succeeds with JSON output", func(t *testing.T) {
@@ -146,7 +150,9 @@ func TestArchive(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated")
+		assert.Contains(t, string(output), "Key:")
+		assert.Contains(t, string(output), "test-flag")
 	})
 
 	t.Run("returns error with missing flags", func(t *testing.T) {

--- a/cmd/flags/toggle.go
+++ b/cmd/flags/toggle.go
@@ -73,7 +73,9 @@ func runE(client resources.Client) func(*cobra.Command, []string) error {
 			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd), output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/flags/toggle_test.go
+++ b/cmd/flags/toggle_test.go
@@ -40,7 +40,11 @@ func TestToggleOn(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, `[{"op": "replace", "path": "/environments/test-env/on", "value": true}]`, string(mockClient.Input))
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated\n\nKey:")
+		assert.Contains(t, string(output), "test-flag")
+		assert.Contains(t, string(output), "Name:")
+		assert.Contains(t, string(output), "test flag")
+		assert.NotContains(t, string(output), "* ")
 	})
 
 	t.Run("succeeds with JSON output", func(t *testing.T) {
@@ -152,7 +156,9 @@ func TestToggleOn(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated")
+		assert.Contains(t, string(output), "Key:")
+		assert.Contains(t, string(output), "test-flag")
 	})
 
 	t.Run("returns error with missing required flags", func(t *testing.T) {
@@ -205,7 +211,11 @@ func TestToggleOff(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, `[{"op": "replace", "path": "/environments/test-env/on", "value": false}]`, string(mockClient.Input))
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated\n\nKey:")
+		assert.Contains(t, string(output), "test-flag")
+		assert.Contains(t, string(output), "Name:")
+		assert.Contains(t, string(output), "test flag")
+		assert.NotContains(t, string(output), "* ")
 	})
 
 	t.Run("succeeds with JSON output", func(t *testing.T) {
@@ -317,7 +327,9 @@ func TestToggleOff(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Equal(t, "Successfully updated test flag (test-flag)\n", string(output))
+		assert.Contains(t, string(output), "Successfully updated")
+		assert.Contains(t, string(output), "Key:")
+		assert.Contains(t, string(output), "test-flag")
 	})
 
 	t.Run("returns error with missing required flags", func(t *testing.T) {

--- a/cmd/members/invite.go
+++ b/cmd/members/invite.go
@@ -63,7 +63,9 @@ func runE(client resources.Client) func(*cobra.Command, []string) error {
 			return output.NewCmdOutputError(err, cliflags.GetOutputKind(cmd))
 		}
 
-		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
+		output, err := output.CmdOutput("update", cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd), output.CmdOutputOpts{
+			ResourceName: "members",
+		})
 		if err != nil {
 			return errors.NewError(err.Error())
 		}

--- a/cmd/members/invite_test.go
+++ b/cmd/members/invite_test.go
@@ -45,5 +45,11 @@ func TestInvite(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, `[{"email":"test1@test.com","role":"writer"},{"email":"test2@test.com","role":"writer"}]`, string(mockClient.Input))
-	assert.Equal(t, "Successfully updated\n* test1@test.com (000000000000000000000001)\n* test2@test.com (000000000000000000000002)\n", string(output))
+	assert.Contains(t, string(output), "Successfully updated")
+	assert.Contains(t, string(output), "EMAIL")
+	assert.Contains(t, string(output), "ROLE")
+	assert.Contains(t, string(output), "test1@test.com")
+	assert.Contains(t, string(output), "test2@test.com")
+	assert.Contains(t, string(output), "writer")
+	assert.NotContains(t, string(output), "* ")
 }

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -349,7 +349,9 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 		res = []byte(fmt.Sprintf(`{"key": %q}`, urlParms[len(urlParms)-1]))
 	}
 
-	output, err := output.CmdOutput(cmd.Use, cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd))
+	output, err := output.CmdOutput(cmd.Use, cliflags.GetOutputKind(cmd), res, cliflags.GetFields(cmd), output.CmdOutputOpts{
+		ResourceName: cmd.Parent().Name(),
+	})
 	if err != nil {
 		return errors.NewError(err.Error())
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -101,8 +101,8 @@ func TestOutputFlags(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Contains(t, string(output), "Successfully updated")
-		assert.Contains(t, string(output), "test-name (test-key)")
+		assert.Contains(t, string(output), "Successfully updated\n\nKey:")
+		assert.Contains(t, string(output), "test-key")
 	})
 }
 
@@ -205,7 +205,8 @@ func TestTTYDefaultOutput(t *testing.T) {
 
 		out := execNonTTYCmd(t, mockClient)
 		assert.Contains(t, string(out), "Successfully updated")
-		assert.Contains(t, string(out), "test-name (test-key)")
+		assert.Contains(t, string(out), "Key:")
+		assert.Contains(t, string(out), "test-key")
 	})
 
 	t.Run("FORCE_TTY overrides non-TTY detection", func(t *testing.T) {

--- a/internal/output/plaintext_fns.go
+++ b/internal/output/plaintext_fns.go
@@ -62,19 +62,19 @@ var SingularPlaintextOutputFn = func(r resource) string {
 
 	switch {
 	case name != nil && key != nil:
-		return fmt.Sprintf("%s (%s)", name.(string), key.(string))
+		return fmt.Sprintf("%s (%s)", fmt.Sprint(name), fmt.Sprint(key))
 	case email != nil && id != nil:
-		return fmt.Sprintf("%s (%s)", email.(string), id.(string))
+		return fmt.Sprintf("%s (%s)", fmt.Sprint(email), fmt.Sprint(id))
 	case name != nil && id != nil:
-		return fmt.Sprintf("%s (%s)", name.(string), id.(string))
+		return fmt.Sprintf("%s (%s)", fmt.Sprint(name), fmt.Sprint(id))
 	case key != nil:
-		return key.(string)
+		return fmt.Sprint(key)
 	case email != nil:
-		return email.(string)
+		return fmt.Sprint(email)
 	case id != nil:
-		return id.(string)
+		return fmt.Sprint(id)
 	case name != nil:
-		return name.(string)
+		return fmt.Sprint(name)
 	default:
 		return "cannot read resource"
 	}

--- a/internal/output/plaintext_fns_internal_test.go
+++ b/internal/output/plaintext_fns_internal_test.go
@@ -7,6 +7,54 @@ import (
 )
 
 func TestErrorPlaintextOutputFn(t *testing.T) {
+	t.Run("with code and message", func(t *testing.T) {
+		r := resource{"code": "conflict", "message": "resource already exists"}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "resource already exists (code: conflict)", result)
+	})
+
+	t.Run("with only a message", func(t *testing.T) {
+		r := resource{"message": "something went wrong"}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "something went wrong", result)
+	})
+
+	t.Run("with only a code", func(t *testing.T) {
+		r := resource{"code": "not_found", "message": ""}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "an error occurred (code: not_found)", result)
+	})
+
+	t.Run("with neither code nor message", func(t *testing.T) {
+		r := resource{}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "unknown error occurred", result)
+	})
+
+	t.Run("with empty message and nil code", func(t *testing.T) {
+		r := resource{"message": ""}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "unknown error occurred", result)
+	})
+
+	t.Run("with suggestion appends suggestion line", func(t *testing.T) {
+		r := resource{"code": "not_found", "message": "Not Found", "suggestion": "Try ldcli flags list."}
+
+		result := ErrorPlaintextOutputFn(r)
+
+		assert.Equal(t, "Not Found (code: not_found)\nSuggestion: Try ldcli flags list.", result)
+	})
+
 	t.Run("with a non-string message does not panic", func(t *testing.T) {
 		r := resource{"message": float64(404)}
 
@@ -30,6 +78,91 @@ func TestErrorPlaintextOutputFn(t *testing.T) {
 
 		assert.Equal(t, "42 (code: true)", result)
 	})
+}
+
+func TestMultiplePlaintextOutputFn(t *testing.T) {
+	tests := map[string]struct {
+		resource resource
+		expected string
+	}{
+		"with a name and key": {
+			resource: resource{
+				"key":  "test-key",
+				"name": "test-name",
+			},
+			expected: "* test-name (test-key)",
+		},
+		"with only a key": {
+			resource: resource{
+				"key": "test-key",
+			},
+			expected: "* test-key",
+		},
+		"with an email and ID": {
+			resource: resource{
+				"_id":   "test-id",
+				"email": "test-email",
+			},
+			expected: "* test-email (test-id)",
+		},
+		"without any valid field": {
+			resource: resource{
+				"other": "other-value",
+			},
+			expected: "* cannot read resource",
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			out := MultiplePlaintextOutputFn(tt.resource)
+
+			assert.Equal(t, tt.expected, out)
+		})
+	}
+}
+
+func TestConfigPlaintextOutputFn(t *testing.T) {
+	tests := map[string]struct {
+		resource resource
+		expected string
+	}{
+		"with multiple keys sorts alphabetically": {
+			resource: resource{
+				"zeta":  "last",
+				"alpha": "first",
+				"mid":   "middle",
+			},
+			expected: "alpha: first\nmid: middle\nzeta: last",
+		},
+		"with single key": {
+			resource: resource{
+				"key": "value",
+			},
+			expected: "key: value",
+		},
+		"with empty resource": {
+			resource: resource{},
+			expected: "",
+		},
+		"with non-string values": {
+			resource: resource{
+				"count":   float64(42),
+				"enabled": true,
+			},
+			expected: "count: 42\nenabled: true",
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			out := ConfigPlaintextOutputFn(tt.resource)
+
+			assert.Equal(t, tt.expected, out)
+		})
+	}
 }
 
 func TestSingularPlaintextOutputFn(t *testing.T) {
@@ -76,6 +209,32 @@ func TestSingularPlaintextOutputFn(t *testing.T) {
 				"other": "other-value",
 			},
 			expected: "cannot read resource",
+		},
+		"with non-string name and key does not panic": {
+			resource: resource{
+				"key":  float64(123),
+				"name": true,
+			},
+			expected: "true (123)",
+		},
+		"with non-string email and id does not panic": {
+			resource: resource{
+				"_id":   float64(999),
+				"email": float64(42),
+			},
+			expected: "42 (999)",
+		},
+		"with non-string key only does not panic": {
+			resource: resource{
+				"key": float64(456),
+			},
+			expected: "456",
+		},
+		"with non-string name only does not panic": {
+			resource: resource{
+				"name": float64(789),
+			},
+			expected: "789",
 		},
 	}
 

--- a/internal/output/resource_output.go
+++ b/internal/output/resource_output.go
@@ -12,10 +12,25 @@ import (
 	errs "github.com/launchdarkly/ldcli/internal/errors"
 )
 
+// CmdOutputOpts configures optional behavior for CmdOutput.
+type CmdOutputOpts struct {
+	Fields       []string
+	ResourceName string
+}
+
 // CmdOutput returns a response from a resource action formatted based on the output flag along with
 // an optional message based on the action. When fields is non-empty and outputKind is "json",
-// only the specified top-level fields are included in the output.
-func CmdOutput(action string, outputKind string, input []byte, fields []string) (string, error) {
+// only the specified top-level fields are included in the output. When resourceName matches a
+// registered resource, list output uses table formatting and singular output uses key-value pairs.
+func CmdOutput(action string, outputKind string, input []byte, fields []string, opts ...CmdOutputOpts) (string, error) {
+	var resourceName string
+	if len(opts) > 0 {
+		resourceName = opts[0].ResourceName
+		if len(fields) == 0 {
+			fields = opts[0].Fields
+		}
+	}
+
 	if outputKind == "json" {
 		if len(fields) > 0 {
 			filtered, err := filterFields(input, fields)
@@ -67,6 +82,13 @@ func CmdOutput(action string, outputKind string, input []byte, fields []string) 
 	}
 
 	if !isMultipleResponse {
+		if cols := GetSingularColumns(resourceName); cols != nil {
+			kv := KeyValueOutput(maybeResource, cols)
+			if strings.TrimSpace(successMessage) != "" {
+				return successMessage + "\n\n" + kv, nil
+			}
+			return kv, nil
+		}
 		return plaintextOutput(SingularPlaintextOutputFn(maybeResource), successMessage+" "), nil
 	}
 
@@ -74,9 +96,15 @@ func CmdOutput(action string, outputKind string, input []byte, fields []string) 
 		return "No items found", nil
 	}
 
-	items := make([]string, 0, len(maybeResources.Items))
-	for _, i := range maybeResources.Items {
-		items = append(items, MultiplePlaintextOutputFn(i))
+	var body string
+	if cols := GetListColumns(resourceName); cols != nil {
+		body = TableOutput(maybeResources.Items, cols)
+	} else {
+		items := make([]string, 0, len(maybeResources.Items))
+		for _, i := range maybeResources.Items {
+			items = append(items, MultiplePlaintextOutputFn(i))
+		}
+		body = strings.Join(items, "\n")
 	}
 
 	var (
@@ -107,7 +135,7 @@ func CmdOutput(action string, outputKind string, input []byte, fields []string) 
 	if successMessage != "" {
 		successMessage += "\n"
 	}
-	return plaintextOutput(strings.Join(items, "\n"), successMessage) + pagination, nil
+	return plaintextOutput(body, successMessage) + pagination, nil
 }
 
 func plaintextOutput(out string, successMessage string) string {

--- a/internal/output/resource_output_test.go
+++ b/internal/output/resource_output_test.go
@@ -592,6 +592,359 @@ func TestCmdOutputWithFields(t *testing.T) {
 	})
 }
 
+func TestCmdOutputWithResourceName(t *testing.T) {
+	t.Run("flags list uses table format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "my-flag",
+					"name": "My Flag",
+					"kind": "boolean",
+					"temporary": true,
+					"tags": ["beta", "frontend"]
+				},
+				{
+					"key": "dark-mode",
+					"name": "Dark Mode",
+					"kind": "boolean",
+					"temporary": false,
+					"tags": ["ui"]
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "NAME")
+		assert.Contains(t, result, "KIND")
+		assert.Contains(t, result, "TEMPORARY")
+		assert.Contains(t, result, "TAGS")
+		assert.Contains(t, result, "my-flag")
+		assert.Contains(t, result, "My Flag")
+		assert.Contains(t, result, "yes")
+		assert.Contains(t, result, "dark-mode")
+		assert.Contains(t, result, "no")
+		assert.NotContains(t, result, "* ")
+	})
+
+	t.Run("flags singular uses key-value format", func(t *testing.T) {
+		input := `{
+			"key": "my-flag",
+			"name": "My Flag",
+			"kind": "boolean",
+			"temporary": true,
+			"creationDate": 1718438400000,
+			"tags": ["beta"]
+		}`
+
+		result, err := output.CmdOutput("get", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "Key:")
+		assert.Contains(t, result, "my-flag")
+		assert.Contains(t, result, "Name:")
+		assert.Contains(t, result, "My Flag")
+		assert.Contains(t, result, "Kind:")
+		assert.Contains(t, result, "boolean")
+		assert.Contains(t, result, "Temporary:")
+		assert.Contains(t, result, "yes")
+	})
+
+	t.Run("flags singular with success message", func(t *testing.T) {
+		input := `{
+			"key": "my-flag",
+			"name": "My Flag",
+			"kind": "boolean",
+			"temporary": false
+		}`
+
+		result, err := output.CmdOutput("update", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "Successfully updated\n\nKey:")
+		assert.Contains(t, result, "my-flag")
+	})
+
+	t.Run("unknown resource falls back to bullet format for lists", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "test-key",
+					"name": "test-name"
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "unknown-resource",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "* test-name (test-key)", result)
+	})
+
+	t.Run("unknown resource falls back to name (key) for singular", func(t *testing.T) {
+		input := `{
+			"key": "test-key",
+			"name": "test-name"
+		}`
+
+		result, err := output.CmdOutput("create", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "unknown-resource",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "Successfully created test-name (test-key)", result)
+	})
+
+	t.Run("empty resource name falls back to bullet format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "test-key",
+					"name": "test-name"
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "* test-name (test-key)", result)
+	})
+
+	t.Run("table output with pagination", func(t *testing.T) {
+		input := `{
+			"_links": {
+				"self": {
+					"href": "/api/v2/flags/proj?limit=5&offset=0",
+					"type": "application/json"
+				}
+			},
+			"items": [
+				{
+					"key": "my-flag",
+					"name": "My Flag",
+					"kind": "boolean",
+					"temporary": true,
+					"tags": ["beta"]
+				}
+			],
+			"totalCount": 100
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "my-flag")
+		assert.Contains(t, result, "Showing results 1 - 5 of 100.")
+		assert.Contains(t, result, "Use --offset 5 for additional results.")
+	})
+
+	t.Run("empty items with resource name returns no items found", func(t *testing.T) {
+		input := `{"items": []}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "No items found", result)
+	})
+
+	t.Run("JSON output is unaffected by resource name", func(t *testing.T) {
+		input := `{
+			"items": [
+				{"key": "my-flag", "name": "My Flag"}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "json", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, input, result)
+	})
+
+	t.Run("members list uses table format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"email": "alice@example.com",
+					"role": "admin",
+					"lastName": "Smith",
+					"firstName": "Alice"
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "members",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "EMAIL")
+		assert.Contains(t, result, "ROLE")
+		assert.Contains(t, result, "alice@example.com")
+		assert.Contains(t, result, "admin")
+		assert.NotContains(t, result, "* ")
+	})
+
+	t.Run("environments list uses table format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "production",
+					"name": "Production",
+					"color": "FF0000"
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "environments",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "NAME")
+		assert.Contains(t, result, "COLOR")
+		assert.Contains(t, result, "production")
+		assert.Contains(t, result, "FF0000")
+	})
+
+	t.Run("projects list uses table format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "proj-1",
+					"name": "Project One",
+					"tags": ["tag1", "tag2"]
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "projects",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "proj-1")
+		assert.Contains(t, result, "2")
+	})
+
+	t.Run("segments list uses table format", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "beta-users",
+					"name": "Beta Users",
+					"creationDate": 1718438400000
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "segments",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "CREATED")
+		assert.Contains(t, result, "beta-users")
+		assert.Contains(t, result, "2024-06-15")
+	})
+
+	t.Run("create with list and resource name shows table with success message", func(t *testing.T) {
+		input := `{
+			"items": [
+				{
+					"key": "new-flag",
+					"name": "New Flag",
+					"kind": "boolean",
+					"temporary": false,
+					"tags": []
+				}
+			]
+		}`
+
+		result, err := output.CmdOutput("create", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "Successfully created")
+		assert.Contains(t, result, "KEY")
+		assert.Contains(t, result, "new-flag")
+	})
+
+	t.Run("segments singular uses key-value format", func(t *testing.T) {
+		input := `{
+			"key": "beta-users",
+			"name": "Beta Users",
+			"creationDate": 1718438400000
+		}`
+
+		result, err := output.CmdOutput("get", "plaintext", []byte(input), nil, output.CmdOutputOpts{
+			ResourceName: "segments",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "Key:")
+		assert.Contains(t, result, "beta-users")
+		assert.Contains(t, result, "Name:")
+		assert.Contains(t, result, "Beta Users")
+		assert.Contains(t, result, "Created:")
+		assert.Contains(t, result, "2024-06-15")
+	})
+
+	t.Run("Fields from opts used when fields param is nil", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag","extra":"noise"}`
+
+		result, err := output.CmdOutput("get", "json", []byte(input), nil, output.CmdOutputOpts{
+			Fields:       []string{"key", "name"},
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"my-flag","name":"My Flag"}`, result)
+	})
+
+	t.Run("explicit fields param takes precedence over opts Fields", func(t *testing.T) {
+		input := `{"key":"my-flag","name":"My Flag","extra":"noise"}`
+
+		result, err := output.CmdOutput("get", "json", []byte(input), []string{"key"}, output.CmdOutputOpts{
+			Fields:       []string{"key", "name"},
+			ResourceName: "flags",
+		})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"key":"my-flag"}`, result)
+	})
+
+	t.Run("empty items without resource name returns no items found", func(t *testing.T) {
+		input := `{"items": []}`
+
+		result, err := output.CmdOutput("list", "plaintext", []byte(input), nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "No items found", result)
+	})
+}
+
 func TestCmdOutputErrorNotAffectedByFields(t *testing.T) {
 	t.Run("JSON error response always returns full structure", func(t *testing.T) {
 		errJSON := `{"code":"not_found","message":"Not Found","statusCode":404,"suggestion":"Try ldcli flags list."}`

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -1,0 +1,198 @@
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+)
+
+// ColumnDef describes a single column in table or key-value output.
+type ColumnDef struct {
+	Header string
+	Field  string
+	Format func(interface{}) string
+}
+
+func defaultFormat(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprint(v)
+}
+
+func boolYesNo(v interface{}) string {
+	switch b := v.(type) {
+	case bool:
+		if b {
+			return "yes"
+		}
+		return "no"
+	default:
+		return defaultFormat(v)
+	}
+}
+
+func truncatedList(max int) func(interface{}) string {
+	return func(v interface{}) string {
+		items, ok := v.([]interface{})
+		if !ok {
+			return defaultFormat(v)
+		}
+		strs := make([]string, 0, len(items))
+		for _, item := range items {
+			strs = append(strs, fmt.Sprint(item))
+		}
+		if len(strs) <= max {
+			return strings.Join(strs, ", ")
+		}
+		return strings.Join(strs[:max], ", ") + ", ..."
+	}
+}
+
+func countList(v interface{}) string {
+	items, ok := v.([]interface{})
+	if !ok {
+		return defaultFormat(v)
+	}
+	return fmt.Sprintf("%d", len(items))
+}
+
+func formatTimestamp(v interface{}) string {
+	switch n := v.(type) {
+	case float64:
+		return time.UnixMilli(int64(n)).UTC().Format(time.RFC3339)
+	default:
+		return defaultFormat(v)
+	}
+}
+
+// listColumnRegistry maps resource names to their list-view column definitions.
+var listColumnRegistry = map[string][]ColumnDef{
+	"flags": {
+		{Header: "KEY", Field: "key"},
+		{Header: "NAME", Field: "name"},
+		{Header: "KIND", Field: "kind"},
+		{Header: "TEMPORARY", Field: "temporary", Format: boolYesNo},
+		{Header: "TAGS", Field: "tags", Format: truncatedList(3)},
+	},
+	"projects": {
+		{Header: "KEY", Field: "key"},
+		{Header: "NAME", Field: "name"},
+		{Header: "TAG COUNT", Field: "tags", Format: countList},
+	},
+	"environments": {
+		{Header: "KEY", Field: "key"},
+		{Header: "NAME", Field: "name"},
+		{Header: "COLOR", Field: "color"},
+	},
+	"members": {
+		{Header: "EMAIL", Field: "email"},
+		{Header: "ROLE", Field: "role"},
+		{Header: "LAST NAME", Field: "lastName"},
+		{Header: "FIRST NAME", Field: "firstName"},
+	},
+	"segments": {
+		{Header: "KEY", Field: "key"},
+		{Header: "NAME", Field: "name"},
+		{Header: "CREATED", Field: "creationDate", Format: formatTimestamp},
+	},
+}
+
+// singularColumnRegistry maps resource names to their singular-view column definitions.
+var singularColumnRegistry = map[string][]ColumnDef{
+	"flags": {
+		{Header: "Key", Field: "key"},
+		{Header: "Name", Field: "name"},
+		{Header: "Kind", Field: "kind"},
+		{Header: "Temporary", Field: "temporary", Format: boolYesNo},
+		{Header: "Created", Field: "creationDate", Format: formatTimestamp},
+		{Header: "Tags", Field: "tags", Format: truncatedList(10)},
+	},
+	"projects": {
+		{Header: "Key", Field: "key"},
+		{Header: "Name", Field: "name"},
+		{Header: "Tag Count", Field: "tags", Format: countList},
+	},
+	"environments": {
+		{Header: "Key", Field: "key"},
+		{Header: "Name", Field: "name"},
+		{Header: "Color", Field: "color"},
+	},
+	"members": {
+		{Header: "Email", Field: "email"},
+		{Header: "Role", Field: "role"},
+		{Header: "Last Name", Field: "lastName"},
+		{Header: "First Name", Field: "firstName"},
+	},
+	"segments": {
+		{Header: "Key", Field: "key"},
+		{Header: "Name", Field: "name"},
+		{Header: "Created", Field: "creationDate", Format: formatTimestamp},
+	},
+}
+
+// GetListColumns returns the column definitions for a resource's list view, or nil if none are registered.
+func GetListColumns(resourceName string) []ColumnDef {
+	return listColumnRegistry[resourceName]
+}
+
+// GetSingularColumns returns the column definitions for a resource's singular view, or nil if none are registered.
+func GetSingularColumns(resourceName string) []ColumnDef {
+	return singularColumnRegistry[resourceName]
+}
+
+func colValue(r resource, col ColumnDef) string {
+	if r == nil {
+		return ""
+	}
+	format := col.Format
+	if format == nil {
+		format = defaultFormat
+	}
+	return strings.ReplaceAll(format(r[col.Field]), "\t", " ")
+}
+
+// TableOutput formats a slice of resources as an aligned table using tabwriter.
+func TableOutput(items []resource, cols []ColumnDef) string {
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 3, ' ', 0)
+
+	headers := make([]string, len(cols))
+	for i, col := range cols {
+		headers[i] = col.Header
+	}
+	fmt.Fprintln(w, strings.Join(headers, "\t"))
+
+	for _, item := range items {
+		vals := make([]string, len(cols))
+		for i, col := range cols {
+			vals[i] = colValue(item, col)
+		}
+		fmt.Fprintln(w, strings.Join(vals, "\t"))
+	}
+
+	w.Flush()
+
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// KeyValueOutput formats a single resource as key-value pairs.
+func KeyValueOutput(r resource, cols []ColumnDef) string {
+	maxLen := 0
+	for _, col := range cols {
+		if len(col.Header) > maxLen {
+			maxLen = len(col.Header)
+		}
+	}
+
+	lines := make([]string, 0, len(cols))
+	for _, col := range cols {
+		val := colValue(r, col)
+		padding := strings.Repeat(" ", maxLen-len(col.Header))
+		lines = append(lines, fmt.Sprintf("%s:%s  %s", col.Header, padding, val))
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -1,0 +1,410 @@
+package output
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTableOutput(t *testing.T) {
+	t.Run("flags list shows key, name, kind, temporary, tags", func(t *testing.T) {
+		cols := GetListColumns("flags")
+		items := []resource{
+			{
+				"key":       "my-flag",
+				"name":      "My Feature Flag",
+				"kind":      "boolean",
+				"temporary": true,
+				"tags":      []interface{}{"beta", "frontend"},
+			},
+			{
+				"key":       "dark-mode",
+				"name":      "Dark Mode Toggle",
+				"kind":      "boolean",
+				"temporary": false,
+				"tags":      []interface{}{"ui"},
+			},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 3)
+		assert.Contains(t, lines[0], "KEY")
+		assert.Contains(t, lines[0], "NAME")
+		assert.Contains(t, lines[0], "KIND")
+		assert.Contains(t, lines[0], "TEMPORARY")
+		assert.Contains(t, lines[0], "TAGS")
+		assert.Contains(t, lines[1], "my-flag")
+		assert.Contains(t, lines[1], "My Feature Flag")
+		assert.Contains(t, lines[1], "boolean")
+		assert.Contains(t, lines[1], "yes")
+		assert.Contains(t, lines[1], "beta, frontend")
+		assert.Contains(t, lines[2], "dark-mode")
+		assert.Contains(t, lines[2], "no")
+	})
+
+	t.Run("flags list truncates tags beyond 3", func(t *testing.T) {
+		cols := GetListColumns("flags")
+		items := []resource{
+			{
+				"key":       "many-tags",
+				"name":      "Many Tags",
+				"kind":      "boolean",
+				"temporary": false,
+				"tags":      []interface{}{"a", "b", "c", "d"},
+			},
+		}
+
+		result := TableOutput(items, cols)
+
+		assert.Contains(t, result, "a, b, c, ...")
+	})
+
+	t.Run("projects list shows key, name, tag count", func(t *testing.T) {
+		cols := GetListColumns("projects")
+		items := []resource{
+			{
+				"key":  "proj-1",
+				"name": "Project One",
+				"tags": []interface{}{"tag1", "tag2", "tag3"},
+			},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 2)
+		assert.Contains(t, lines[0], "KEY")
+		assert.Contains(t, lines[0], "NAME")
+		assert.Contains(t, lines[0], "TAG COUNT")
+		assert.Contains(t, lines[1], "proj-1")
+		assert.Contains(t, lines[1], "Project One")
+		assert.Contains(t, lines[1], "3")
+	})
+
+	t.Run("environments list shows key, name, color", func(t *testing.T) {
+		cols := GetListColumns("environments")
+		items := []resource{
+			{
+				"key":   "production",
+				"name":  "Production",
+				"color": "FF0000",
+			},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 2)
+		assert.Contains(t, lines[0], "KEY")
+		assert.Contains(t, lines[0], "NAME")
+		assert.Contains(t, lines[0], "COLOR")
+		assert.Contains(t, lines[1], "production")
+		assert.Contains(t, lines[1], "Production")
+		assert.Contains(t, lines[1], "FF0000")
+	})
+
+	t.Run("members list shows email, role, lastName, firstName", func(t *testing.T) {
+		cols := GetListColumns("members")
+		items := []resource{
+			{
+				"email":     "alice@example.com",
+				"role":      "admin",
+				"lastName":  "Smith",
+				"firstName": "Alice",
+			},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 2)
+		assert.Contains(t, lines[0], "EMAIL")
+		assert.Contains(t, lines[0], "ROLE")
+		assert.Contains(t, lines[0], "LAST NAME")
+		assert.Contains(t, lines[0], "FIRST NAME")
+		assert.Contains(t, lines[1], "alice@example.com")
+		assert.Contains(t, lines[1], "admin")
+		assert.Contains(t, lines[1], "Smith")
+		assert.Contains(t, lines[1], "Alice")
+	})
+
+	t.Run("segments list shows key, name, creationDate", func(t *testing.T) {
+		cols := GetListColumns("segments")
+		items := []resource{
+			{
+				"key":          "beta-users",
+				"name":         "Beta Users",
+				"creationDate": float64(1718438400000),
+			},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 2)
+		expected := time.UnixMilli(1718438400000).UTC().Format(time.RFC3339)
+		assert.Contains(t, lines[0], "KEY")
+		assert.Contains(t, lines[0], "NAME")
+		assert.Contains(t, lines[0], "CREATED")
+		assert.Contains(t, lines[1], "beta-users")
+		assert.Contains(t, lines[1], "Beta Users")
+		assert.Contains(t, lines[1], expected)
+	})
+
+	t.Run("handles nil field values gracefully", func(t *testing.T) {
+		cols := GetListColumns("flags")
+		items := []resource{
+			{
+				"key":  "no-extras",
+				"name": "No Extras",
+			},
+		}
+
+		result := TableOutput(items, cols)
+
+		assert.Contains(t, result, "no-extras")
+		assert.Contains(t, result, "No Extras")
+	})
+
+	t.Run("multiple rows are aligned", func(t *testing.T) {
+		cols := GetListColumns("environments")
+		items := []resource{
+			{"key": "short", "name": "S", "color": "000"},
+			{"key": "a-very-long-key", "name": "A Very Long Name", "color": "FFF"},
+		}
+
+		result := TableOutput(items, cols)
+		lines := strings.Split(result, "\n")
+
+		assert.Len(t, lines, 3)
+		headerKeyEnd := strings.Index(lines[0], "NAME")
+		row1KeyEnd := strings.Index(lines[1], "S")
+		row2KeyEnd := strings.Index(lines[2], "A Very Long Name")
+		assert.Equal(t, headerKeyEnd, row1KeyEnd)
+		assert.Equal(t, headerKeyEnd, row2KeyEnd)
+	})
+}
+
+func TestKeyValueOutput(t *testing.T) {
+	t.Run("flags singular shows key-value pairs", func(t *testing.T) {
+		cols := GetSingularColumns("flags")
+		r := resource{
+			"key":          "my-flag",
+			"name":         "My Feature Flag",
+			"kind":         "boolean",
+			"temporary":    true,
+			"creationDate": float64(1718438400000),
+			"tags":         []interface{}{"beta", "frontend"},
+		}
+
+		result := KeyValueOutput(r, cols)
+
+		expected := time.UnixMilli(1718438400000).UTC().Format(time.RFC3339)
+		assert.Contains(t, result, "Key:")
+		assert.Contains(t, result, "my-flag")
+		assert.Contains(t, result, "Name:")
+		assert.Contains(t, result, "My Feature Flag")
+		assert.Contains(t, result, "Kind:")
+		assert.Contains(t, result, "boolean")
+		assert.Contains(t, result, "Temporary:")
+		assert.Contains(t, result, "yes")
+		assert.Contains(t, result, "Created:")
+		assert.Contains(t, result, expected)
+		assert.Contains(t, result, "Tags:")
+		assert.Contains(t, result, "beta, frontend")
+	})
+
+	t.Run("members singular shows email, role, names", func(t *testing.T) {
+		cols := GetSingularColumns("members")
+		r := resource{
+			"email":     "alice@example.com",
+			"role":      "admin",
+			"lastName":  "Smith",
+			"firstName": "Alice",
+		}
+
+		result := KeyValueOutput(r, cols)
+
+		assert.Contains(t, result, "Email:")
+		assert.Contains(t, result, "alice@example.com")
+		assert.Contains(t, result, "Role:")
+		assert.Contains(t, result, "admin")
+	})
+
+	t.Run("handles nil values", func(t *testing.T) {
+		cols := GetSingularColumns("flags")
+		r := resource{
+			"key":  "minimal",
+			"name": "Minimal Flag",
+		}
+
+		result := KeyValueOutput(r, cols)
+
+		assert.Contains(t, result, "Key:        minimal")
+		assert.Contains(t, result, "Name:       Minimal Flag")
+		assert.Contains(t, result, "Kind:")
+	})
+}
+
+func TestGetListColumns(t *testing.T) {
+	t.Run("returns nil for unknown resource", func(t *testing.T) {
+		cols := GetListColumns("unknown-resource")
+
+		assert.Nil(t, cols)
+	})
+
+	t.Run("returns columns for flags", func(t *testing.T) {
+		cols := GetListColumns("flags")
+
+		assert.NotNil(t, cols)
+		assert.Equal(t, "KEY", cols[0].Header)
+	})
+}
+
+func TestGetSingularColumns(t *testing.T) {
+	t.Run("returns nil for unknown resource", func(t *testing.T) {
+		cols := GetSingularColumns("unknown-resource")
+
+		assert.Nil(t, cols)
+	})
+
+	t.Run("returns columns for flags", func(t *testing.T) {
+		cols := GetSingularColumns("flags")
+
+		assert.NotNil(t, cols)
+		assert.Equal(t, "Key", cols[0].Header)
+	})
+}
+
+func TestBoolYesNo(t *testing.T) {
+	assert.Equal(t, "yes", boolYesNo(true))
+	assert.Equal(t, "no", boolYesNo(false))
+	assert.Equal(t, "something", boolYesNo("something"))
+	assert.Equal(t, "", boolYesNo(nil))
+}
+
+func TestTruncatedList(t *testing.T) {
+	fn := truncatedList(3)
+
+	t.Run("within limit", func(t *testing.T) {
+		result := fn([]interface{}{"a", "b"})
+		assert.Equal(t, "a, b", result)
+	})
+
+	t.Run("at limit", func(t *testing.T) {
+		result := fn([]interface{}{"a", "b", "c"})
+		assert.Equal(t, "a, b, c", result)
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		result := fn([]interface{}{"a", "b", "c", "d"})
+		assert.Equal(t, "a, b, c, ...", result)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		result := fn([]interface{}{})
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("non-slice value", func(t *testing.T) {
+		result := fn("not-a-list")
+		assert.Equal(t, "not-a-list", result)
+	})
+
+	t.Run("nil value", func(t *testing.T) {
+		result := fn(nil)
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestCountList(t *testing.T) {
+	t.Run("counts items", func(t *testing.T) {
+		result := countList([]interface{}{"a", "b", "c"})
+		assert.Equal(t, "3", result)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		result := countList([]interface{}{})
+		assert.Equal(t, "0", result)
+	})
+
+	t.Run("non-slice", func(t *testing.T) {
+		result := countList("not-a-list")
+		assert.Equal(t, "not-a-list", result)
+	})
+
+	t.Run("nil value", func(t *testing.T) {
+		result := countList(nil)
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestFormatTimestamp(t *testing.T) {
+	t.Run("formats float64 unix millis to RFC3339", func(t *testing.T) {
+		result := formatTimestamp(float64(1718438400000))
+		expected := time.UnixMilli(1718438400000).UTC().Format(time.RFC3339)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("nil returns empty string", func(t *testing.T) {
+		result := formatTimestamp(nil)
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("string passes through to defaultFormat", func(t *testing.T) {
+		result := formatTimestamp("2024-06-15T00:00:00Z")
+		assert.Equal(t, "2024-06-15T00:00:00Z", result)
+	})
+}
+
+func TestTableOutputEdgeCases(t *testing.T) {
+	t.Run("empty items produces header only", func(t *testing.T) {
+		cols := GetListColumns("flags")
+		result := TableOutput([]resource{}, cols)
+		lines := strings.Split(result, "\n")
+		assert.Len(t, lines, 1)
+		assert.Contains(t, lines[0], "KEY")
+	})
+
+	t.Run("nil resource in items does not panic", func(t *testing.T) {
+		cols := GetListColumns("environments")
+		items := []resource{
+			{"key": "good", "name": "Good", "color": "FFF"},
+			nil,
+		}
+		result := TableOutput(items, cols)
+		assert.Contains(t, result, "good")
+	})
+
+	t.Run("tab in value does not break alignment", func(t *testing.T) {
+		cols := []ColumnDef{
+			{Header: "KEY", Field: "key"},
+			{Header: "NAME", Field: "name"},
+		}
+		items := []resource{
+			{"key": "has\ttab", "name": "normal"},
+		}
+		result := TableOutput(items, cols)
+		assert.NotContains(t, result, "\t")
+		assert.Contains(t, result, "has tab")
+	})
+}
+
+func TestKeyValueOutputEdgeCases(t *testing.T) {
+	t.Run("empty cols returns empty string", func(t *testing.T) {
+		r := resource{"key": "val"}
+		result := KeyValueOutput(r, []ColumnDef{})
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestBoolYesNoEdgeCases(t *testing.T) {
+	t.Run("numeric float64 passes through", func(t *testing.T) {
+		result := boolYesNo(float64(1))
+		assert.Equal(t, "1", result)
+	})
+}


### PR DESCRIPTION
Replace the minimal plaintext output (* name (key) bullets) with table-formatted output using text/tabwriter. Define column sets per resource type starting with 5-6 high-value resources (flags, projects, environments, members, segments). Everything else falls back to the current bullet format. Singular resources show key-value pairs.

before:
<img width="584" height="112" alt="Screenshot 2026-03-17 at 9 26 37 PM" src="https://github.com/user-attachments/assets/e665b3fe-7387-4201-b86e-8d388f37726c" />
<img width="721" height="85" alt="Screenshot 2026-03-17 at 9 26 24 PM" src="https://github.com/user-attachments/assets/6a5f8c6e-d602-4d4b-b323-fbc3fc3dc1ce" />
<img width="622" height="180" alt="Screenshot 2026-03-17 at 9 26 10 PM" src="https://github.com/user-attachments/assets/1980b424-0e0f-4262-bf3d-48be640139c7" />


after: 
<img width="712" height="201" alt="Screenshot 2026-03-17 at 9 21 49 PM" src="https://github.com/user-attachments/assets/86fa1b15-5433-4d02-87ce-9f9c984fe31d" />
<img width="1315" height="230" alt="Screenshot 2026-03-17 at 9 21 17 PM" src="https://github.com/user-attachments/assets/1ea2c8a2-1933-4e4b-ae43-ff73f5b71362" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the CLI’s default plaintext rendering across multiple resource commands, which can impact user workflows and tests that parse human-readable output (JSON output remains unchanged).
> 
> **Overview**
> Updates plaintext CLI output to be *resource-aware*: when `CmdOutput` is given a `ResourceName`, list responses render as aligned tables and singular responses render as key/value blocks (with fallback to the existing bullet and `name (key)` formats for unknown resources).
> 
> Adds `internal/output/table.go` with per-resource column registries (initially `flags`, `projects`, `environments`, `members`, `segments`) plus formatting helpers (yes/no booleans, tag truncation, timestamp formatting), and extends `CmdOutput` with optional `CmdOutputOpts` (including default `Fields`). Commands now pass `ResourceName` (e.g., `flags archive/toggle`, `members invite`, and generated `resources` operations), and tests are updated/expanded to assert the new plaintext output while keeping JSON behavior the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 887c6148bfd2494fd55aab0be1a19312429c6ab6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->