### PR TITLE
feat(REL-12779): Add a command to sign up that directs the user to the sign up page

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	logincmd "github.com/launchdarkly/ldcli/cmd/login"
 	memberscmd "github.com/launchdarkly/ldcli/cmd/members"
 	resourcecmd "github.com/launchdarkly/ldcli/cmd/resources"
+	signupcmd "github.com/launchdarkly/ldcli/cmd/signup"
 	sourcemapscmd "github.com/launchdarkly/ldcli/cmd/sourcemaps"
 	"github.com/launchdarkly/ldcli/internal/analytics"
 	"github.com/launchdarkly/ldcli/internal/config"
@@ -100,6 +101,7 @@ func NewRootCommand(
 				"config",
 				"help",
 				"login",
+				"signup",
 			} {
 				if cmd.HasParent() && cmd.Parent().Name() == name {
 					cmd.DisableFlagParsing = true
@@ -209,6 +211,7 @@ func NewRootCommand(
 	cmd.AddCommand(configCmd.Cmd())
 	cmd.AddCommand(NewQuickStartCmd(analyticsTrackerFn, clients.EnvironmentsClient, clients.FlagsClient))
 	cmd.AddCommand(logincmd.NewLoginCmd(clients.ResourcesClient))
+	cmd.AddCommand(signupcmd.NewSignupCmd(analyticsTrackerFn))
 	cmd.AddCommand(resourcecmd.NewResourcesCmd())
 	cmd.AddCommand(devcmd.NewDevServerCmd(clients.ResourcesClient, analyticsTrackerFn, clients.DevClient))
 	cmd.AddCommand(sourcemapscmd.NewSourcemapsCmd(clients.ResourcesClient, analyticsTrackerFn))

--- a/cmd/signup/signup.go
+++ b/cmd/signup/signup.go
@@ -1,0 +1,52 @@
+package signup
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	cmdAnalytics "github.com/launchdarkly/ldcli/cmd/analytics"
+	"github.com/launchdarkly/ldcli/cmd/cliflags"
+	"github.com/launchdarkly/ldcli/internal/analytics"
+)
+
+func NewSignupCmd(analyticsTrackerFn analytics.TrackerFn) *cobra.Command {
+	cmd := &cobra.Command{
+		Long: "Open your browser to create a new LaunchDarkly account",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			analyticsTrackerFn(
+				viper.GetString(cliflags.AccessTokenFlag),
+				viper.GetString(cliflags.BaseURIFlag),
+				viper.GetBool(cliflags.AnalyticsOptOut),
+			).SendCommandRunEvent(cmdAnalytics.CmdRunEventProperties(cmd, "signup", nil))
+		},
+		RunE:  run,
+		Short: "Create a new LaunchDarkly account",
+		Use:   "signup",
+	}
+
+	return cmd
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	signupURL, err := url.JoinPath(
+		viper.GetString(cliflags.BaseURIFlag),
+		"/signup",
+	)
+	if err != nil {
+		return fmt.Errorf("failed to construct signup URL: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Opening your browser to %s to create a new LaunchDarkly account.\n", signupURL)
+	fmt.Fprintln(cmd.OutOrStdout(), "If your browser does not open automatically, you can paste the above URL into your browser.")
+
+	err = browser.OpenURL(signupURL)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to open browser automatically: %v\n", err)
+	}
+
+	return nil
+}

--- a/cmd/signup/signup_test.go
+++ b/cmd/signup/signup_test.go
@@ -1,0 +1,26 @@
+package signup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/launchdarkly/ldcli/internal/analytics"
+)
+
+func TestSignupCmd(t *testing.T) {
+	t.Run("creates signup command with correct attributes", func(t *testing.T) {
+		mockTracker := &analytics.MockTracker{}
+		analyticsTrackerFn := func(accessToken string, baseURI string, optOut bool) analytics.Tracker {
+			return mockTracker
+		}
+
+		cmd := NewSignupCmd(analyticsTrackerFn)
+
+		assert.Equal(t, "signup", cmd.Use)
+		assert.Equal(t, "Create a new LaunchDarkly account", cmd.Short)
+		assert.Equal(t, "Open your browser to create a new LaunchDarkly account", cmd.Long)
+		assert.NotNil(t, cmd.RunE)
+		assert.NotNil(t, cmd.PreRun)
+	})
+}

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -15,6 +15,7 @@ Commands:
   {{rpad "config" 29}} View and modify specific configuration values
   {{rpad "completion" 29}} Enable command autocompletion within supported shells
   {{rpad "login" 29}} Log in to your LaunchDarkly account
+  {{rpad "signup" 29}} Create a new LaunchDarkly account
   {{rpad "dev-server" 29}} Run a development server to serve flags locally
 
 Common resource commands:


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

https://launchdarkly.atlassian.net/browse/REL-12779

**Describe the solution you've provided**

This pull request adds a new `signup` command to the CLI, allowing users to easily open a browser and create a new LaunchDarkly account. The implementation includes the command itself, integration into the CLI, updates to help text, and a basic test for the new command.

**New Signup Command Integration**

* Added a new `signup` command in `cmd/signup/signup.go`, which opens the user's browser to the LaunchDarkly signup page and tracks analytics for the command run.
* Integrated the new `signup` command into the CLI by importing it, registering it in the root command, and including it in the list of commands that disable flag parsing when used as a parent. (`cmd/root.go`) [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR25) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR104) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR214)

**User Experience Improvements**

* Updated the CLI help templates to include the new `signup` command in the list of available commands. (`cmd/templates.go`)

**Testing**

* Added a unit test for the `signup` command to verify its attributes and ensure it is created correctly. (`cmd/signup/signup_test.go`)

**Describe alternatives you've considered**

Not adding this at all? But fundamentally we need to get the data. 

**Additional context**

<img width="699" height="45" alt="Screenshot 2026-03-18 at 3 44 27 PM" src="https://github.com/user-attachments/assets/b42f4e1c-5e7b-4c91-8eea-2f09cb20630e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, isolated CLI command and help text with minimal interaction with existing logic. Main risk is minor UX/platform behavior differences when auto-opening a browser or constructing the signup URL from `base-uri`.
> 
> **Overview**
> Adds a new top-level `ldcli signup` command that opens the user’s browser to the `/signup` page (based on the configured `base-uri`) and emits the standard command-run analytics event.
> 
> Wires `signup` into the root command (including disabling required flag parsing for it as a parent) and updates the usage template to list it; includes a basic unit test asserting the command metadata and handlers are set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88b9412112b6f2a1e0a117f5c5b185d893ffd999. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ld-jira-link -->
---
Related Jira issue: [REL-12779: Add signup command to CLI to determine usage and to point folks to signup](https://launchdarkly.atlassian.net/browse/REL-12779)
<!-- end-ld-jira-link -->