### PR TITLE
chore: migrate to googleapis/release-please-action v4.4.1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary
- Replace deprecated `google-github-actions/release-please-action` with `googleapis/release-please-action`, pinned to v4.4.1

## Test plan
- [ ] Verify release-please workflow runs without the deprecation warning on the next push to main

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only swaps the `release-please` GitHub Action reference in the release workflow, with no application/runtime code changes. Primary risk is CI/release automation behavior differing slightly due to the action migration/pin.
> 
> **Overview**
> Updates the `release-please` GitHub Actions workflow to use the non-deprecated `googleapis/release-please-action`, pinned to `v4.4.1` (commit SHA), replacing `google-github-actions/release-please-action`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b3c7c2fefd8d2e6b3e9f56399c02def3b5c05e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->