### PR TITLE
fix: add permissions for release-please job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- Add `contents: write` and `pull-requests: write` permissions to the `release-please` job so it can create/update its release PR git tree via the GitHub API
- Fixes "Error adding to tree" failure from release-please

## Test plan
- [ ] Verify release-please workflow succeeds on the next push to main

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Elevates workflow token privileges (`contents: write`, `pull-requests: write`), which is security-sensitive but scoped to a single job and only affects the release automation workflow.
> 
> **Overview**
> **Fixes release automation failures** by adding explicit `GITHUB_TOKEN` permissions to the `release-please` job.
> 
> The workflow now grants `contents: write` and `pull-requests: write` so `release-please` can create/update the release PR git tree via the GitHub API when running on pushes to `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c22e90b843ac29743540d1f0b895686b9652dbce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->