### PR TITLE
fix: anchor release-please to v3.0.0 release commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,9 @@
 {
   "packages": {
     ".": {
-      "release-type": "go",
+      "release-type": "simple",
       "versioning": "default",
+      "last-release-sha": "caa1fd26848adc2d79112a17edff9771d60c377e",
       "extra-files": [
         "PROVENANCE.md",
         {


### PR DESCRIPTION
## Summary

Fixes the release-please version regression from 3.0.0 to 0.12.1.

**Root cause:** The `release-type: "go"` config caused release-please to walk all 698 commits from the beginning of the repo because no `v3.0.0` git tag exists. The Go release-type also enforces Go module path conventions (requiring `/v3` suffix for major versions >= 2), which this CLI binary doesn't follow.

**Fix:**
- Changed `release-type` from `"go"` to `"simple"` — uses the manifest as source of truth, no Go module path conventions
- Added `last-release-sha` pointing to the 3.0.0 release commit (`caa1fd2`) so release-please only considers commits after that point

After this merges, release-please should correctly create a 3.0.1 release PR. PR #685 (the regressed 0.12.1 PR) should be closed.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to release automation; no runtime code paths affected, but it can change how future versions/changelogs are computed.
> 
> **Overview**
> Updates `release-please-config.json` to switch the root package `release-type` from **`go` to `simple`**, avoiding Go module/versioning conventions.
> 
> Pins release-please’s starting point by adding `last-release-sha` for the `v3.0.0` release commit so only commits after that SHA are considered for future release PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b10bc9c5022acae11d83aaa85606bcd51e562e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->