### PR TITLE
fix: anchor release-please to v3.0.0 release commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
     ".": {
       "release-type": "go",
       "versioning": "default",
+      "last-release-sha": "caa1fd26848adc2d79112a17edff9771d60c377e",
       "extra-files": [
         "PROVENANCE.md",
         {


### PR DESCRIPTION
## Summary

Fixes the release-please version regression from 3.0.0 to 0.12.1.

**Root cause:** The v3.0.0 git tag is permanently burned by GitHub's immutable releases feature. Without the tag, release-please walks all 698 commits from the beginning of the repo and computes 0.12.x instead of 3.0.1.

**Fix:** Add `last-release-sha` pointing to the 3.0.0 release commit (`caa1fd2`) so release-please only considers commits after that point. No change to `release-type`.

After this merges, release-please should correctly create a 3.0.1 release PR.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change affecting automated release version calculation; no runtime, security, or data-path code is modified.
> 
> **Overview**
> Anchors `release-please` history by adding `last-release-sha` to `release-please-config.json`, so version calculation starts from the v3.0.0 release commit instead of scanning the full repo history.
> 
> This prevents release-please from regressing the computed version (e.g., to `0.12.x`) when the `v3.0.0` tag is unavailable, and should restore correct `3.x` release PR generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8287853e39cbb8469d1c6707fe7bb6587a62e71d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->