### PR TITLE
fix: tolerate missing *.zip in gh release upload

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -102,4 +102,14 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
-        gh release upload "${{ inputs.tag }}" ./dist/*.tar.gz ./dist/*.zip ./dist/*.txt --clobber
+        # nullglob lets the *.zip (and any other format we don't currently
+        # produce) expand to nothing instead of being passed literally to
+        # gh release upload, which would fail with "no matches found".
+        set -euo pipefail
+        shopt -s nullglob
+        files=(./dist/*.tar.gz ./dist/*.zip ./dist/*.txt)
+        if [ ${#files[@]} -eq 0 ]; then
+          echo "No artifacts found in ./dist to upload" >&2
+          exit 1
+        fi
+        gh release upload "${{ inputs.tag }}" "${files[@]}" --clobber


### PR DESCRIPTION
## Summary

Fixes the v3.0.2 release failure. The `Upload Release Artifacts` step in `.github/actions/publish/action.yml` passed `./dist/*.zip` to `gh release upload`, but goreleaser isn't configured to produce zip archives — the literal unmatched glob was passed to `gh`, which errored with `no matches found for \`./dist/*.zip\``.

Swap the shell glob for `shopt -s nullglob` + array expansion so missing archive formats just expand to nothing. The `*.zip` entry stays so that if we ever add `format_overrides` for Windows zips in `.goreleaser.yaml` they'll be picked up automatically.

See run 24580531429 for the original failure.

## Context

- `v3.0.2` tag + draft release were created by release-please (they exist immutably).
- `release-ldcli` got as far as pushing `launchdarkly/ldcli:3.0.2` / `:v3` / `:latest` to Docker Hub before failing on the upload step, so those Docker tags exist **without attestations**.
- No binaries made it onto the `v3.0.2` GitHub release.
- npm never published (it depended on `release-ldcli` succeeding).

Since this is a `fix:` commit, release-please should propose `3.0.3` next. We'll skip v3.0.2 (same pattern as v3.0.0 → v3.0.1) and clean up:
- Delete the `v3.0.2` draft GitHub release.
- Delete the `launchdarkly/ldcli:3.0.2` tag on Docker Hub (so no one pulls an unattested image).
- `:v3` and `:latest` will be overwritten when v3.0.3 ships.

## Test plan

- [ ] Merge this PR.
- [ ] Clean up v3.0.2 (draft release + Docker Hub `:3.0.2`).
- [ ] Watch release-please open `chore(main): release 3.0.3`.
- [ ] Merge the release-please PR.
- [ ] Verify binaries + checksums are attached to the `v3.0.3` release.
- [ ] Verify attestations: `gh attestation verify ldcli_3.0.3_linux_amd64.tar.gz --owner launchdarkly` and `gh attestation verify oci://launchdarkly/ldcli:3.0.3 --owner launchdarkly`.
- [ ] Verify `npm view @launchdarkly/ldcli version` returns `3.0.3`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only change to the GitHub release upload step; risk is limited to altering which artifacts get attached to a release.
> 
> **Overview**
> Fixes the release publishing composite action so `gh release upload` no longer fails when optional artifact globs (like `./dist/*.zip`) have no matches.
> 
> The upload step now enables `nullglob`, builds an explicit `files` array, and errors with a clear message if *no* artifacts are present before calling `gh release upload`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5e5fe6b0d1767311082e9177cb4ca672ce80148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->