### PR TITLE
ci: switch npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -83,6 +83,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.dry-run-npm == false }}
     needs: [release-ldcli]
+    # id-token: write lets npm CLI exchange the GITHUB_TOKEN for an OIDC token
+    # that the npm registry trusts via the trusted publisher config. The npm
+    # trusted publisher must be configured with this workflow filename
+    # (manual-publish.yml) for publishes from this path to succeed.
     permissions:
       actions: read
       id-token: write
@@ -92,15 +96,14 @@ jobs:
         name: Checkout
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
-      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.1
-        name: 'Get NPM token'
-        with:
-          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-          ssm_parameter_pairs: '/production/common/releasing/npm/token = NODE_AUTH_TOKEN'
+      - name: Update npm
+        shell: bash
+        # npm CLI requires >= 11.5.1 for trusted publishing (OIDC) support.
+        run: npm install -g npm@11.6.2
       - id: publish-npm
         name: Publish NPM Package
         uses: ./.github/actions/publish-npm

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -107,21 +107,24 @@ jobs:
   release-ldcli-npm:
     runs-on: ubuntu-latest
     needs: [release-please, release-ldcli]
+    # id-token: write lets npm CLI exchange the GITHUB_TOKEN for an OIDC token
+    # that the npm registry trusts via the trusted publisher config for this
+    # workflow. No static NPM token is needed (or wanted: if NODE_AUTH_TOKEN is
+    # set, npm prefers the token path and skips OIDC).
     permissions:
       id-token: write
       contents: write
     if: needs.release-please.outputs.release_created == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
-      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.1
-        name: 'Get NPM token'
-        with:
-          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-          ssm_parameter_pairs: '/production/common/releasing/npm/token = NODE_AUTH_TOKEN'
+      - name: Update npm
+        shell: bash
+        # npm CLI requires >= 11.5.1 for trusted publishing (OIDC) support.
+        run: npm install -g npm@11.6.2
       - id: publish-npm
         name: Publish NPM Package
         uses: ./.github/actions/publish-npm


### PR DESCRIPTION
## Summary

- Fixes the `npm publish` 404 that broke the `v3.0.3` release after trusted publishing was enabled on `@launchdarkly/ldcli`: bumps `actions/setup-node` to `v4`, installs `npm@11.6.2` (OIDC support requires `>= 11.5.1`), and drops the `NODE_AUTH_TOKEN` SSM lookup so the npm CLI uses the OIDC token from `id-token: write`.
- Matches the pattern already in use by `js-client-sdk`, `observability-sdk` (`@launchdarkly/*` packages), and `launchdarkly-toolbar` — `ldcli` was the last repo still on the legacy static-token path.
- Applied identically to both `release-please.yml` (auto release path) and `manual-publish.yml` (`workflow_dispatch` recovery path). No changes to `scripts/publish-npm.sh`.

## npm-side config

For both workflows to publish successfully, the npm trusted publisher config on `@launchdarkly/ldcli` must list this repo + workflow filenames:
- `release-please.yml` (already configured)
- `manual-publish.yml` (needs to be added if we want the manual recovery path to work end-to-end)

## Test plan

- [ ] Merge; re-run `manual-publish.yml` for `v3.0.3` and confirm npm publish succeeds without a token.
- [ ] Un-draft the `v3.0.3` GitHub release once the npm package + attestations are in place.
- [ ] On the next `release-please` cut, confirm the auto path publishes cleanly end-to-end.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation for npm publishing; misconfiguration of npm trusted publisher/workflow name or npm version could block releases even though the change is confined to CI.
> 
> **Overview**
> Updates the `release-ldcli-npm` jobs in both `release-please.yml` and `manual-publish.yml` to publish to npm via **trusted publishing (OIDC)** instead of retrieving and using `NODE_AUTH_TOKEN` from SSM.
> 
> Bumps `actions/setup-node` from `v3` to `v4` and installs `npm@11.6.2` in the workflow to ensure the npm CLI supports OIDC-based publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b94ac99b2db3f6bdc2a47225c7c9f8eccb0a8dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->