### PR TITLE
fix: noop to trigger release please

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ npm run lint    # ESLint
 npm run build   # Production build (checked into repo)
 
 
+
 ```
 
 ## Testing


### PR DESCRIPTION
## Summary

- Drops a one-line noop into `AGENTS.md` (matching the established pattern from #681 / #684) so release-please sees a `fix:` commit and opens a `3.0.4` release PR.
- First release past the npm OIDC migration in #695 — this is the run where we confirm the full release-please flow (binaries, Docker, attestations, npm) works end-to-end on the new workflow.

## Why

`v3.0.3` landed with binaries/Docker/attestations but no npm package (the draft was un-drafted via `manual-publish.yml` after the token-based publish 404'd). With #695 merged, `release-please.yml` now publishes npm via trusted publishing (OIDC). We need a bumpable commit on `main` for release-please to propose the next version and run through the new flow.

## Test plan

- [ ] After merge, confirm release-please opens a `chore(main): release 3.0.4` PR.
- [ ] Merge the release PR and confirm the `release-ldcli-npm` job succeeds (this is the net-new behavior — it was failing on `v3.0.3`).
- [ ] Confirm `@launchdarkly/ldcli@3.0.4` is published on npm, GH release is un-drafted, and Docker images are pushed.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only whitespace/no-op change intended to trigger release automation; no runtime or behavior impact.
> 
> **Overview**
> Makes a no-op whitespace change in `AGENTS.md` (adds an extra blank line in the dev server UI command snippet) to create a `fix:`-scoped commit for release automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a2dc19d23e8cb8b0cfcbaa80d21df800bd323b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->