### PR TITLE
feat: [FD-5561] implement FDv2 polling endpoint GET /sdk/poll

### DIFF
--- a/internal/dev_server/sdk/fdv2.go
+++ b/internal/dev_server/sdk/fdv2.go
@@ -1,0 +1,164 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/launchdarkly/ldcli/internal/dev_server/model"
+)
+
+const (
+	fdv2EventServerIntent       = "server-intent"
+	fdv2EventPutObject          = "put-object"
+	fdv2EventPayloadTransferred = "payload-transferred"
+
+	fdv2IntentXferFull = "xfer-full"
+	fdv2IntentNone     = "none"
+
+	fdv2ReasonUpToDate       = "up-to-date"
+	fdv2ReasonCantCatchup    = "cant-catchup"
+	fdv2ReasonPayloadMissing = "payload-missing"
+)
+
+// fdv2RawEvent matches the wire format the SDK deserializes from the /sdk/poll response.
+// The SDK's RawEvent uses json:"event" (not json:"name") as of v7.13+.
+type fdv2RawEvent struct {
+	Event string          `json:"event"`
+	Data  json.RawMessage `json:"data"`
+}
+
+type fdv2Payload struct {
+	ID         string `json:"id"`
+	Target     int    `json:"target"`
+	IntentCode string `json:"intentCode"`
+	Reason     string `json:"reason"`
+}
+
+type fdv2ServerIntentData struct {
+	Payloads []fdv2Payload `json:"payloads"`
+}
+
+type fdv2PutObjectData struct {
+	Version int             `json:"version"`
+	Kind    string          `json:"kind"`
+	Key     string          `json:"key"`
+	Object  json.RawMessage `json:"object"`
+}
+
+type fdv2PayloadTransferredData struct {
+	State   string `json:"state"`
+	Version int    `json:"version"`
+}
+
+type fdv2PollResponse struct {
+	Events []fdv2RawEvent `json:"events"`
+}
+
+// parseBasisVersion extracts the payload version from a basis state string of the
+// form "(p:<payloadId>:<version>)". Returns 0 if the string is absent or unparseable.
+func parseBasisVersion(basis string) int {
+	if basis == "" {
+		return 0
+	}
+	lastColon := strings.LastIndex(basis, ":")
+	if lastColon == -1 {
+		return 0
+	}
+	versionStr := strings.TrimSuffix(basis[lastColon+1:], ")")
+	version, err := strconv.Atoi(versionStr)
+	if err != nil || version < 0 {
+		return 0
+	}
+	return version
+}
+
+// buildPollResponse constructs the FDv2 polling response.
+//
+// payloadID is the stable identifier for this payload (the project key).
+// currentVersion is the project's current PayloadVersion.
+// flags is the current flag state with overrides applied.
+// basisVersion is parsed from the SDK's ?basis query param (0 = no basis provided).
+func buildPollResponse(payloadID string, currentVersion int, flags model.FlagsState, basisVersion int) (fdv2PollResponse, error) {
+	switch {
+	case basisVersion == 0:
+		return buildFullTransferResponse(payloadID, currentVersion, flags, fdv2ReasonPayloadMissing)
+	case basisVersion >= currentVersion:
+		event, err := makeServerIntentEvent(payloadID, currentVersion, fdv2IntentNone, fdv2ReasonUpToDate)
+		if err != nil {
+			return fdv2PollResponse{}, err
+		}
+		return fdv2PollResponse{Events: []fdv2RawEvent{event}}, nil
+	default:
+		// Stale: we don't store history so we can't compute a delta — send the full payload.
+		return buildFullTransferResponse(payloadID, currentVersion, flags, fdv2ReasonCantCatchup)
+	}
+}
+
+func buildFullTransferResponse(payloadID string, version int, flags model.FlagsState, reason string) (fdv2PollResponse, error) {
+	intentEvent, err := makeServerIntentEvent(payloadID, version, fdv2IntentXferFull, reason)
+	if err != nil {
+		return fdv2PollResponse{}, err
+	}
+	events := []fdv2RawEvent{intentEvent}
+
+	for key, flagState := range flags {
+		event, err := makePutObjectEvent(version, key, flagState)
+		if err != nil {
+			return fdv2PollResponse{}, err
+		}
+		events = append(events, event)
+	}
+
+	transferredEvent, err := makePayloadTransferredEvent(payloadID, version)
+	if err != nil {
+		return fdv2PollResponse{}, err
+	}
+	events = append(events, transferredEvent)
+
+	return fdv2PollResponse{Events: events}, nil
+}
+
+func makeServerIntentEvent(payloadID string, target int, intentCode, reason string) (fdv2RawEvent, error) {
+	data, err := json.Marshal(fdv2ServerIntentData{
+		Payloads: []fdv2Payload{{
+			ID:         payloadID,
+			Target:     target,
+			IntentCode: intentCode,
+			Reason:     reason,
+		}},
+	})
+	if err != nil {
+		return fdv2RawEvent{}, err
+	}
+	return fdv2RawEvent{Event: fdv2EventServerIntent, Data: data}, nil
+}
+
+func makePutObjectEvent(version int, key string, flagState model.FlagState) (fdv2RawEvent, error) {
+	object, err := json.Marshal(serverFlagFromFlagState(key, flagState))
+	if err != nil {
+		return fdv2RawEvent{}, err
+	}
+	data, err := json.Marshal(fdv2PutObjectData{
+		Version: version,
+		Kind:    "flag",
+		Key:     key,
+		Object:  object,
+	})
+	if err != nil {
+		return fdv2RawEvent{}, err
+	}
+	return fdv2RawEvent{Event: fdv2EventPutObject, Data: data}, nil
+}
+
+func makePayloadTransferredEvent(payloadID string, version int) (fdv2RawEvent, error) {
+	data, err := json.Marshal(fdv2PayloadTransferredData{
+		State:   fmt.Sprintf("(p:%s:%d)", payloadID, version),
+		Version: version,
+	})
+	if err != nil {
+		return fdv2RawEvent{}, err
+	}
+	return fdv2RawEvent{Event: fdv2EventPayloadTransferred, Data: data}, nil
+}

--- a/internal/dev_server/sdk/fdv2_test.go
+++ b/internal/dev_server/sdk/fdv2_test.go
@@ -1,0 +1,221 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/ldcli/internal/dev_server/model"
+	"github.com/launchdarkly/ldcli/internal/dev_server/model/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestParseBasisVersion(t *testing.T) {
+	tests := []struct {
+		basis    string
+		expected int
+	}{
+		{"", 0},
+		{"(p:my-project:5)", 5},
+		{"(p:my-project:1)", 1},
+		{"(p:complex:key:with:colons:99)", 99},
+		{"not-valid", 0},
+		{"(p:no-version)", 0},
+		{"(p:negative:-1)", 0},
+		{"(p:nan:abc)", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("basis=%q", tt.basis), func(t *testing.T) {
+			assert.Equal(t, tt.expected, parseBasisVersion(tt.basis))
+		})
+	}
+}
+
+func TestBuildPollResponse(t *testing.T) {
+	payloadID := "test-project"
+	currentVersion := 5
+	flags := model.FlagsState{
+		"flag-1": model.FlagState{Value: ldvalue.Bool(true), Version: 2},
+	}
+
+	t.Run("no basis sends xfer-full with payload-missing", func(t *testing.T) {
+		resp, err := buildPollResponse(payloadID, currentVersion, flags, 0)
+		require.NoError(t, err)
+
+		require.GreaterOrEqual(t, len(resp.Events), 3) // server-intent + put-objects + payload-transferred
+
+		assertServerIntentEvent(t, resp.Events[0], payloadID, currentVersion, fdv2IntentXferFull, fdv2ReasonPayloadMissing)
+		assertPayloadTransferredEvent(t, resp.Events[len(resp.Events)-1], payloadID, currentVersion)
+	})
+
+	t.Run("up-to-date basis sends none with up-to-date", func(t *testing.T) {
+		resp, err := buildPollResponse(payloadID, currentVersion, flags, currentVersion)
+		require.NoError(t, err)
+
+		require.Len(t, resp.Events, 1)
+		assertServerIntentEvent(t, resp.Events[0], payloadID, currentVersion, fdv2IntentNone, fdv2ReasonUpToDate)
+	})
+
+	t.Run("basis ahead of current version sends none with up-to-date", func(t *testing.T) {
+		resp, err := buildPollResponse(payloadID, currentVersion, flags, currentVersion+10)
+		require.NoError(t, err)
+
+		require.Len(t, resp.Events, 1)
+		assertServerIntentEvent(t, resp.Events[0], payloadID, currentVersion, fdv2IntentNone, fdv2ReasonUpToDate)
+	})
+
+	t.Run("stale basis sends xfer-full with cant-catchup", func(t *testing.T) {
+		resp, err := buildPollResponse(payloadID, currentVersion, flags, currentVersion-1)
+		require.NoError(t, err)
+
+		require.GreaterOrEqual(t, len(resp.Events), 3)
+		assertServerIntentEvent(t, resp.Events[0], payloadID, currentVersion, fdv2IntentXferFull, fdv2ReasonCantCatchup)
+		assertPayloadTransferredEvent(t, resp.Events[len(resp.Events)-1], payloadID, currentVersion)
+	})
+
+	t.Run("full transfer includes a put-object for each flag", func(t *testing.T) {
+		multiFlags := model.FlagsState{
+			"flag-a": model.FlagState{Value: ldvalue.Bool(true), Version: 1},
+			"flag-b": model.FlagState{Value: ldvalue.String("hello"), Version: 2},
+		}
+		resp, err := buildPollResponse(payloadID, currentVersion, multiFlags, 0)
+		require.NoError(t, err)
+
+		// server-intent + 2 put-objects + payload-transferred
+		assert.Len(t, resp.Events, 4)
+		putKeys := make(map[string]bool)
+		for _, event := range resp.Events {
+			if event.Event == fdv2EventPutObject {
+				var put fdv2PutObjectData
+				require.NoError(t, json.Unmarshal(event.Data, &put))
+				putKeys[put.Key] = true
+				assert.Equal(t, currentVersion, put.Version)
+				assert.Equal(t, "flag", put.Kind)
+			}
+		}
+		assert.True(t, putKeys["flag-a"])
+		assert.True(t, putKeys["flag-b"])
+	})
+}
+
+func TestPollV2Handler(t *testing.T) {
+	mockController := gomock.NewController(t)
+	store := mocks.NewMockStore(mockController)
+	observers := model.NewObservers()
+
+	router := mux.NewRouter()
+	router.Use(model.ObserversMiddleware(observers))
+	router.Use(model.StoreMiddleware(store))
+	BindRoutes(router)
+
+	project := &model.Project{
+		Key:                  exampleProjectKey,
+		SourceEnvironmentKey: "my-environment",
+		Context:              ldcontext.Context{},
+		LastSyncTime:         time.Unix(0, 0),
+		AllFlagsState: model.FlagsState{
+			"flag-1": model.FlagState{Value: ldvalue.Bool(true), Version: 1},
+		},
+		AvailableVariations: nil,
+		PayloadVersion:      3,
+	}
+
+	t.Run("no basis returns full payload", func(t *testing.T) {
+		store.EXPECT().GetDevProject(gomock.Any(), exampleProjectKey).Return(project, nil)
+		store.EXPECT().GetOverridesForProject(gomock.Any(), exampleProjectKey).Return(nil, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/sdk/poll", nil)
+		req.Header.Set("Authorization", exampleProjectKey)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+		var resp fdv2PollResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.GreaterOrEqual(t, len(resp.Events), 3)
+		assertServerIntentEvent(t, resp.Events[0], exampleProjectKey, 3, fdv2IntentXferFull, fdv2ReasonPayloadMissing)
+		assertPayloadTransferredEvent(t, resp.Events[len(resp.Events)-1], exampleProjectKey, 3)
+	})
+
+	t.Run("up-to-date basis returns none intent", func(t *testing.T) {
+		store.EXPECT().GetDevProject(gomock.Any(), exampleProjectKey).Return(project, nil)
+		store.EXPECT().GetOverridesForProject(gomock.Any(), exampleProjectKey).Return(nil, nil)
+
+		basisState := fmt.Sprintf("(p:%s:%d)", exampleProjectKey, project.PayloadVersion)
+		req := httptest.NewRequest(http.MethodGet, "/sdk/poll?basis="+basisState, nil)
+		req.Header.Set("Authorization", exampleProjectKey)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var resp fdv2PollResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.Len(t, resp.Events, 1)
+		assertServerIntentEvent(t, resp.Events[0], exampleProjectKey, 3, fdv2IntentNone, fdv2ReasonUpToDate)
+	})
+
+	t.Run("stale basis returns full payload with cant-catchup", func(t *testing.T) {
+		store.EXPECT().GetDevProject(gomock.Any(), exampleProjectKey).Return(project, nil)
+		store.EXPECT().GetOverridesForProject(gomock.Any(), exampleProjectKey).Return(nil, nil)
+
+		basisState := fmt.Sprintf("(p:%s:%d)", exampleProjectKey, project.PayloadVersion-1)
+		req := httptest.NewRequest(http.MethodGet, "/sdk/poll?basis="+basisState, nil)
+		req.Header.Set("Authorization", exampleProjectKey)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var resp fdv2PollResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.GreaterOrEqual(t, len(resp.Events), 3)
+		assertServerIntentEvent(t, resp.Events[0], exampleProjectKey, 3, fdv2IntentXferFull, fdv2ReasonCantCatchup)
+		assertPayloadTransferredEvent(t, resp.Events[len(resp.Events)-1], exampleProjectKey, 3)
+	})
+
+	t.Run("unknown project returns 404", func(t *testing.T) {
+		store.EXPECT().GetDevProject(gomock.Any(), exampleProjectKey).Return(nil, model.NewErrNotFound("project", exampleProjectKey))
+
+		req := httptest.NewRequest(http.MethodGet, "/sdk/poll", nil)
+		req.Header.Set("Authorization", exampleProjectKey)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+}
+
+// assertServerIntentEvent unmarshals a server-intent event and checks its fields.
+func assertServerIntentEvent(t *testing.T, event fdv2RawEvent, payloadID string, target int, intentCode, reason string) {
+	t.Helper()
+	assert.Equal(t, fdv2EventServerIntent, event.Event)
+	var data fdv2ServerIntentData
+	require.NoError(t, json.Unmarshal(event.Data, &data))
+	require.Len(t, data.Payloads, 1)
+	assert.Equal(t, payloadID, data.Payloads[0].ID)
+	assert.Equal(t, target, data.Payloads[0].Target)
+	assert.Equal(t, intentCode, data.Payloads[0].IntentCode)
+	assert.Equal(t, reason, data.Payloads[0].Reason)
+}
+
+// assertPayloadTransferredEvent unmarshals a payload-transferred event and checks its fields.
+func assertPayloadTransferredEvent(t *testing.T, event fdv2RawEvent, payloadID string, version int) {
+	t.Helper()
+	assert.Equal(t, fdv2EventPayloadTransferred, event.Event)
+	var data fdv2PayloadTransferredData
+	require.NoError(t, json.Unmarshal(event.Data, &data))
+	assert.Equal(t, version, data.Version)
+	assert.Equal(t, fmt.Sprintf("(p:%s:%d)", payloadID, version), data.State)
+}

--- a/internal/dev_server/sdk/polling.go
+++ b/internal/dev_server/sdk/polling.go
@@ -4,8 +4,39 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/launchdarkly/ldcli/internal/dev_server/model"
 	"github.com/pkg/errors"
 )
+
+func PollV2(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	store := model.StoreFromContext(ctx)
+	projectKey := GetProjectKeyFromContext(ctx)
+
+	project, err := store.GetDevProject(ctx, projectKey)
+	if err != nil {
+		WriteError(ctx, w, errors.Wrap(err, "failed to get project"))
+		return
+	}
+
+	allFlags, err := project.GetFlagStateWithOverridesForProject(ctx)
+	if err != nil {
+		WriteError(ctx, w, errors.Wrap(err, "failed to get flag state"))
+		return
+	}
+
+	basisVersion := parseBasisVersion(r.URL.Query().Get("basis"))
+	response, err := buildPollResponse(projectKey, project.PayloadVersion, allFlags, basisVersion)
+	if err != nil {
+		WriteError(ctx, w, errors.Wrap(err, "failed to build poll response"))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		WriteError(ctx, w, errors.Wrap(err, "failed to encode response"))
+	}
+}
 
 func LatestAll(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/internal/dev_server/sdk/routes.go
+++ b/internal/dev_server/sdk/routes.go
@@ -21,6 +21,7 @@ func BindRoutes(router *mux.Router) {
 
 	router.Handle("/all", GetProjectKeyFromAuthorizationHeader(http.HandlerFunc(StreamServerAllPayload)))
 	router.Handle("/sdk/latest-all", GetProjectKeyFromAuthorizationHeader(http.HandlerFunc(LatestAll)))
+	router.Handle("/sdk/poll", GetProjectKeyFromAuthorizationHeader(http.HandlerFunc(PollV2)))
 
 	router.PathPrefix("/sdk/flags/{flagKey}").
 		Methods(http.MethodGet).


### PR DESCRIPTION
Adds the FDv2 flag-delivery-v2 polling endpoint. The endpoint only does full transfers here because since this is a dev server and it would be an overkill to track all changes in the first iteration. 

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
<!-- ld-jira-link -->
---
Related Jira issue: [FD-5561: Implement poll server side endpoint handling in Launchdarkly dev server](https://launchdarkly.atlassian.net/browse/FD-5561)
<!-- end-ld-jira-link -->