### PR TITLE
fix(REL-13522): convert kebab-case query params to camelCase

### DIFF
--- a/cmd/resources/resource_cmds_test.go
+++ b/cmd/resources/resource_cmds_test.go
@@ -8,7 +8,35 @@ import (
 
 	"github.com/launchdarkly/ldcli/cmd"
 	"github.com/launchdarkly/ldcli/internal/analytics"
+	"github.com/launchdarkly/ldcli/internal/resources"
 )
+
+func TestKebabCaseQueryParamConversion(t *testing.T) {
+	mockClient := &resources.MockClient{
+		Response: []byte(`{"items": []}`),
+	}
+
+	t.Run("converts kebab-case flag --with-branches to camelCase query param withBranches", func(t *testing.T) {
+		args := []string{
+			"code-refs", "list-repositories",
+			"--access-token", "abcd1234",
+			"--with-branches", "true",
+		}
+
+		_, err := cmd.CallCmd(
+			t,
+			cmd.APIClients{
+				ResourcesClient: mockClient,
+			},
+			analytics.NoopClientFn{}.Tracker(),
+			args,
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, "true", mockClient.Query.Get("withBranches"), "query param should be camelCase withBranches, not kebab-case with-branches")
+		assert.Empty(t, mockClient.Query.Get("with-branches"), "kebab-case with-branches should not appear in query")
+	})
+}
 
 func TestCreateTeam(t *testing.T) {
 	t.Run("help shows postTeam description", func(t *testing.T) {

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -318,7 +318,7 @@ func (op *OperationCmd) makeRequest(cmd *cobra.Command, args []string) error {
 			case "path":
 				urlParms = append(urlParms, val)
 			case "query":
-				query.Add(p.Name, val)
+				query.Add(strcase.ToLowerCamel(p.Name), val)
 			}
 		}
 	}


### PR DESCRIPTION
This pull request improves the handling of query parameters in the resources command by ensuring that flag names in kebab-case are correctly converted to camelCase when sent as query parameters. It also adds a test to verify this behavior.


**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Closes https://launchdarkly.atlassian.net/browse/REL-13522

**Describe the solution you've provided**

**Query parameter formatting improvements:**

* Updated the logic in `resources.go` so that query parameters are now added using camelCase (e.g., `withBranches`) instead of the original kebab-case flag name (e.g., `with-branches`). This ensures consistency with API expectations.

**Testing enhancements:**

* Added a new test `TestKebabCaseQueryParamConversion` in `resource_cmds_test.go` to verify that kebab-case flags are converted to camelCase query parameters and that the kebab-case version is not present in the query.

<img width="967" height="518" alt="example run" src="https://github.com/user-attachments/assets/97e79b1b-5895-4c05-905c-639c67acc549" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all `resources` commands serialize query parameters, which could alter request behavior if any endpoints previously relied on kebab-case names. Scope is small but affects every operation using query params.
> 
> **Overview**
> **Fixes query parameter naming for generated `resources` commands.** Query params are now sent as lower camelCase (e.g. `withBranches`) rather than the kebab-case flag name.
> 
> Adds a regression test (`TestKebabCaseQueryParamConversion`) that runs `code-refs list-repositories --with-branches true` against a mock client and asserts the outgoing query uses `withBranches` and does not include `with-branches`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d119923a3ab3d059ca2f2ed3de7ccbb1639bed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->