### PR TITLE
feat(proposal): ldcli explain — agent-discoverable command schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,19 @@
 
 This file provides guidance to AI coding agents when working with code in this repository.
 
+## For LLM agents driving `ldcli` (not editing this repo)
+
+Before constructing a payload for any write command with non-trivial options —
+in particular anything that takes `--data` with a semantic patch (e.g.
+`ldcli flags update`, `ldcli segments update`, `ldcli expiring-targets update`)
+— call `ldcli explain <command-path> --json` first. It returns the full
+input schema (including the instruction catalog for semantic patches), the
+output shape, the error catalog, and curated examples in a single response.
+Use `ldcli explain --list` to discover which commands are covered today; for
+anything not yet covered, fall back to `<command> --help`. `explain` makes no
+API calls and requires no access token. See `docs/agent-explain.md` for the
+design and roadmap.
+
 ## Project Overview
 
 LaunchDarkly CLI (`ldcli`) — a Go CLI for managing LaunchDarkly feature flags. Built with Cobra/Viper, distributed via Homebrew, Docker, NPM, and GitHub Releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@
 
 ## [Unreleased]
 
+### Features
+
+* add `ldcli explain <command>` subcommand (draft proposal) that emits a machine-readable schema (inputs, outputs, errors, examples) for any command in a single call, eliminating multi-turn `--help` recursion for LLM agents. Initial curated coverage for `flags update` and `flags list`; see `docs/agent-explain.md` for the design and path to full coverage.
+
 ### ⚠ BREAKING CHANGES
 
 * When stdout is not a TTY, the default `--output` format is now **json** instead of plaintext. Scripts that assumed plaintext when output was piped or redirected should set `LD_OUTPUT=plaintext`, run `ldcli config --set output plaintext`, or pass `--output plaintext` (or `--output json` explicitly if you want JSON regardless of TTY). You can also set **`FORCE_TTY`** or **`LD_FORCE_TTY`** to any non-empty value to keep plaintext as the default when stdout is not a TTY, without changing the saved `output` setting.

--- a/cmd/explain/explain.go
+++ b/cmd/explain/explain.go
@@ -1,0 +1,139 @@
+// Package explain implements the `ldcli explain` subcommand: a structured,
+// machine-readable view of any ldcli command's schema, designed for LLM
+// agents that would otherwise spend many turns chasing `--help` output.
+//
+// The command resolves a command path to an explainer via
+// internal/explain.Registry, then renders JSON (default for agents) or
+// markdown (default for humans on a TTY).
+package explain
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	resourcescmd "github.com/launchdarkly/ldcli/cmd/resources"
+	"github.com/launchdarkly/ldcli/internal/explain"
+)
+
+const (
+	formatJSON     = "json"
+	formatMarkdown = "markdown"
+)
+
+// NewExplainCmd builds the `explain` subcommand. The Registry is passed in so
+// tests can substitute a custom one; production callers should use
+// explain.DefaultRegistry().
+func NewExplainCmd(registry *explain.Registry) *cobra.Command {
+	var formatFlag string
+	var markdownFlag bool
+
+	cmd := &cobra.Command{
+		Use:   "explain <command> [subcommand...]",
+		Short: "Print a machine-readable schema for an ldcli command",
+		Long: `Print a structured description of an ldcli command — including its inputs,
+output shape, error catalog, and curated examples — so that LLM agents can
+construct payloads without recursing through "--help".
+
+The output is JSON by default (the canonical agent format). Use --markdown
+for a human-readable view.
+
+Examples:
+
+  # JSON schema for the highest-value write command
+  ldcli explain flags update
+
+  # Markdown view (good for humans)
+  ldcli explain flags list --markdown
+
+  # List which commands have a curated schema today
+  ldcli explain --list
+`,
+		// We don't talk to the API and we don't read config; bypass the root
+		// --access-token requirement.
+		DisableFlagParsing: false,
+		SilenceUsage:       true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if markdownFlag {
+				formatFlag = formatMarkdown
+			}
+
+			listOnly, _ := c.Flags().GetBool("list")
+			if listOnly {
+				return runList(c, registry)
+			}
+
+			if len(args) == 0 {
+				return errors.New("explain requires a command path, e.g. `ldcli explain flags update`")
+			}
+
+			path := normalizePath(args)
+			expl, err := registry.Resolve(path)
+			if err != nil {
+				if errors.Is(err, explain.ErrCommandNotFound) {
+					return fmt.Errorf(
+						"no explanation available for `%s`. Run `ldcli explain --list` to see covered commands; until full coverage lands, fall back to `ldcli %s --help`",
+						strings.Join(path, " "), strings.Join(path, " "),
+					)
+				}
+				return err
+			}
+
+			switch formatFlag {
+			case formatMarkdown:
+				fmt.Fprint(c.OutOrStdout(), explain.RenderMarkdown(expl))
+			case formatJSON, "":
+				out, err := explain.RenderJSON(expl)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(c.OutOrStdout(), out)
+			default:
+				return fmt.Errorf("unsupported --format: %q (expected `json` or `markdown`)", formatFlag)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&formatFlag, "format", formatJSON, "Output format: `json` (default) or `markdown`.")
+	cmd.Flags().BoolVar(&markdownFlag, "markdown", false, "Shortcut for --format markdown.")
+	cmd.Flags().Bool("list", false, "List commands that have curated explanations.")
+	cmd.SetUsageTemplate(resourcescmd.SubcommandUsageTemplate())
+
+	return cmd
+}
+
+func runList(c *cobra.Command, registry *explain.Registry) error {
+	paths := registry.CuratedPaths()
+	if len(paths) == 0 {
+		fmt.Fprintln(c.OutOrStdout(), "No curated explanations registered.")
+		return nil
+	}
+	fmt.Fprintln(c.OutOrStdout(), "Commands with curated explanations:")
+	for _, p := range paths {
+		fmt.Fprintf(c.OutOrStdout(), "  ldcli %s\n", p)
+	}
+	return nil
+}
+
+// normalizePath accepts argv-style input ("flags update") or a single
+// space-joined string ("flags update") and returns the canonical slice.
+func normalizePath(args []string) []string {
+	if len(args) == 1 && strings.Contains(args[0], " ") {
+		return strings.Fields(args[0])
+	}
+	out := make([]string, 0, len(args))
+	for _, a := range args {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if a == "ldcli" {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}

--- a/cmd/explain/explain_test.go
+++ b/cmd/explain/explain_test.go
@@ -1,0 +1,126 @@
+package explain_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	explaincmd "github.com/launchdarkly/ldcli/cmd/explain"
+	"github.com/launchdarkly/ldcli/internal/explain"
+)
+
+// runExplain wires up an explain command against the default registry, runs
+// it with the given args, and returns stdout. It intentionally constructs
+// the command in isolation (without the full root command) so we can test
+// the subcommand behavior independent of root flag plumbing.
+func runExplain(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := explaincmd.NewExplainCmd(explain.DefaultRegistry())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestExplain_JSONShape_FlagsUpdate(t *testing.T) {
+	out, err := runExplain(t, "flags", "update")
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed), "explain output must be valid JSON")
+
+	assert.Equal(t, "ldcli flags update", parsed["command"])
+	assert.Equal(t, "PATCH", parsed["httpMethod"])
+	assert.Equal(t, "patchFeatureFlag", parsed["operationId"])
+
+	inputs, ok := parsed["inputs"].([]any)
+	require.True(t, ok, "inputs must be present and a list")
+	assert.NotEmpty(t, inputs)
+
+	// The whole point of this command is that the semantic-patch instruction
+	// catalog is right there in the JSON. Sanity-check that the catalog made
+	// it into the payload.
+	body, _ := json.Marshal(parsed)
+	for _, kind := range []string{"addRule", "removeRule", "addTargets", "updateName"} {
+		assert.Contains(t, string(body), kind, "instruction kind %q should appear in the JSON", kind)
+	}
+
+	examples, ok := parsed["examples"].([]any)
+	require.True(t, ok)
+	assert.GreaterOrEqual(t, len(examples), 1, "must include at least one curated example")
+}
+
+func TestExplain_JSONShape_FlagsList(t *testing.T) {
+	out, err := runExplain(t, "flags", "list")
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed))
+
+	assert.Equal(t, "ldcli flags list", parsed["command"])
+	assert.Equal(t, "GET", parsed["httpMethod"])
+
+	output, ok := parsed["output"].(map[string]any)
+	require.True(t, ok)
+	pagination, ok := output["pagination"].(map[string]any)
+	require.True(t, ok, "flags list must document pagination semantics")
+	assert.Equal(t, "offset-limit", pagination["style"])
+}
+
+func TestExplain_Markdown(t *testing.T) {
+	out, err := runExplain(t, "flags", "update", "--markdown")
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(out, "# ldcli flags update"), "markdown should start with the command heading")
+	assert.Contains(t, out, "## Inputs")
+	assert.Contains(t, out, "## Examples")
+	assert.Contains(t, out, "addRule")
+}
+
+func TestExplain_UnknownCommand(t *testing.T) {
+	_, err := runExplain(t, "no-such-command")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no explanation available")
+	assert.Contains(t, err.Error(), "no-such-command")
+}
+
+func TestExplain_NoArgs(t *testing.T) {
+	_, err := runExplain(t)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "command path")
+}
+
+func TestExplain_UnsupportedFormat(t *testing.T) {
+	_, err := runExplain(t, "flags", "update", "--format", "yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported --format")
+}
+
+func TestExplain_List(t *testing.T) {
+	out, err := runExplain(t, "--list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "ldcli flags update")
+	assert.Contains(t, out, "ldcli flags list")
+}
+
+// TestExplain_AcceptsLDCliPrefix verifies that the user can paste the full
+// command path including "ldcli" without confusing the resolver.
+func TestExplain_AcceptsLDCliPrefix(t *testing.T) {
+	out, err := runExplain(t, "ldcli", "flags", "update")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"command": "ldcli flags update"`)
+}
+
+// TestExplain_AcceptsSpaceJoinedArg verifies that a single quoted argument
+// like `ldcli explain "flags update"` works the same as separate args.
+func TestExplain_AcceptsSpaceJoinedArg(t *testing.T) {
+	out, err := runExplain(t, "flags update")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"command": "ldcli flags update"`)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,11 +19,12 @@ import (
 	"github.com/launchdarkly/ldcli/cmd/cliflags"
 	configcmd "github.com/launchdarkly/ldcli/cmd/config"
 	devcmd "github.com/launchdarkly/ldcli/cmd/dev_server"
+	explaincmd "github.com/launchdarkly/ldcli/cmd/explain"
 	flagscmd "github.com/launchdarkly/ldcli/cmd/flags"
 	logincmd "github.com/launchdarkly/ldcli/cmd/login"
 	memberscmd "github.com/launchdarkly/ldcli/cmd/members"
-	sdkactivecmd "github.com/launchdarkly/ldcli/cmd/sdk_active"
 	resourcecmd "github.com/launchdarkly/ldcli/cmd/resources"
+	sdkactivecmd "github.com/launchdarkly/ldcli/cmd/sdk_active"
 	signupcmd "github.com/launchdarkly/ldcli/cmd/signup"
 	sourcemapscmd "github.com/launchdarkly/ldcli/cmd/sourcemaps"
 	"github.com/launchdarkly/ldcli/internal/analytics"
@@ -31,6 +32,7 @@ import (
 	"github.com/launchdarkly/ldcli/internal/dev_server"
 	"github.com/launchdarkly/ldcli/internal/environments"
 	errs "github.com/launchdarkly/ldcli/internal/errors"
+	"github.com/launchdarkly/ldcli/internal/explain"
 	"github.com/launchdarkly/ldcli/internal/flags"
 	"github.com/launchdarkly/ldcli/internal/members"
 	"github.com/launchdarkly/ldcli/internal/projects"
@@ -128,6 +130,7 @@ func NewRootCommand(
 			for _, name := range []string{
 				"completion",
 				"config",
+				"explain",
 				"help",
 				"login",
 				"signup",
@@ -256,6 +259,7 @@ func NewRootCommand(
 	cmd.AddCommand(signupcmd.NewSignupCmd(analyticsTrackerFn))
 	cmd.AddCommand(resourcecmd.NewResourcesCmd())
 	cmd.AddCommand(devcmd.NewDevServerCmd(clients.ResourcesClient, analyticsTrackerFn, clients.DevClient))
+	cmd.AddCommand(explaincmd.NewExplainCmd(explain.DefaultRegistry()))
 	cmd.AddCommand(sourcemapscmd.NewSourcemapsCmd(clients.ResourcesClient, analyticsTrackerFn))
 	resourcecmd.AddAllResourceCmds(cmd, clients.ResourcesClient, analyticsTrackerFn)
 

--- a/docs/agent-explain.md
+++ b/docs/agent-explain.md
@@ -1,0 +1,236 @@
+# `ldcli explain` — agent-discoverable command schema
+
+**Status:** Draft / proposal — see PR for discussion.
+**Owner:** _agent-bench experiment_
+**Audience:** LLM agents that drive `ldcli` via shell tool-use, and the humans who maintain `ldcli`.
+
+## Problem
+
+LLM agents using `ldcli` from a shell-tool harness spend an excessive number of
+turns on "what does this command want?" discovery. Concretely, from the
+`ld-agent-bench` v3.0 run against `claude-opus-4-7` (45 cells, 15 tasks ×
+3 providers):
+
+| Task | Description                                                           | `claude-cli-md` tool calls | `claude-mcp` tool calls |
+|------|-----------------------------------------------------------------------|---------------------------:|------------------------:|
+| T06  | Add a percentage-rollout targeting rule via semantic patch            |                     **18** |                       2 |
+| T08  | Add individual targets to a variation                                 |                     **12** |                       2 |
+| T15  | Update flag fallthrough variation                                     |                     **10** |                       2 |
+
+In every cell the cost pattern was the same: the model invoked
+`ldcli flags update --help`, scanned the (~10 KB) help text for the
+`--data` flag, guessed a JSON body, got a 400, re-read `--help`, guessed
+again. The MCP version finished the same task in two calls because the
+tool's input schema is typed.
+
+The CLI doesn't need MCP — it needs a way to surface the same typed schema
+*through* the CLI. That's the proposal here.
+
+## Proposal
+
+Add a top-level subcommand:
+
+```
+ldcli explain <command-path> [--json|--markdown] [--list]
+```
+
+`explain` takes a command path (positional args; `ldcli` prefix optional) and
+emits a structured description in one call. It never talks to the API.
+
+- `--json` (default): canonical machine-readable shape. Agents should always
+  use this.
+- `--markdown`: pretty-printed for humans on a TTY.
+- `--list`: list the commands that currently have a curated explanation.
+
+### JSON output shape
+
+The full Go types live in `internal/explain/types.go`. The on-the-wire JSON
+shape is, abbreviated:
+
+```jsonc
+{
+  "command":     "ldcli flags update",
+  "summary":     "...",
+  "description": "...",
+  "stability":   "stable",
+  "httpMethod":  "PATCH",
+  "path":        "/api/v2/flags/{projectKey}/{featureFlagKey}",
+  "operationId": "patchFeatureFlag",
+
+  "inputs": [
+    {
+      "name": "data", "location": "flag", "type": "object", "required": true,
+      "fields": [
+        {"name": "environmentKey", "type": "string"},
+        {"name": "instructions", "type": "array", "required": true,
+         "fields": [{
+            "name": "[]", "type": "object",
+            "fields": [{"name": "kind", "type": "string", "required": true, "enum": [...]}],
+            "oneOf": [
+              {"name": "addRule", "type": "object", "fields": [...]},
+              {"name": "removeRule", "type": "object", "fields": [...]},
+              {"name": "addTargets", "type": "object", "fields": [...]}
+              // ...
+            ]
+         }]}
+      ]
+    }
+  ],
+
+  "output": {
+    "format": "json",
+    "type": "object",
+    "fields": [{"name": "key"}, {"name": "_version"}, {"name": "environments"}, ...]
+  },
+
+  "errors": [
+    {"code": "approval_required", "httpStatus": 405,
+     "description": "...", "remediation": "..."}
+  ],
+
+  "examples": [
+    {
+      "title": "Add a percentage-rollout targeting rule",
+      "args":  ["flags","update","--project-key","default","--feature-flag-key","new-checkout","--semantic-patch","--data","@-"],
+      "body":  "{...}",
+      "result": "Returns the updated flag JSON..."
+    }
+  ],
+
+  "agentNotes": [
+    "Prefer --semantic-patch over raw JSON patch...",
+    "Use --dry-run first when constructing a non-trivial patch..."
+  ],
+  "seeAlso": ["ldcli flags get", "ldcli flags toggle-on"]
+}
+```
+
+A concrete sample is checked in at
+`internal/explain/testdata/flags_update.json` and refreshed by the snapshot
+test (run with `UPDATE_GOLDEN=1`).
+
+### Composition with existing agent-forward flags
+
+`explain` is purely informational; it makes zero API calls and respects no
+runtime state. It composes cleanly with the post-v3 agent-forward surface:
+
+- `--fields` — still applies on real write/read commands; `explain` documents
+  which output fields are available so the agent can pick.
+- `--dry-run` — `explain` lists `--dry-run` in `inputs[]` when supported, and
+  `agentNotes` recommends using it for non-trivial patches.
+- `--json` / `--output` — `explain` is a sibling, not a replacement; the
+  recommended workflow is `explain` → construct payload → `<command> --json
+  --dry-run` → `<command> --json`.
+
+## Implementation
+
+This PR ships the skeleton plus two real coverages.
+
+```
+cmd/explain/                  # top-level command
+  explain.go                  # Cobra wiring, JSON/markdown rendering
+  explain_test.go             # output-shape + error-path tests
+internal/explain/             # package
+  types.go                    # CommandExplanation, InputSpec, OutputSpec, ...
+  registry.go                 # Registry + DefaultRegistry
+  errors.go                   # ErrCommandNotFound
+  render.go                   # RenderJSON / RenderMarkdown
+  flags_update.go             # curated: ldcli flags update (semantic-patch)
+  flags_list.go               # curated: ldcli flags list (filter grammar)
+  testdata/flags_update.json  # golden snapshot
+  explain_test.go             # registry + snapshot tests
+```
+
+`cmd/root.go` adds `explain` to the list of commands that bypass the global
+`--access-token` requirement (it's read-only and offline) and wires
+`explain.DefaultRegistry()` into the root.
+
+## Path to full coverage
+
+This PR covers two commands end-to-end. To reach the rest of the surface
+without growing the codebase by 50 KB of hand-rolled metadata, we propose:
+
+### 1. Auto-generated resource commands (~140 commands)
+
+The generated `cmd/resources/resource_cmds.go` already encodes
+`OperationData` for every operation (HTTP method, path, params, request-body
+required-ness, semantic-patch support). The remaining schema lives in
+`ld-openapi.json`. Add an `OpenAPIExplainer` to the registry as a fallback:
+
+- Resolve the Cobra command to its `OperationData.OperationID`.
+- Pull the request schema (`#/components/schemas/...`) for `--data`,
+  flatten one level of `$ref`s so agents see real fields not pointers.
+- Pull the success response schema; carry forward `description` so agents
+  understand what fields they're projecting with `--fields`.
+- Pull the error responses; map each HTTP status to an `ErrorSpec`. The
+  LaunchDarkly API uses a consistent `{code, message}` error envelope that
+  we can hard-code as the default shape.
+
+This is the single biggest unlock and is mostly mechanical. Estimated effort:
+~1 week of work; most of it is teaching the loader to dereference `$ref`s
+without blowing up on cyclic schemas.
+
+### 2. Hand-rolled commands (~5 commands today)
+
+For commands like `flags toggle-on`, `flags archive`, `members invite`,
+`dev-server ...` — anything not derived from OpenAPI — expose an
+`Explain()` hook on the Cobra command:
+
+```go
+type Explainable interface {
+    Explain() explain.CommandExplanation
+}
+```
+
+The registry checks for this interface before falling back to OpenAPI or
+the flag tree.
+
+### 3. Flag-tree fallback (any Cobra command)
+
+For commands without curated or OpenAPI metadata, produce a best-effort
+explanation by walking the Cobra flag tree:
+
+- One `InputSpec` per `flag.Flag`, with `name`, `type` (from `Flag.Value.Type()`),
+  `description` (from `Flag.Usage`), `default` (from `Flag.DefValue`),
+  `required` (from the `required` annotation).
+- No example, no error catalog, but at least agents stop seeing a "command
+  not found" from `explain` for commands ldcli ships.
+
+### 4. Curated examples are always hand-written
+
+The OpenAPI spec doesn't carry compelling, agent-friendly examples. We
+recommend a `cmd/<name>/examples.go` convention: each package that wants
+to override or supplement the auto-generated explanation owns its examples,
+and they're registered via the `Explainable` interface above. The bar is
+1–3 examples per command, the most common ones the bench harness exercises.
+
+## Agent UX
+
+`AGENTS.md` is updated in this PR with one paragraph telling agents to call
+`ldcli explain <cmd>` before constructing complex payloads. We expect the
+bench harness ("claude-cli-explain" provider; see PR description) to
+demonstrate the win quantitatively before we commit to full coverage.
+
+## Open questions
+
+1. **Should `explain` be the default for `--help` on agent-context invocations?**
+   When `LD_AGENT_CONTEXT` is set (or the process detects it's not a TTY and
+   the analytics `agent` annotation is on), we could route `<cmd> --help` to
+   `explain <cmd>` automatically. This is a behavior change that needs Ramon's
+   eyes.
+2. **Schema versioning.** The JSON shape should be versioned (e.g.
+   `"_schemaVersion": "1"`) so agents can fail fast on a breaking change. Not
+   included in this draft pending discussion.
+3. **Coverage as CI gate.** Once OpenAPIExplainer lands, we can fail CI if a
+   new operation ships without at least a fallback. Worth doing.
+4. **Examples in OpenAPI.** Upstream-ing curated agent examples into the
+   OpenAPI spec itself (under `x-ldcli-examples`) would let us derive them
+   instead of hand-writing in Go. Wide-reaching change; not in scope here.
+
+## References
+
+- Bench harness: `ld-agent-bench` (T06 / T08 / T15 specifically)
+- Prior art: PR #660 — agent-forward CLI (Ramon)
+- LaunchDarkly REST API:
+  https://launchdarkly.com/docs/api/feature-flags/patch-feature-flag
+- CLI House Style guide §4 (examples), §16 (`--dry-run`), §19 (doctor/whoami)

--- a/internal/explain/errors.go
+++ b/internal/explain/errors.go
@@ -1,0 +1,8 @@
+package explain
+
+import "errors"
+
+// ErrCommandNotFound is returned by Registry.Resolve when no explainer can
+// produce a result for the given command path. Callers should map this to a
+// user-facing "no explanation available for this command" message.
+var ErrCommandNotFound = errors.New("command not found")

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -1,0 +1,64 @@
+package explain_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/launchdarkly/ldcli/internal/explain"
+)
+
+func TestDefaultRegistry_HasCuratedCoverage(t *testing.T) {
+	r := explain.DefaultRegistry()
+	assert.True(t, r.HasCurated([]string{"flags", "update"}))
+	assert.True(t, r.HasCurated([]string{"flags", "list"}))
+	assert.False(t, r.HasCurated([]string{"nope"}))
+}
+
+func TestRegistry_ResolveUnknownReturnsErrCommandNotFound(t *testing.T) {
+	r := explain.NewRegistry()
+	_, err := r.Resolve([]string{"some", "thing"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, explain.ErrCommandNotFound)
+}
+
+// TestFlagsUpdateSnapshot is a soft snapshot. It compares the JSON-rendered
+// explanation to a checked-in golden file. Run with `-update` to refresh.
+//
+// We deliberately keep the assertion soft (key-by-key) rather than a strict
+// byte-equality test: the structure must be stable for agents, but field
+// reordering of nested examples is not a regression.
+func TestFlagsUpdateSnapshot(t *testing.T) {
+	r := explain.DefaultRegistry()
+	exp, err := r.Resolve([]string{"flags", "update"})
+	require.NoError(t, err)
+
+	out, err := explain.RenderJSON(exp)
+	require.NoError(t, err)
+
+	goldenPath := filepath.Join("testdata", "flags_update.json")
+	if os.Getenv("UPDATE_GOLDEN") != "" {
+		require.NoError(t, os.MkdirAll(filepath.Dir(goldenPath), 0o755))
+		require.NoError(t, os.WriteFile(goldenPath, []byte(out), 0o644))
+		t.Logf("wrote golden file: %s", goldenPath)
+		return
+	}
+
+	goldenBytes, err := os.ReadFile(goldenPath)
+	if os.IsNotExist(err) {
+		t.Skipf("golden file %s not present; run with UPDATE_GOLDEN=1 to create", goldenPath)
+	}
+	require.NoError(t, err)
+
+	var got, want map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	require.NoError(t, json.Unmarshal(goldenBytes, &want))
+
+	for _, key := range []string{"command", "summary", "httpMethod", "path", "operationId"} {
+		assert.Equal(t, want[key], got[key], "top-level field %q drifted from golden", key)
+	}
+}

--- a/internal/explain/flags_list.go
+++ b/internal/explain/flags_list.go
@@ -1,0 +1,107 @@
+package explain
+
+// flagsListExplainer is the curated explainer for `ldcli flags list`. Read
+// commands are lower-risk than writes for agents, but list endpoints with
+// rich filter/sort grammars (this one in particular) still cause `--help`
+// recursion. Exposing the filter argument catalog up front saves several
+// turns.
+type flagsListExplainer struct{}
+
+func (flagsListExplainer) Explain(_ []string) (CommandExplanation, error) {
+	return CommandExplanation{
+		Command:     "ldcli flags list",
+		Summary:     "List feature flags in a project, optionally filtered and paginated.",
+		Description: "Returns the flags in a project. Heavy responses unless you scope with --env, --filter, or --limit. Use --fields to project only the columns you need.",
+		Stability:   "stable",
+		HTTPMethod:  "GET",
+		Path:        "/api/v2/flags/{projectKey}",
+		OperationID: "getFeatureFlags",
+		Inputs: []InputSpec{
+			{Name: "project-key", Location: "flag", Type: "string", Required: true, Description: "The project key."},
+			{Name: "env", Location: "flag", Type: "string", Description: "Filter configurations to a single environment. Strongly recommended for agents: cuts payload size by >80% on most accounts."},
+			{Name: "tag", Location: "flag", Type: "string", Description: "Filter feature flags by tag."},
+			{Name: "limit", Location: "flag", Type: "integer", Default: 20, Description: "Page size."},
+			{Name: "offset", Location: "flag", Type: "integer", Default: 0, Description: "Pagination offset; pair with limit."},
+			{Name: "summary", Location: "flag", Type: "boolean", Description: "Set to false (\"summary=0\") to include prerequisites, targets, and rules in the response."},
+			{
+				Name: "filter", Location: "flag", Type: "string",
+				Description: "Comma-separated list of filter expressions. Each is `field:value`. Supported fields: query, tags, archived, state (live|deprecated|archived), type (temporary|permanent), maintainerId, maintainerTeamKey, applicationEvaluated, contextKindsEvaluated, codeReferences.min, codeReferences.max, creationDate, evaluated, filterEnv, hasExperiment, sdkAvailability, releasePipeline, guardedRollout. Use `+` to AND tags, `,` to AND filters.",
+			},
+			{
+				Name: "sort", Location: "flag", Type: "string",
+				Description: "Sort field. Prefix with `-` for descending. Supported: name, key, creationDate, maintainerId, tags, targetingModifiedDate (requires --env), type.",
+			},
+			{Name: "compare", Location: "flag", Type: "boolean", Description: "Include before/after comparison metadata for environments that share the same `compareEnv`."},
+			{Name: "expand", Location: "flag", Type: "string", Description: "Comma-separated list of fields to expand. Supported: codeReferences, evaluation, migrationSettings."},
+		},
+		Output: OutputSpec{
+			Format:      "json",
+			Type:        "object",
+			Description: "Paginated list response.",
+			Fields: []InputSpec{
+				{Name: "items", Type: "array", Description: "The page of flags."},
+				{Name: "totalCount", Type: "integer", Description: "Total flags matching the query, across all pages."},
+				{Name: "_links", Type: "object", Description: "HATEOAS links: self, first, prev, next, last. Absent links indicate edge of range."},
+			},
+			Pagination: &PaginationSpec{
+				Style:       "offset-limit",
+				Description: "Pass --limit and --offset, or follow _links.next.href on each response until absent.",
+			},
+		},
+		Errors: []ErrorSpec{
+			{Code: "unauthorized", HTTPStatus: 401, Description: "Access token missing or invalid."},
+			{Code: "forbidden", HTTPStatus: 403, Description: "Token lacks `reader` access for this project."},
+			{Code: "not_found", HTTPStatus: 404, Description: "Project key not found."},
+			{Code: "rate_limited", HTTPStatus: 429, Description: "Slow down; respect `X-Ratelimit-Reset` header.", Remediation: "Reduce concurrent requests or narrow your query."},
+		},
+		Examples: []ExampleSpec{
+			{
+				Title:       "Find a flag by partial name match in production",
+				Description: "Scope to one environment, project only the keys you need.",
+				Args: []string{
+					"flags", "list",
+					"--project-key", "default",
+					"--env", "production",
+					"--filter", "query:checkout",
+					"--limit", "10",
+					"--fields", "key,name,_version",
+					"--json",
+				},
+				Result: "Returns up to 10 flags whose key or name contains \"checkout\", with only the requested fields per item.",
+			},
+			{
+				Title: "List archived flags maintained by a team, sorted by most-recently archived",
+				Args: []string{
+					"flags", "list",
+					"--project-key", "default",
+					"--filter", "state:archived,maintainerTeamKey:platform",
+					"--sort", "-creationDate",
+					"--limit", "50",
+					"--json",
+				},
+			},
+			{
+				Title:       "Page through all live flags",
+				Description: "Use --offset in a loop, or follow _links.next.href.",
+				Args: []string{
+					"flags", "list",
+					"--project-key", "default",
+					"--filter", "state:live",
+					"--limit", "100",
+					"--offset", "0",
+					"--json",
+				},
+				Result: "Increment --offset by 100 until items is shorter than 100 or _links.next is absent.",
+			},
+		},
+		AgentNotes: []string{
+			"Always pair --env with --fields when you only need a few columns; the un-scoped response can be megabytes.",
+			"Filter syntax is positional and case-sensitive. Quote the entire --filter value when piping through a shell.",
+			"This is a read-only command — safe to retry on any 5xx without --dry-run.",
+		},
+		SeeAlso: []string{
+			"ldcli flags get",
+			"ldcli flags update",
+		},
+	}, nil
+}

--- a/internal/explain/flags_update.go
+++ b/internal/explain/flags_update.go
@@ -1,0 +1,287 @@
+package explain
+
+// flagsUpdateExplainer is the curated explainer for `ldcli flags update`.
+//
+// This is the highest-value command for agents: the auto-generated CLI accepts
+// a free-form JSON body via --data, and the only way to discover the legal
+// shape of that body is to read the (very long) Long description, which is
+// itself embedded as a single line of escaped JSON in the generated
+// resource_cmds.go. Bench data (T06 on claude-cli-md) showed agents spending
+// 10–18 tool calls to converge on a valid payload.
+//
+// The shape below is hand-curated. Each `kind` of instruction matches the
+// LaunchDarkly REST API semantic-patch contract documented at
+// https://launchdarkly.com/docs/api/feature-flags/patch-feature-flag. When the
+// OpenAPIExplainer fallback lands (see docs/agent-explain.md, "Path to full
+// coverage"), this file should shrink to just the curated examples — the
+// instruction catalog can be auto-derived from the OpenAPI Long description.
+type flagsUpdateExplainer struct{}
+
+func (flagsUpdateExplainer) Explain(_ []string) (CommandExplanation, error) {
+	return CommandExplanation{
+		Command:     "ldcli flags update",
+		Summary:     "Update a feature flag using semantic patch, JSON patch, or JSON merge patch.",
+		Description: "Apply a partial update to a feature flag. Semantic patch is the recommended format for agents because it expresses intent (e.g. \"add a targeting rule\") rather than raw JSON pointers. Append `--semantic-patch` to switch the request Content-Type.",
+		Stability:   "stable",
+		HTTPMethod:  "PATCH",
+		Path:        "/api/v2/flags/{projectKey}/{featureFlagKey}",
+		OperationID: "patchFeatureFlag",
+		Inputs: []InputSpec{
+			{Name: "project-key", Location: "flag", Type: "string", Required: true, Description: "The project key."},
+			{Name: "feature-flag-key", Location: "flag", Type: "string", Required: true, Description: "The feature flag key."},
+			{Name: "semantic-patch", Location: "flag", Type: "boolean", Default: false, Description: "Send the body as a semantic patch (recommended for agents)."},
+			{Name: "ignore-conflicts", Location: "flag", Type: "boolean", Description: "Apply the patch even if it conflicts with a pending scheduled change or approval request."},
+			{Name: "dry-run", Location: "flag", Type: "boolean", Description: "Validate the patch without persisting. Returns a preview of the post-patch flag."},
+			{Name: "data", Location: "flag", Type: "object", Required: true, Description: "The patch body. Shape depends on --semantic-patch; see the `body` input below.", Fields: semanticPatchBodySpec()},
+		},
+		Output: OutputSpec{
+			Format:      "json",
+			Type:        "object",
+			Description: "The updated feature flag, including environment-specific targeting state.",
+			Fields: []InputSpec{
+				{Name: "key", Type: "string", Description: "Flag key."},
+				{Name: "name", Type: "string", Description: "Human-readable flag name."},
+				{Name: "kind", Type: "string", Enum: []string{"boolean", "multivariate"}},
+				{Name: "_version", Type: "integer", Description: "Monotonic version, useful for optimistic locking on subsequent patches."},
+				{Name: "environments", Type: "object", Description: "Map of environment key to env-specific configuration (on/off, rules, targets, fallthrough)."},
+				{Name: "variations", Type: "array", Description: "Variation definitions; each element has _id, value, name."},
+			},
+		},
+		Errors: []ErrorSpec{
+			{Code: "invalid_request", HTTPStatus: 400, Description: "The patch body did not match the expected schema, or conflicts with a pending change.", Remediation: "Re-read this explain output, in particular the instruction shape; if conflict, retry with --ignore-conflicts."},
+			{Code: "unauthorized", HTTPStatus: 401, Description: "Access token missing or invalid.", Remediation: "Confirm LD_ACCESS_TOKEN is set."},
+			{Code: "forbidden", HTTPStatus: 403, Description: "Token lacks required role for this flag/project."},
+			{Code: "not_found", HTTPStatus: 404, Description: "Project key or flag key not found."},
+			{Code: "approval_required", HTTPStatus: 405, Description: "The environment requires approval before changing this flag's targeting."},
+			{Code: "conflict", HTTPStatus: 409, Description: "The change would cause a pending scheduled change or approval request to fail.", Remediation: "Retry with --ignore-conflicts=true, or resolve the pending change first."},
+		},
+		Examples: []ExampleSpec{
+			{
+				Title:       "Add a percentage-rollout targeting rule",
+				Description: "Semantic patch with addRule + percentage rollout. Most common write the bench harness exercises.",
+				Args: []string{
+					"flags", "update",
+					"--project-key", "default",
+					"--feature-flag-key", "new-checkout",
+					"--semantic-patch",
+					"--data", "@-",
+				},
+				Body: `{
+  "environmentKey": "production",
+  "comment": "Roll out new checkout to 25% of users",
+  "instructions": [
+    {
+      "kind": "addRule",
+      "clauses": [
+        {"contextKind": "user", "attribute": "country", "op": "in", "negate": false, "values": ["US"]}
+      ],
+      "rolloutContextKind": "user",
+      "rolloutWeights": {
+        "2f43f67c-3e4e-4945-a18a-26559378ca00": 25000,
+        "e5830889-1ec5-4b0c-9cc9-c48790090c43": 75000
+      }
+    }
+  ]
+}`,
+				Result: "Returns the updated flag JSON with the new rule appended under environments.production.rules.",
+			},
+			{
+				Title:       "Add individual targets to a variation",
+				Description: "addTargets instruction; values is a list of context keys.",
+				Args: []string{
+					"flags", "update",
+					"--project-key", "default",
+					"--feature-flag-key", "new-checkout",
+					"--semantic-patch",
+					"--data", "@-",
+				},
+				Body: `{
+  "environmentKey": "production",
+  "instructions": [
+    {
+      "kind": "addTargets",
+      "contextKind": "user",
+      "variationId": "2f43f67c-3e4e-4945-a18a-26559378ca00",
+      "values": ["alice", "bob"]
+    }
+  ]
+}`,
+			},
+			{
+				Title:       "Remove a targeting rule by id",
+				Description: "removeRule instruction; rule id comes from `flags get` under environments.<env>.rules[]._id.",
+				Args: []string{
+					"flags", "update",
+					"--project-key", "default",
+					"--feature-flag-key", "new-checkout",
+					"--semantic-patch",
+					"--data", "@-",
+				},
+				Body: `{
+  "environmentKey": "production",
+  "instructions": [
+    {"kind": "removeRule", "ruleId": "a902ef4a-2faf-4eaf-88e1-ecc356708a29"}
+  ]
+}`,
+			},
+			{
+				Title:       "Rename the flag (cross-environment)",
+				Description: "updateName does not require environmentKey; it updates a flag-level attribute.",
+				Args: []string{
+					"flags", "update",
+					"--project-key", "default",
+					"--feature-flag-key", "new-checkout",
+					"--semantic-patch",
+					"--data", "@-",
+				},
+				Body: `{
+  "instructions": [
+    {"kind": "updateName", "value": "Checkout v2"}
+  ]
+}`,
+			},
+		},
+		AgentNotes: []string{
+			"Prefer --semantic-patch over raw JSON patch: it expresses intent and produces clearer diffs in audit log.",
+			"Use --dry-run first when constructing a non-trivial patch — it validates the body without mutating state.",
+			"Rule ids, clause ids, and variation ids are returned by `ldcli flags get`; copy them verbatim.",
+			"Instructions that mutate per-environment state (addRule, addTargets, etc.) require `environmentKey`. Flag-level instructions (updateName, addTags, archiveFlag) do not.",
+		},
+		SeeAlso: []string{
+			"ldcli flags get",
+			"ldcli flags toggle-on",
+			"ldcli flags toggle-off",
+		},
+	}, nil
+}
+
+// semanticPatchBodySpec returns the schema for the JSON body the agent must
+// pass via --data when --semantic-patch is set. The catalog of instruction
+// kinds is hand-curated for now; once the OpenAPIExplainer is in place this
+// should be auto-derived from the operation's request schema.
+func semanticPatchBodySpec() []InputSpec {
+	return []InputSpec{
+		{Name: "comment", Type: "string", Description: "Free-text comment recorded with the change."},
+		{Name: "environmentKey", Type: "string", Description: "Required for instructions that mutate environment-specific state (addRule, addTargets, turnFlagOn, etc.). Omit for flag-level instructions."},
+		{
+			Name: "instructions", Type: "array", Required: true,
+			Description: "Ordered list of mutation instructions; each element is an object with a `kind` field that determines the rest of the shape.",
+			Fields:      []InputSpec{instructionsItemSpec()},
+		},
+	}
+}
+
+func instructionsItemSpec() InputSpec {
+	return InputSpec{
+		Name: "[]", Type: "object",
+		Description: "One semantic-patch instruction. The `kind` field selects which other fields apply.",
+		Fields: []InputSpec{
+			{Name: "kind", Type: "string", Required: true, Enum: instructionKinds(), Description: "Selects the instruction shape. See OneOf for per-kind parameters."},
+		},
+		OneOf: instructionVariants(),
+	}
+}
+
+func instructionKinds() []string {
+	return []string{
+		"turnFlagOn", "turnFlagOff",
+		"addRule", "removeRule", "reorderRules",
+		"addClauses", "removeClauses", "addValuesToClause", "removeValuesFromClause", "updateClause",
+		"addTargets", "removeTargets", "clearTargets", "replaceTargets",
+		"addUserTargets", "removeUserTargets", "clearUserTargets", "replaceUserTargets",
+		"addPrerequisite", "removePrerequisite", "updatePrerequisite", "replacePrerequisites",
+		"addVariation", "removeVariation", "updateVariation",
+		"updateFallthroughVariationOrRollout", "updateOffVariation", "updateRuleVariationOrRollout",
+		"updateDefaultVariation", "updateRuleDescription", "updateRuleTrackEvents",
+		"updateTrackEvents", "updateTrackEventsFallthrough",
+		"addTags", "removeTags",
+		"addCustomProperties", "removeCustomProperties", "replaceCustomProperties",
+		"updateName", "updateDescription", "updateMaintainerMember", "updateMaintainerTeam", "removeMaintainer",
+		"makeFlagPermanent", "makeFlagTemporary",
+		"turnOnClientSideAvailability", "turnOffClientSideAvailability",
+		"archiveFlag", "restoreFlag", "deprecateFlag", "restoreDeprecatedFlag", "deleteFlag",
+		"replaceRules",
+	}
+}
+
+// instructionVariants enumerates the per-kind shapes. Only the high-frequency
+// shapes are expanded today; the rest are documented in AgentNotes as "see the
+// REST API docs". A full expansion is part of the path-to-full-coverage work.
+func instructionVariants() []InputSpec {
+	return []InputSpec{
+		{
+			Name: "addRule", Type: "object",
+			Description: "Append a new targeting rule. Requires environmentKey on the parent body.",
+			Fields: []InputSpec{
+				{Name: "kind", Type: "string", Required: true, Enum: []string{"addRule"}},
+				{Name: "clauses", Type: "array", Required: true, Description: "Array of clause objects (contextKind, attribute, op, negate, values)."},
+				{Name: "beforeRuleId", Type: "string", Description: "Optional: insert before this rule id rather than appending."},
+				{Name: "variationId", Type: "string", Description: "Serve this variation when the rule matches. Mutually exclusive with rolloutWeights."},
+				{Name: "rolloutWeights", Type: "object", Description: "Map of variationId -> weight (0-100000 thousandths of a percent). Mutually exclusive with variationId."},
+				{Name: "rolloutBucketBy", Type: "string", Description: "Context attribute to bucket by."},
+				{Name: "rolloutContextKind", Type: "string", Default: "user"},
+			},
+		},
+		{
+			Name: "removeRule", Type: "object",
+			Fields: []InputSpec{
+				{Name: "kind", Type: "string", Required: true, Enum: []string{"removeRule"}},
+				{Name: "ruleId", Type: "string", Required: true, Description: "Rule id, from `flags get` under environments.<env>.rules[]._id."},
+			},
+		},
+		{
+			Name: "addTargets", Type: "object",
+			Description: "Add individual context keys to a variation's targets.",
+			Fields: []InputSpec{
+				{Name: "kind", Type: "string", Required: true, Enum: []string{"addTargets"}},
+				{Name: "variationId", Type: "string", Required: true},
+				{Name: "values", Type: "array", Required: true, Description: "List of context keys (strings)."},
+				{Name: "contextKind", Type: "string", Default: "user"},
+			},
+		},
+		{
+			Name: "removeTargets", Type: "object",
+			Fields: []InputSpec{
+				{Name: "kind", Type: "string", Required: true, Enum: []string{"removeTargets"}},
+				{Name: "variationId", Type: "string", Required: true},
+				{Name: "values", Type: "array", Required: true},
+				{Name: "contextKind", Type: "string", Default: "user"},
+			},
+		},
+		{
+			Name: "turnFlagOn", Type: "object",
+			Fields: []InputSpec{
+				{Name: "kind", Type: "string", Required: true, Enum: []string{"turnFlagOn"}},
+			},
+		},
+		{
+			Name: "turnFlagOff", Type: "object",
+			Fields: []InputSpec{
+				{Name: "kind", Type: "string", Required: true, Enum: []string{"turnFlagOff"}},
+			},
+		},
+		{
+			Name: "updateName", Type: "object",
+			Description: "Flag-level rename; do NOT pass environmentKey.",
+			Fields: []InputSpec{
+				{Name: "kind", Type: "string", Required: true, Enum: []string{"updateName"}},
+				{Name: "value", Type: "string", Required: true},
+			},
+		},
+		{
+			Name: "addTags", Type: "object",
+			Description: "Flag-level; do NOT pass environmentKey.",
+			Fields: []InputSpec{
+				{Name: "kind", Type: "string", Required: true, Enum: []string{"addTags"}},
+				{Name: "values", Type: "array", Required: true, Description: "List of tag strings."},
+			},
+		},
+		{
+			Name: "archiveFlag", Type: "object",
+			Description: "Flag-level; equivalent to `ldcli flags archive`.",
+			Fields: []InputSpec{
+				{Name: "kind", Type: "string", Required: true, Enum: []string{"archiveFlag"}},
+			},
+		},
+	}
+}

--- a/internal/explain/registry.go
+++ b/internal/explain/registry.go
@@ -1,0 +1,110 @@
+package explain
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Registry resolves a command path to an Explainer. It's deliberately a simple
+// in-memory map keyed by the full slash-joined command path: agents reference
+// commands by argv (e.g. ["flags", "update"]) which we normalize to
+// "flags/update".
+//
+// The registry layering is:
+//
+//  1. Curated entries registered via Register() (highest fidelity).
+//  2. Fallback explainers tried in order (OpenAPI-driven, then flag-tree).
+//
+// The registry is safe for concurrent reads after initial setup. We don't
+// expect Register() to be called from concurrent goroutines.
+type Registry struct {
+	mu        sync.RWMutex
+	curated   map[string]Explainer
+	fallbacks []Explainer
+}
+
+// NewRegistry creates an empty registry. Most callers will want
+// DefaultRegistry, which pre-registers the bundled curated explainers.
+func NewRegistry() *Registry {
+	return &Registry{curated: make(map[string]Explainer)}
+}
+
+// Register associates an Explainer with a command path. The path is the
+// argv slice that would be passed to ldcli, e.g. ["flags", "update"]. Calling
+// Register twice for the same path replaces the prior entry.
+func (r *Registry) Register(commandPath []string, e Explainer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.curated[key(commandPath)] = e
+}
+
+// AddFallback appends a fallback explainer. Fallbacks are consulted only if no
+// curated explainer matches.
+func (r *Registry) AddFallback(e Explainer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.fallbacks = append(r.fallbacks, e)
+}
+
+// Resolve returns a CommandExplanation for the given command path. Returns
+// ErrCommandNotFound when no curated or fallback explainer can produce one.
+func (r *Registry) Resolve(commandPath []string) (CommandExplanation, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if e, ok := r.curated[key(commandPath)]; ok {
+		return e.Explain(commandPath)
+	}
+
+	for _, fb := range r.fallbacks {
+		exp, err := fb.Explain(commandPath)
+		if err == nil {
+			return exp, nil
+		}
+		// Fallbacks may legitimately not know a command; only bubble up
+		// non-not-found errors. We treat ErrCommandNotFound as "try next".
+		if err != ErrCommandNotFound {
+			return CommandExplanation{}, err
+		}
+	}
+
+	return CommandExplanation{}, fmt.Errorf("%w: %s", ErrCommandNotFound, strings.Join(commandPath, " "))
+}
+
+// HasCurated reports whether the given path has a curated (not fallback)
+// explainer. This is used by tests and by the AGENTS.md "coverage" status.
+func (r *Registry) HasCurated(commandPath []string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.curated[key(commandPath)]
+	return ok
+}
+
+// CuratedPaths returns the sorted list of command paths with curated
+// explainers. Useful for documentation / coverage reports.
+func (r *Registry) CuratedPaths() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, 0, len(r.curated))
+	for k := range r.curated {
+		out = append(out, strings.ReplaceAll(k, "/", " "))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func key(commandPath []string) string {
+	return strings.Join(commandPath, "/")
+}
+
+// DefaultRegistry returns a Registry pre-populated with the curated
+// explainers bundled with ldcli. Callers can still Register more entries on
+// top of this.
+func DefaultRegistry() *Registry {
+	r := NewRegistry()
+	r.Register([]string{"flags", "update"}, flagsUpdateExplainer{})
+	r.Register([]string{"flags", "list"}, flagsListExplainer{})
+	return r
+}

--- a/internal/explain/render.go
+++ b/internal/explain/render.go
@@ -1,0 +1,141 @@
+package explain
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// RenderJSON serializes the explanation as pretty-printed JSON. This is the
+// canonical machine-readable format and the one agents should consume.
+func RenderJSON(e CommandExplanation) (string, error) {
+	bs, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
+}
+
+// RenderMarkdown produces a compact markdown view of the explanation. It's
+// intended for human reviewers on the terminal; agents should prefer JSON.
+//
+// The output is deliberately terse: headers, bullet lists, no fancy tables.
+// This keeps it readable when piped through `less` or rendered inline by an
+// agent that strips markdown.
+func RenderMarkdown(e CommandExplanation) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "# %s\n\n", e.Command)
+	if e.Summary != "" {
+		fmt.Fprintf(&b, "%s\n\n", e.Summary)
+	}
+	if e.HTTPMethod != "" || e.Path != "" {
+		fmt.Fprintf(&b, "`%s %s`", e.HTTPMethod, e.Path)
+		if e.OperationID != "" {
+			fmt.Fprintf(&b, " (operationId: `%s`)", e.OperationID)
+		}
+		b.WriteString("\n\n")
+	}
+	if e.Description != "" {
+		fmt.Fprintf(&b, "%s\n\n", e.Description)
+	}
+
+	if len(e.Inputs) > 0 {
+		b.WriteString("## Inputs\n\n")
+		writeInputs(&b, e.Inputs, 0)
+		b.WriteString("\n")
+	}
+
+	b.WriteString("## Output\n\n")
+	fmt.Fprintf(&b, "- format: `%s`\n", e.Output.Format)
+	if e.Output.Type != "" {
+		fmt.Fprintf(&b, "- type: `%s`\n", e.Output.Type)
+	}
+	if e.Output.Description != "" {
+		fmt.Fprintf(&b, "- %s\n", e.Output.Description)
+	}
+	if e.Output.Pagination != nil {
+		fmt.Fprintf(&b, "- pagination: %s — %s\n", e.Output.Pagination.Style, e.Output.Pagination.Description)
+	}
+	if len(e.Output.Fields) > 0 {
+		b.WriteString("\nFields:\n")
+		writeInputs(&b, e.Output.Fields, 0)
+	}
+	b.WriteString("\n")
+
+	if len(e.Errors) > 0 {
+		b.WriteString("## Errors\n\n")
+		for _, er := range e.Errors {
+			fmt.Fprintf(&b, "- **%s** (HTTP %d): %s", er.Code, er.HTTPStatus, er.Description)
+			if er.Remediation != "" {
+				fmt.Fprintf(&b, " _Remediation: %s_", er.Remediation)
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	if len(e.Examples) > 0 {
+		b.WriteString("## Examples\n\n")
+		for i, ex := range e.Examples {
+			fmt.Fprintf(&b, "### %d. %s\n\n", i+1, ex.Title)
+			if ex.Description != "" {
+				fmt.Fprintf(&b, "%s\n\n", ex.Description)
+			}
+			fmt.Fprintf(&b, "```sh\nldcli %s\n```\n", strings.Join(ex.Args, " "))
+			if ex.Body != "" {
+				fmt.Fprintf(&b, "\nBody:\n\n```json\n%s\n```\n", strings.TrimSpace(ex.Body))
+			}
+			if ex.Result != "" {
+				fmt.Fprintf(&b, "\n_Result: %s_\n", ex.Result)
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	if len(e.AgentNotes) > 0 {
+		b.WriteString("## Agent notes\n\n")
+		for _, n := range e.AgentNotes {
+			fmt.Fprintf(&b, "- %s\n", n)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(e.SeeAlso) > 0 {
+		b.WriteString("## See also\n\n")
+		for _, s := range e.SeeAlso {
+			fmt.Fprintf(&b, "- `%s`\n", s)
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func writeInputs(b *strings.Builder, inputs []InputSpec, depth int) {
+	indent := strings.Repeat("  ", depth)
+	for _, in := range inputs {
+		req := ""
+		if in.Required {
+			req = " (required)"
+		}
+		fmt.Fprintf(b, "%s- `%s`: `%s`%s", indent, in.Name, in.Type, req)
+		if in.Description != "" {
+			fmt.Fprintf(b, " — %s", in.Description)
+		}
+		if in.Default != nil {
+			fmt.Fprintf(b, " _(default: %v)_", in.Default)
+		}
+		if len(in.Enum) > 0 {
+			fmt.Fprintf(b, " _(one of: %s)_", strings.Join(in.Enum, ", "))
+		}
+		b.WriteString("\n")
+		if len(in.Fields) > 0 {
+			writeInputs(b, in.Fields, depth+1)
+		}
+		if len(in.OneOf) > 0 {
+			fmt.Fprintf(b, "%s  oneOf:\n", indent)
+			writeInputs(b, in.OneOf, depth+2)
+		}
+	}
+}

--- a/internal/explain/testdata/flags_update.json
+++ b/internal/explain/testdata/flags_update.json
@@ -1,0 +1,548 @@
+{
+  "command": "ldcli flags update",
+  "summary": "Update a feature flag using semantic patch, JSON patch, or JSON merge patch.",
+  "description": "Apply a partial update to a feature flag. Semantic patch is the recommended format for agents because it expresses intent (e.g. \"add a targeting rule\") rather than raw JSON pointers. Append `--semantic-patch` to switch the request Content-Type.",
+  "stability": "stable",
+  "httpMethod": "PATCH",
+  "path": "/api/v2/flags/{projectKey}/{featureFlagKey}",
+  "operationId": "patchFeatureFlag",
+  "inputs": [
+    {
+      "name": "project-key",
+      "location": "flag",
+      "type": "string",
+      "description": "The project key.",
+      "required": true
+    },
+    {
+      "name": "feature-flag-key",
+      "location": "flag",
+      "type": "string",
+      "description": "The feature flag key.",
+      "required": true
+    },
+    {
+      "name": "semantic-patch",
+      "location": "flag",
+      "type": "boolean",
+      "description": "Send the body as a semantic patch (recommended for agents).",
+      "default": false
+    },
+    {
+      "name": "ignore-conflicts",
+      "location": "flag",
+      "type": "boolean",
+      "description": "Apply the patch even if it conflicts with a pending scheduled change or approval request."
+    },
+    {
+      "name": "dry-run",
+      "location": "flag",
+      "type": "boolean",
+      "description": "Validate the patch without persisting. Returns a preview of the post-patch flag."
+    },
+    {
+      "name": "data",
+      "location": "flag",
+      "type": "object",
+      "description": "The patch body. Shape depends on --semantic-patch; see the `body` input below.",
+      "required": true,
+      "fields": [
+        {
+          "name": "comment",
+          "location": "",
+          "type": "string",
+          "description": "Free-text comment recorded with the change."
+        },
+        {
+          "name": "environmentKey",
+          "location": "",
+          "type": "string",
+          "description": "Required for instructions that mutate environment-specific state (addRule, addTargets, turnFlagOn, etc.). Omit for flag-level instructions."
+        },
+        {
+          "name": "instructions",
+          "location": "",
+          "type": "array",
+          "description": "Ordered list of mutation instructions; each element is an object with a `kind` field that determines the rest of the shape.",
+          "required": true,
+          "fields": [
+            {
+              "name": "[]",
+              "location": "",
+              "type": "object",
+              "description": "One semantic-patch instruction. The `kind` field selects which other fields apply.",
+              "fields": [
+                {
+                  "name": "kind",
+                  "location": "",
+                  "type": "string",
+                  "description": "Selects the instruction shape. See OneOf for per-kind parameters.",
+                  "required": true,
+                  "enum": [
+                    "turnFlagOn",
+                    "turnFlagOff",
+                    "addRule",
+                    "removeRule",
+                    "reorderRules",
+                    "addClauses",
+                    "removeClauses",
+                    "addValuesToClause",
+                    "removeValuesFromClause",
+                    "updateClause",
+                    "addTargets",
+                    "removeTargets",
+                    "clearTargets",
+                    "replaceTargets",
+                    "addUserTargets",
+                    "removeUserTargets",
+                    "clearUserTargets",
+                    "replaceUserTargets",
+                    "addPrerequisite",
+                    "removePrerequisite",
+                    "updatePrerequisite",
+                    "replacePrerequisites",
+                    "addVariation",
+                    "removeVariation",
+                    "updateVariation",
+                    "updateFallthroughVariationOrRollout",
+                    "updateOffVariation",
+                    "updateRuleVariationOrRollout",
+                    "updateDefaultVariation",
+                    "updateRuleDescription",
+                    "updateRuleTrackEvents",
+                    "updateTrackEvents",
+                    "updateTrackEventsFallthrough",
+                    "addTags",
+                    "removeTags",
+                    "addCustomProperties",
+                    "removeCustomProperties",
+                    "replaceCustomProperties",
+                    "updateName",
+                    "updateDescription",
+                    "updateMaintainerMember",
+                    "updateMaintainerTeam",
+                    "removeMaintainer",
+                    "makeFlagPermanent",
+                    "makeFlagTemporary",
+                    "turnOnClientSideAvailability",
+                    "turnOffClientSideAvailability",
+                    "archiveFlag",
+                    "restoreFlag",
+                    "deprecateFlag",
+                    "restoreDeprecatedFlag",
+                    "deleteFlag",
+                    "replaceRules"
+                  ]
+                }
+              ],
+              "oneOf": [
+                {
+                  "name": "addRule",
+                  "location": "",
+                  "type": "object",
+                  "description": "Append a new targeting rule. Requires environmentKey on the parent body.",
+                  "fields": [
+                    {
+                      "name": "kind",
+                      "location": "",
+                      "type": "string",
+                      "required": true,
+                      "enum": [
+                        "addRule"
+                      ]
+                    },
+                    {
+                      "name": "clauses",
+                      "location": "",
+                      "type": "array",
+                      "description": "Array of clause objects (contextKind, attribute, op, negate, values).",
+                      "required": true
+                    },
+                    {
+                      "name": "beforeRuleId",
+                      "location": "",
+                      "type": "string",
+                      "description": "Optional: insert before this rule id rather than appending."
+                    },
+                    {
+                      "name": "variationId",
+                      "location": "",
+                      "type": "string",
+                      "description": "Serve this variation when the rule matches. Mutually exclusive with rolloutWeights."
+                    },
+                    {
+                      "name": "rolloutWeights",
+                      "location": "",
+                      "type": "object",
+                      "description": "Map of variationId -\u003e weight (0-100000 thousandths of a percent). Mutually exclusive with variationId."
+                    },
+                    {
+                      "name": "rolloutBucketBy",
+                      "location": "",
+                      "type": "string",
+                      "description": "Context attribute to bucket by."
+                    },
+                    {
+                      "name": "rolloutContextKind",
+                      "location": "",
+                      "type": "string",
+                      "default": "user"
+                    }
+                  ]
+                },
+                {
+                  "name": "removeRule",
+                  "location": "",
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "kind",
+                      "location": "",
+                      "type": "string",
+                      "required": true,
+                      "enum": [
+                        "removeRule"
+                      ]
+                    },
+                    {
+                      "name": "ruleId",
+                      "location": "",
+                      "type": "string",
+                      "description": "Rule id, from `flags get` under environments.\u003cenv\u003e.rules[]._id.",
+                      "required": true
+                    }
+                  ]
+                },
+                {
+                  "name": "addTargets",
+                  "location": "",
+                  "type": "object",
+                  "description": "Add individual context keys to a variation's targets.",
+                  "fields": [
+                    {
+                      "name": "kind",
+                      "location": "",
+                      "type": "string",
+                      "required": true,
+                      "enum": [
+                        "addTargets"
+                      ]
+                    },
+                    {
+                      "name": "variationId",
+                      "location": "",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "name": "values",
+                      "location": "",
+                      "type": "array",
+                      "description": "List of context keys (strings).",
+                      "required": true
+                    },
+                    {
+                      "name": "contextKind",
+                      "location": "",
+                      "type": "string",
+                      "default": "user"
+                    }
+                  ]
+                },
+                {
+                  "name": "removeTargets",
+                  "location": "",
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "kind",
+                      "location": "",
+                      "type": "string",
+                      "required": true,
+                      "enum": [
+                        "removeTargets"
+                      ]
+                    },
+                    {
+                      "name": "variationId",
+                      "location": "",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "name": "values",
+                      "location": "",
+                      "type": "array",
+                      "required": true
+                    },
+                    {
+                      "name": "contextKind",
+                      "location": "",
+                      "type": "string",
+                      "default": "user"
+                    }
+                  ]
+                },
+                {
+                  "name": "turnFlagOn",
+                  "location": "",
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "kind",
+                      "location": "",
+                      "type": "string",
+                      "required": true,
+                      "enum": [
+                        "turnFlagOn"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "turnFlagOff",
+                  "location": "",
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "kind",
+                      "location": "",
+                      "type": "string",
+                      "required": true,
+                      "enum": [
+                        "turnFlagOff"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "updateName",
+                  "location": "",
+                  "type": "object",
+                  "description": "Flag-level rename; do NOT pass environmentKey.",
+                  "fields": [
+                    {
+                      "name": "kind",
+                      "location": "",
+                      "type": "string",
+                      "required": true,
+                      "enum": [
+                        "updateName"
+                      ]
+                    },
+                    {
+                      "name": "value",
+                      "location": "",
+                      "type": "string",
+                      "required": true
+                    }
+                  ]
+                },
+                {
+                  "name": "addTags",
+                  "location": "",
+                  "type": "object",
+                  "description": "Flag-level; do NOT pass environmentKey.",
+                  "fields": [
+                    {
+                      "name": "kind",
+                      "location": "",
+                      "type": "string",
+                      "required": true,
+                      "enum": [
+                        "addTags"
+                      ]
+                    },
+                    {
+                      "name": "values",
+                      "location": "",
+                      "type": "array",
+                      "description": "List of tag strings.",
+                      "required": true
+                    }
+                  ]
+                },
+                {
+                  "name": "archiveFlag",
+                  "location": "",
+                  "type": "object",
+                  "description": "Flag-level; equivalent to `ldcli flags archive`.",
+                  "fields": [
+                    {
+                      "name": "kind",
+                      "location": "",
+                      "type": "string",
+                      "required": true,
+                      "enum": [
+                        "archiveFlag"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "output": {
+    "format": "json",
+    "type": "object",
+    "description": "The updated feature flag, including environment-specific targeting state.",
+    "fields": [
+      {
+        "name": "key",
+        "location": "",
+        "type": "string",
+        "description": "Flag key."
+      },
+      {
+        "name": "name",
+        "location": "",
+        "type": "string",
+        "description": "Human-readable flag name."
+      },
+      {
+        "name": "kind",
+        "location": "",
+        "type": "string",
+        "enum": [
+          "boolean",
+          "multivariate"
+        ]
+      },
+      {
+        "name": "_version",
+        "location": "",
+        "type": "integer",
+        "description": "Monotonic version, useful for optimistic locking on subsequent patches."
+      },
+      {
+        "name": "environments",
+        "location": "",
+        "type": "object",
+        "description": "Map of environment key to env-specific configuration (on/off, rules, targets, fallthrough)."
+      },
+      {
+        "name": "variations",
+        "location": "",
+        "type": "array",
+        "description": "Variation definitions; each element has _id, value, name."
+      }
+    ]
+  },
+  "errors": [
+    {
+      "code": "invalid_request",
+      "httpStatus": 400,
+      "description": "The patch body did not match the expected schema, or conflicts with a pending change.",
+      "remediation": "Re-read this explain output, in particular the instruction shape; if conflict, retry with --ignore-conflicts."
+    },
+    {
+      "code": "unauthorized",
+      "httpStatus": 401,
+      "description": "Access token missing or invalid.",
+      "remediation": "Confirm LD_ACCESS_TOKEN is set."
+    },
+    {
+      "code": "forbidden",
+      "httpStatus": 403,
+      "description": "Token lacks required role for this flag/project."
+    },
+    {
+      "code": "not_found",
+      "httpStatus": 404,
+      "description": "Project key or flag key not found."
+    },
+    {
+      "code": "approval_required",
+      "httpStatus": 405,
+      "description": "The environment requires approval before changing this flag's targeting."
+    },
+    {
+      "code": "conflict",
+      "httpStatus": 409,
+      "description": "The change would cause a pending scheduled change or approval request to fail.",
+      "remediation": "Retry with --ignore-conflicts=true, or resolve the pending change first."
+    }
+  ],
+  "examples": [
+    {
+      "title": "Add a percentage-rollout targeting rule",
+      "description": "Semantic patch with addRule + percentage rollout. Most common write the bench harness exercises.",
+      "args": [
+        "flags",
+        "update",
+        "--project-key",
+        "default",
+        "--feature-flag-key",
+        "new-checkout",
+        "--semantic-patch",
+        "--data",
+        "@-"
+      ],
+      "body": "{\n  \"environmentKey\": \"production\",\n  \"comment\": \"Roll out new checkout to 25% of users\",\n  \"instructions\": [\n    {\n      \"kind\": \"addRule\",\n      \"clauses\": [\n        {\"contextKind\": \"user\", \"attribute\": \"country\", \"op\": \"in\", \"negate\": false, \"values\": [\"US\"]}\n      ],\n      \"rolloutContextKind\": \"user\",\n      \"rolloutWeights\": {\n        \"2f43f67c-3e4e-4945-a18a-26559378ca00\": 25000,\n        \"e5830889-1ec5-4b0c-9cc9-c48790090c43\": 75000\n      }\n    }\n  ]\n}",
+      "result": "Returns the updated flag JSON with the new rule appended under environments.production.rules."
+    },
+    {
+      "title": "Add individual targets to a variation",
+      "description": "addTargets instruction; values is a list of context keys.",
+      "args": [
+        "flags",
+        "update",
+        "--project-key",
+        "default",
+        "--feature-flag-key",
+        "new-checkout",
+        "--semantic-patch",
+        "--data",
+        "@-"
+      ],
+      "body": "{\n  \"environmentKey\": \"production\",\n  \"instructions\": [\n    {\n      \"kind\": \"addTargets\",\n      \"contextKind\": \"user\",\n      \"variationId\": \"2f43f67c-3e4e-4945-a18a-26559378ca00\",\n      \"values\": [\"alice\", \"bob\"]\n    }\n  ]\n}"
+    },
+    {
+      "title": "Remove a targeting rule by id",
+      "description": "removeRule instruction; rule id comes from `flags get` under environments.\u003cenv\u003e.rules[]._id.",
+      "args": [
+        "flags",
+        "update",
+        "--project-key",
+        "default",
+        "--feature-flag-key",
+        "new-checkout",
+        "--semantic-patch",
+        "--data",
+        "@-"
+      ],
+      "body": "{\n  \"environmentKey\": \"production\",\n  \"instructions\": [\n    {\"kind\": \"removeRule\", \"ruleId\": \"a902ef4a-2faf-4eaf-88e1-ecc356708a29\"}\n  ]\n}"
+    },
+    {
+      "title": "Rename the flag (cross-environment)",
+      "description": "updateName does not require environmentKey; it updates a flag-level attribute.",
+      "args": [
+        "flags",
+        "update",
+        "--project-key",
+        "default",
+        "--feature-flag-key",
+        "new-checkout",
+        "--semantic-patch",
+        "--data",
+        "@-"
+      ],
+      "body": "{\n  \"instructions\": [\n    {\"kind\": \"updateName\", \"value\": \"Checkout v2\"}\n  ]\n}"
+    }
+  ],
+  "agentNotes": [
+    "Prefer --semantic-patch over raw JSON patch: it expresses intent and produces clearer diffs in audit log.",
+    "Use --dry-run first when constructing a non-trivial patch — it validates the body without mutating state.",
+    "Rule ids, clause ids, and variation ids are returned by `ldcli flags get`; copy them verbatim.",
+    "Instructions that mutate per-environment state (addRule, addTargets, etc.) require `environmentKey`. Flag-level instructions (updateName, addTags, archiveFlag) do not."
+  ],
+  "seeAlso": [
+    "ldcli flags get",
+    "ldcli flags toggle-on",
+    "ldcli flags toggle-off"
+  ]
+}

--- a/internal/explain/types.go
+++ b/internal/explain/types.go
@@ -1,0 +1,174 @@
+// Package explain provides structured, machine-readable schemas for ldcli
+// commands. It is consumed by the `ldcli explain` subcommand and is intended
+// for LLM agents that need to construct payloads for write commands without
+// chained `--help` invocations.
+//
+// The package defines two layers:
+//
+//   - A set of plain Go types (CommandExplanation, InputSpec, OutputSpec,
+//     ExampleSpec, ErrorSpec) that describe a command's schema in a way that
+//     serializes cleanly to JSON.
+//
+//   - An Explainer interface implemented by per-command "providers". A
+//     command resolves an Explainer in one of three ways, in order of
+//     preference:
+//
+//     1. Hand-rolled commands register a curated provider (the highest-fidelity
+//     and the source of truth for examples).
+//     2. Auto-generated resource commands fall back to an OpenAPIExplainer,
+//     which reads the operation schema directly from ld-openapi.json.
+//     3. Anything else falls back to a best-effort summary derived from the
+//     Cobra flag tree (FlagTreeExplainer).
+//
+// This first cut wires (1) for `flags update` and `flags list` and stubs (2)
+// and (3). See docs/agent-explain.md for the larger design.
+package explain
+
+// CommandExplanation is the top-level structured description of a single
+// ldcli command. It is intentionally flat and JSON-friendly so that agents can
+// pull what they need without traversing nested $ref chains.
+type CommandExplanation struct {
+	// Command is the full command path, e.g. "ldcli flags update".
+	Command string `json:"command"`
+
+	// Summary is a one-line description of what the command does.
+	Summary string `json:"summary"`
+
+	// Description is a longer-form description; may include markdown.
+	Description string `json:"description,omitempty"`
+
+	// Stability is one of "stable", "beta", "experimental". Defaults to
+	// "stable" when omitted.
+	Stability string `json:"stability,omitempty"`
+
+	// HTTPMethod and Path describe the underlying REST operation for commands
+	// that map 1:1 to the LaunchDarkly API. Omitted for purely local commands.
+	HTTPMethod string `json:"httpMethod,omitempty"`
+	Path       string `json:"path,omitempty"`
+
+	// OperationID is the OpenAPI operationId for auto-generated commands.
+	// Useful when an agent wants to cross-reference the LaunchDarkly REST API
+	// docs.
+	OperationID string `json:"operationId,omitempty"`
+
+	// Inputs is the list of flags, positional args, and request body fields
+	// that the command accepts.
+	Inputs []InputSpec `json:"inputs"`
+
+	// Output describes the success-case response shape.
+	Output OutputSpec `json:"output"`
+
+	// Errors enumerates the structured error shapes the command can return.
+	// This is a curated catalog, not an exhaustive list of every HTTP status.
+	Errors []ErrorSpec `json:"errors,omitempty"`
+
+	// Examples is a curated list of agent-friendly examples. Order is
+	// significant: the first example should be the most representative.
+	Examples []ExampleSpec `json:"examples,omitempty"`
+
+	// AgentNotes contains tips that are specifically useful for LLM agents
+	// (e.g. "always set --json", "this is idempotent"). Free-form prose.
+	AgentNotes []string `json:"agentNotes,omitempty"`
+
+	// SeeAlso lists related command paths the agent may want to call instead
+	// of or alongside this one.
+	SeeAlso []string `json:"seeAlso,omitempty"`
+}
+
+// InputSpec describes a single input to a command: a flag, a positional
+// argument, or a field of the request body.
+type InputSpec struct {
+	// Name is the user-visible name. For flags this is the long flag name
+	// (without the leading "--"). For body fields this is the JSON key, which
+	// may include a dotted path (e.g. "instructions[].kind").
+	Name string `json:"name"`
+
+	// Location tells the agent where this input lives in the invocation.
+	// One of: "flag", "arg", "body", "env".
+	Location string `json:"location"`
+
+	// Type is the JSON-schema-flavored type, e.g. "string", "integer",
+	// "boolean", "array", "object", "oneOf".
+	Type string `json:"type"`
+
+	// Description is human-readable help text.
+	Description string `json:"description,omitempty"`
+
+	// Required indicates whether this input must be provided.
+	Required bool `json:"required,omitempty"`
+
+	// Default is the default value, if any. Encoded as the value itself
+	// (string, number, bool); omit when there is no default.
+	Default interface{} `json:"default,omitempty"`
+
+	// Enum is the set of permitted values, if the type is constrained.
+	Enum []string `json:"enum,omitempty"`
+
+	// Fields is set when Type is "object" or "array" of objects: it lists the
+	// nested fields. This is how we expose semantic-patch instruction shapes.
+	Fields []InputSpec `json:"fields,omitempty"`
+
+	// OneOf is set when this input has multiple shapes (e.g. an `addRule`
+	// instruction takes either a `variationId` or a percentage rollout).
+	OneOf []InputSpec `json:"oneOf,omitempty"`
+}
+
+// OutputSpec describes the success-case output of a command.
+type OutputSpec struct {
+	// Format is the wire format ("json", "plaintext", "table", "markdown").
+	// For agents this should typically be "json".
+	Format string `json:"format"`
+
+	// Type is the top-level JSON type ("object", "array").
+	Type string `json:"type,omitempty"`
+
+	// Description is a human-readable description of the response.
+	Description string `json:"description,omitempty"`
+
+	// Fields enumerates the notable top-level fields of the response. This is
+	// curated: not every field is listed, just the ones agents typically need.
+	Fields []InputSpec `json:"fields,omitempty"`
+
+	// Pagination indicates how the agent should page through results, if any.
+	Pagination *PaginationSpec `json:"pagination,omitempty"`
+}
+
+// PaginationSpec describes pagination semantics for list endpoints.
+type PaginationSpec struct {
+	Style       string `json:"style"` // "offset-limit", "cursor", or "links"
+	Description string `json:"description,omitempty"`
+}
+
+// ExampleSpec is a curated example: an agent should be able to copy the args
+// and run it (after substituting placeholders).
+type ExampleSpec struct {
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+
+	// Args is the argv to pass to ldcli, e.g.
+	// ["flags", "update", "--project-key", "default", ...].
+	Args []string `json:"args"`
+
+	// Body is the JSON body to pass via --data, if any. Captured as a string
+	// (already JSON-encoded) so it round-trips faithfully.
+	Body string `json:"body,omitempty"`
+
+	// Result is a short description of what success looks like.
+	Result string `json:"result,omitempty"`
+}
+
+// ErrorSpec describes one error shape an agent should expect.
+type ErrorSpec struct {
+	Code        string `json:"code"`
+	HTTPStatus  int    `json:"httpStatus,omitempty"`
+	Description string `json:"description,omitempty"`
+	// Remediation is short, action-oriented guidance for the agent.
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// Explainer is implemented by anything that can produce a CommandExplanation
+// for a single ldcli command. The CommandPath is the full path including the
+// leading "ldcli" segment.
+type Explainer interface {
+	Explain(commandPath []string) (CommandExplanation, error)
+}


### PR DESCRIPTION
> Draft proposal  -  Not finished feature work — looking for design feedback from @ramonmsuarez and the CLI team before going further.

## Why
When running some benchmarking of MCP vs CLI - I surfaced a consistent cost pattern: CLI tasks that construct semantic-patch payloads burn many turns on `--help` recursion.

In every case the agent invoked `ldcli flags update --help`, scanned ~10 KB of help text for `--data`, guessed a JSON body, got a 400, re-read `--help`, guessed again. MCP wins because its tool schema is typed. The CLI doesn't need MCP — it needs a way to surface the same typed schema through the CLI.

## What this PR adds

A new top-level subcommand:

```
ldcli explain <command-path> [--json|--markdown] [--list]
```

`explain` resolves a Cobra command path, dispatches to an `Explainer`, and emits the structured schema (inputs, outputs, error catalog, curated examples, agent notes) in one call. It makes zero API calls and requires no access token.

This is a **draft / proposal-grade** PR:

- ✅ Working skeleton: `cmd/explain/` + `internal/explain/`
- ✅ Two real coverages:
  - **`ldcli explain flags update`** — full semantic-patch schema with the `instructions` array shape (`addRule`, `removeRule`, `addTargets`, `turnFlagOn`, `updateName`, …) plus 4 curated examples.
  - **`ldcli explain flags list`** — query parameter catalog, filter grammar, pagination semantics, 3 examples.
- ✅ Design doc: `docs/agent-explain.md` covering JSON shape, composition with existing `--fields` / `--dry-run` / `--json`, and the path to full coverage.
- ✅ AGENTS.md updated with a one-paragraph "call explain first" note.
- ✅ Unit tests + JSON golden snapshot for `flags update`.
- ✅ CHANGELOG entry under Unreleased.

What is **not** in this PR:
- OpenAPI-driven `OpenAPIExplainer` (designed in the doc; not coded).
- Flag-tree fallback for arbitrary commands.
- Coverage for the other ~140 generated commands.
- Schema versioning (e.g. `_schemaVersion: \"1\"`) — open question in the doc.

## Try it

```sh
make build
./ldcli explain flags update --markdown | less
./ldcli explain flags update --json | jq '.inputs[] | select(.name==\"data\")'
./ldcli explain --list
```

## Design (excerpt — full doc at `docs/agent-explain.md`)

### JSON output shape

\`\`\`jsonc
{
  \"command\":     \"ldcli flags update\",
  \"httpMethod\":  \"PATCH\",
  \"path\":        \"/api/v2/flags/{projectKey}/{featureFlagKey}\",
  \"operationId\": \"patchFeatureFlag\",
  \"inputs\": [
    {
      \"name\": \"data\", \"location\": \"flag\", \"type\": \"object\", \"required\": true,
      \"fields\": [
        {\"name\": \"environmentKey\", \"type\": \"string\"},
        {\"name\": \"instructions\", \"type\": \"array\", \"required\": true,
         \"fields\": [{
            \"name\": \"[]\", \"type\": \"object\",
            \"fields\": [{\"name\": \"kind\", \"type\": \"string\", \"required\": true, \"enum\": [...]}],
            \"oneOf\":  [{\"name\": \"addRule\", ...}, {\"name\": \"removeRule\", ...}, ...]
         }]}
      ]
    }
  ],
  \"output\":  { \"format\": \"json\", \"fields\": [...] },
  \"errors\":  [ { \"code\": \"approval_required\", \"httpStatus\": 405, \"remediation\": \"...\" } ],
  \"examples\": [
    { \"title\": \"Add a percentage-rollout targeting rule\", \"args\": [...], \"body\": \"{...}\" }
  ],
  \"agentNotes\": [\"Prefer --semantic-patch...\", \"Use --dry-run first...\"],
  \"seeAlso\":    [\"ldcli flags get\", \"ldcli flags toggle-on\"]
}
\`\`\`

A concrete sample is checked in at `internal/explain/testdata/flags_update.json`.

### Composition with existing agent-forward flags (#660, #677, #678)

`explain` is purely informational and composes with the post-v3 surface:

- `--fields` — `explain` documents which output fields exist; agent picks via `--fields`.
- `--dry-run` — `explain` lists it in `inputs[]` when supported; agent notes recommend using it.
- `--json` / `--output` — `explain` is a sibling, not a replacement. Recommended flow: `explain` → construct payload → `<command> --json --dry-run` → `<command> --json`.

### Path to full coverage

1. **OpenAPI fallback** (`OpenAPIExplainer`): walk `ld-openapi.json` by `operationId` (already on `OperationData`), pull request/response/error schemas. One-time effort, covers ~140 commands mechanically.
2. **Hand-rolled commands**: expose an `Explainable` interface on the Cobra command (`flags toggle-on`, `flags archive`, etc.).
3. **Flag-tree fallback**: walk `cmd.Flags()` for anything else — best-effort, no examples.
4. **Curated examples stay hand-written.** 1–3 per command, owned in the package.

### Open questions

1. Should `<cmd> --help` route to `explain <cmd>` when `LD_AGENT_CONTEXT` is set?
2. Schema versioning (`_schemaVersion`) — include now?
3. CI gate that fails when a new operation lacks any explainer?
4. Push curated examples upstream as `x-ldcli-examples` in the OpenAPI spec?

## Test plan

- [x] `make build` — clean
- [x] `make test` — all packages pass (`cmd/explain`, `internal/explain` plus existing suite)
- [x] `gofmt -l` — clean
- [x] Manual: `./ldcli explain flags update --markdown`, `--json`, `--list`, unknown command, no args, unsupported format
- [ ] Bench run on a build of this branch (separate from PR)

## Constraints honored

- Auto-generated `cmd/resources/resource_cmds.go` is **not** touched.
- `make generate` was **not** run.
- Branch: `agent-bench/explain-subcommand`.
- Draft via `gh pr create --draft`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new top-level command and new JSON/markdown output surface wired into `cmd/root.go`; while it makes no API calls, it introduces new public schema/formatting behavior that could impact downstream tooling expectations.
> 
> **Overview**
> Introduces a new `ldcli explain` top-level subcommand that emits a structured schema for a command (inputs, output shape, error catalog, curated examples) in **JSON (default)** or **markdown**, plus `--list` to show currently covered commands.
> 
> Adds a new `internal/explain` package with a registry, rendering helpers, and initial curated explainers for `flags update` (including semantic-patch instruction catalog + examples) and `flags list` (filter/sort/pagination docs + examples), backed by unit tests and a golden JSON snapshot.
> 
> Wires `explain` into the root command and updates docs (`AGENTS.md`, `docs/agent-explain.md`) and the Unreleased changelog entry to guide agents to call `ldcli explain` before constructing complex `--data` payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b051d71ddc96e38aa8ce5f4051f809d767b5487f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->