### PR TITLE
fix: grant pull-requests read permission to lint-pr-title workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -9,4 +9,7 @@ on:
 
 jobs:
   lint-pr-title:
+    permissions:
+      contents: read
+      pull-requests: read
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
## Summary
- The reusable workflow `launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main` requests `pull-requests: read`, but the caller job granted `pull-requests: none`, producing a **startup failure** on PRs (including the `release-please` PR, e.g. [run 29060791953](https://github.com/launchdarkly/ldcli/actions/runs/29060791953)).
- Grant the calling `lint-pr-title` job `contents: read` and `pull-requests: read` so the nested reusable workflow is allowed to run.

## Test plan
- [ ] `lint-pr-title` check runs successfully on this PR instead of hitting a startup failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission scope change with read-only access; no application or runtime behavior changes.
> 
> **Overview**
> Fixes **GitHub Actions startup failures** on PRs for the `lint-pr-title` check by declaring job-level permissions on the caller.
> 
> The `lint-pr-title` job now sets **`contents: read`** and **`pull-requests: read`** before invoking `launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main`. The reusable workflow expects `pull-requests: read`, but the caller previously left PR access at the default/none effective level, which blocked the nested workflow from running (including on release-please PRs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 211c6d0455963b917042c8912f6f519106527387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->