### PR TITLE
docs: add Cursor Cloud dev environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,17 @@ Installed via `make install-hooks`. Checks:
 
 - Go: `golangci-lint` (v1.63.4) via pre-commit
 - Frontend: ESLint + Prettier
+
+## Cursor Cloud specific instructions
+
+Services and how to run/verify them (standard commands live in the sections above; only non-obvious caveats are noted here):
+
+- **`ldcli` CLI** — `make build` produces `./ldcli`. Tests: `make test`. Lint: `golangci-lint run ./...` (see gotcha below). No credentials needed to build/test/lint.
+- **Dev server (Go HTTP + SQLite + embedded React UI)** — `./ldcli dev-server start` serves the API and the embedded UI at `http://localhost:8765/ui/`.
+  - `--access-token` is a required flag even to boot. The token is only used when syncing a project from LaunchDarkly, so any placeholder in the `api-<uuid>` token format (e.g. an all-zero UUID) is enough to start the server, serve the UI, and exercise the local HTTP API offline (e.g. `curl http://localhost:8765/dev/projects` → `[]`). Real flag data requires a real token.
+  - SQLite DBs live at `~/.local/state/ldcli/dev_server.db` (and `_events.db`).
+- **Dev server UI** — standard `npm` scripts in `internal/dev_server/ui` (`npm run lint` / `npm test` / `npm run build`). The production build (`dist/`) is checked into the repo and embedded into the Go binary.
+
+Gotchas:
+
+- **golangci-lint toolchain downgrade:** v1.63.4 refuses to run when the Go version it was *built with* is lower than the repo's `go.mod` target (currently 1.24.3), failing with `the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version`. Plain `go install .../golangci-lint@v1.63.4` (and the `make install-hooks` / pre-commit `golangci-lint` hook) auto-downgrade the toolchain to go1.22.2, so lint fails locally. Install it forcing the local toolchain: `GOTOOLCHAIN=$(go env GOVERSION) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4`. CI avoids this only because it runs on a newer Go (stable). Ensure `$(go env GOPATH)/bin` (`~/go/bin`) is on `PATH`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for `ldcli` in Cursor Cloud, and records durable, non-obvious setup notes for future agents under a new `## Cursor Cloud specific instructions` section in `AGENTS.md`.

No application/source code was modified — only documentation.

## What was verified

| Service | Lint | Test | Build | Run |
| --- | --- | --- | --- | --- |
| `ldcli` CLI (Go) | `golangci-lint run ./...` ✅ | `make test` ✅ | `make build` ✅ | `./ldcli config --set ...` / `dev-server start` ✅ |
| Dev server UI (React/Vite) | `npm run lint` ✅ | `npm test` (vitest) ✅ | `npm run build` ✅ | served via dev-server at `/ui/` ✅ |

Hello-world action: set + listed CLI config (persisted to `config.yml`), started the `dev-server` (Go HTTP + SQLite + embedded React UI), confirmed the API (`GET /dev/projects` → `[]`) and loaded the interactive `LaunchDevly` UI in a browser.

## Notes captured in AGENTS.md

- `golangci-lint` v1.63.4 auto-downgrades its build toolchain to go1.22.2 via `go install`, which then refuses to run against this repo's `go.mod` target (1.24.3). Install with `GOTOOLCHAIN=$(go env GOVERSION) go install ...`.
- `dev-server start` requires `--access-token` even to boot, but only contacts LaunchDarkly on project sync — a placeholder token is enough to run the server/UI/API offline.
- Local SQLite DB path and UI script locations.

## Update script (configured separately, not in repo)

```
go mod download
npm --prefix internal/dev_server/ui ci
GOTOOLCHAIN=$(go env GOVERSION) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
```

<a href="https://cursor.com/agents/bc-c112c4c9-370e-4222-bfe9-327404fb11bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdevserver_ui_demo.mp4"><img src="https://cursor.com/artifacts/c/art-e6741d81-e2cc-448d-a3c9-8e343cd453c9" alt="devserver_ui_demo.mp4" /></a>
![LaunchDevly UI loaded](https://cursor.com/artifacts/c/art-4f27eb06-6c5e-4328-8b90-bfc271ddc5f6)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c112c4c9-370e-4222-bfe9-327404fb11bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c112c4c9-370e-4222-bfe9-327404fb11bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

