### PR TITLE
feat(symbols): zero-config Android uploads, and gzip what an upload sends

### DIFF
--- a/cmd/symbols/android_discover.go
+++ b/cmd/symbols/android_discover.go
@@ -1,0 +1,194 @@
+package symbols
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Android build discovery.
+//
+// The Android Gradle Plugin already writes everything an upload needs, in
+// well-known places: R8's mapping at
+// <module>/build/outputs/mapping/<variant>/mapping.txt, and the version that
+// shipped in <module>/build/outputs/{apk,bundle}/**/output-metadata.json. Reading
+// both here means `ldcli symbols upload --type android` works from an Android
+// project root with no --path, no --app-version, and no build script staging
+// files for it.
+
+const (
+	// androidOutputMetadataName is the JSON manifest AGP writes beside each
+	// packaged APK/AAB, recording the variant and the versionName/versionCode it
+	// was built with.
+	androidOutputMetadataName = "output-metadata.json"
+
+	// androidMappingGlobs are the paths R8 writes a mapping to, relative to the
+	// directory being searched: a module's own build dir, then one and two levels
+	// of nesting so a project root or a grouped module (features/foo) both match.
+	// Deliberately a fixed set of shapes rather than a recursive walk, so an
+	// unrelated mapping.txt somewhere in the tree can't be mistaken for a build.
+	androidMappingGlob1 = "build/outputs/mapping/*/" + androidMappingFileName
+	androidMappingGlob2 = "*/build/outputs/mapping/*/" + androidMappingFileName
+	androidMappingGlob3 = "*/*/build/outputs/mapping/*/" + androidMappingFileName
+)
+
+// resolveAndroidBuild fills in from the build itself whatever the command line
+// left out: the mapping to upload, and the version to key it by. Both are
+// returned unchanged when path is not an AGP output tree, or when the caller
+// already said which mapping and version it means.
+func resolveAndroidBuild(path, appVersion string) (string, string, error) {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		// A path naming one file is already an answer; a path naming nothing is
+		// reported by the ordinary search, whose error says what was looked for.
+		return path, appVersion, nil
+	}
+
+	build, err := discoverAndroidBuild(path)
+	if err != nil || build == nil {
+		return path, appVersion, err
+	}
+
+	fmt.Printf("Found the %s mapping at %s\n", build.Variant, build.MappingPath)
+	if appVersion == "" {
+		if version := build.AppVersion(); version != "" {
+			appVersion = version
+			fmt.Printf("Using app version %s, as packaged for %s\n", version, build.Variant)
+		}
+	}
+	return build.MappingPath, appVersion, nil
+}
+
+// androidBuild is one obfuscated variant found in an AGP output tree.
+type androidBuild struct {
+	// MappingPath is the mapping.txt R8 produced for the variant.
+	MappingPath string
+	// Variant is the AGP variant name (composeRelease), which is both the
+	// directory the mapping sits in and how output-metadata.json identifies a build.
+	Variant string
+	// BuildDir is the module's build directory, the root of the outputs tree the
+	// mapping and the packaged app share.
+	BuildDir string
+}
+
+// discoverAndroidBuild finds the obfuscated build under root, so a mapping never
+// has to be pointed at or copied somewhere for upload.
+//
+// Returns nil when root is not an AGP output tree, which leaves the caller on its
+// ordinary search: this only adds a shortcut for the conventional layout, it does
+// not take away the ability to upload a mapping from anywhere. Several variants
+// is an error rather than a guess, since each is a different app build and only
+// one of them is the one being shipped.
+func discoverAndroidBuild(root string) (*androidBuild, error) {
+	builds, err := findAndroidBuilds(root)
+	if err != nil || len(builds) == 0 {
+		return nil, err
+	}
+	if len(builds) > 1 {
+		paths := make([]string, 0, len(builds))
+		for _, b := range builds {
+			paths = append(paths, fmt.Sprintf("  %s (%s)", b.MappingPath, b.Variant))
+		}
+		return nil, fmt.Errorf(
+			"found %d obfuscated Android variants under %s; pass --%s to pick the one you are shipping:\n%s",
+			len(builds), root, pathFlag, strings.Join(paths, "\n"),
+		)
+	}
+	return builds[0], nil
+}
+
+// findAndroidBuilds returns every variant with a non-empty mapping under root,
+// ordered by path so the ambiguity error reads the same on every run. An empty
+// mapping is skipped: AGP writes one for a variant R8 left unobfuscated, and it
+// would retrace nothing.
+func findAndroidBuilds(root string) ([]*androidBuild, error) {
+	var matches []string
+	for _, glob := range []string{androidMappingGlob1, androidMappingGlob2, androidMappingGlob3} {
+		found, err := filepath.Glob(filepath.Join(root, glob))
+		if err != nil {
+			// The globs are constants, so the only error the pattern can raise is
+			// impossible here; surfacing it keeps that assumption honest.
+			return nil, err
+		}
+		matches = append(matches, found...)
+	}
+	sort.Strings(matches)
+
+	builds := make([]*androidBuild, 0, len(matches))
+	for _, mappingPath := range matches {
+		info, err := os.Stat(mappingPath)
+		if err != nil || info.IsDir() || info.Size() == 0 {
+			continue
+		}
+		variantDir := filepath.Dir(mappingPath)
+		builds = append(builds, &androidBuild{
+			MappingPath: mappingPath,
+			Variant:     filepath.Base(variantDir),
+			// <build>/outputs/mapping/<variant>/mapping.txt, so the build dir is
+			// three levels up from the variant directory.
+			BuildDir: filepath.Dir(filepath.Dir(filepath.Dir(variantDir))),
+		})
+	}
+	return builds, nil
+}
+
+// AppVersion returns the versionName the variant was packaged with, or "" when
+// the app has not been packaged (mapping but no APK/AAB) or AGP recorded no
+// version. It is the same string the app reports at runtime, which is what makes
+// it usable as the Version Lane key.
+//
+// Note this is the app's version, and the SDK only reports it when the app passes
+// it as the observability service version; a build that leaves that at its default
+// reports the SDK's version instead, and needs a symbols id to be symbolicated.
+func (b *androidBuild) AppVersion() string {
+	for _, metadataPath := range b.outputMetadataPaths() {
+		content, err := os.ReadFile(metadataPath)
+		if err != nil {
+			continue
+		}
+		var metadata struct {
+			VariantName string `json:"variantName"`
+			Elements    []struct {
+				VersionName string `json:"versionName"`
+			} `json:"elements"`
+		}
+		if err := json.Unmarshal(content, &metadata); err != nil {
+			continue
+		}
+		// A module builds many variants into one outputs tree, so the metadata has
+		// to name this one: taking another variant's version would key the upload
+		// to a build these symbols do not describe.
+		if metadata.VariantName != b.Variant {
+			continue
+		}
+		for _, element := range metadata.Elements {
+			if element.VersionName != "" {
+				return element.VersionName
+			}
+		}
+	}
+	return ""
+}
+
+// outputMetadataPaths are where AGP writes packaging metadata, which is under the
+// APK's flavor/buildType directories rather than the variant directory the mapping
+// uses — hence the wildcards, with the variant identified by the file's contents.
+func (b *androidBuild) outputMetadataPaths() []string {
+	var paths []string
+	for _, glob := range []string{
+		filepath.Join("outputs", "apk", "*", "*", androidOutputMetadataName),
+		filepath.Join("outputs", "apk", "*", androidOutputMetadataName),
+		filepath.Join("outputs", "bundle", "*", androidOutputMetadataName),
+	} {
+		found, err := filepath.Glob(filepath.Join(b.BuildDir, glob))
+		if err != nil {
+			continue
+		}
+		paths = append(paths, found...)
+	}
+	sort.Strings(paths)
+	return paths
+}

--- a/cmd/symbols/android_discover.go
+++ b/cmd/symbols/android_discover.go
@@ -35,31 +35,44 @@ const (
 	androidMappingGlob3 = "*/*/build/outputs/mapping/*/" + androidMappingFileName
 )
 
+// androidUpload is what an Android upload has to know about a build: which
+// mapping to send, and how symbolication will look it up again.
+type androidUpload struct {
+	Path       string
+	AppVersion string
+	SymbolsID  string
+}
+
 // resolveAndroidBuild fills in from the build itself whatever the command line
-// left out: the mapping to upload, and the version to key it by. Both are
-// returned unchanged when path is not an AGP output tree, or when the caller
-// already said which mapping and version it means.
-func resolveAndroidBuild(path, appVersion string) (string, string, error) {
-	info, err := os.Stat(path)
+// left out. Everything is returned unchanged when the path is not an AGP output
+// tree, or when the caller already said what it means.
+func resolveAndroidBuild(upload androidUpload) (androidUpload, error) {
+	info, err := os.Stat(upload.Path)
 	if err != nil || !info.IsDir() {
 		// A path naming one file is already an answer; a path naming nothing is
 		// reported by the ordinary search, whose error says what was looked for.
-		return path, appVersion, nil
+		return upload, nil
 	}
 
-	build, err := discoverAndroidBuild(path)
+	build, err := discoverAndroidBuild(upload.Path)
 	if err != nil || build == nil {
-		return path, appVersion, err
+		return upload, err
 	}
+	upload.Path = build.MappingPath
 
 	fmt.Printf("Found the %s mapping at %s\n", build.Variant, build.MappingPath)
-	if appVersion == "" {
+	if upload.AppVersion == "" {
 		if version := build.AppVersion(); version != "" {
-			appVersion = version
+			upload.AppVersion = version
 			fmt.Printf("Using app version %s, as packaged for %s\n", version, build.Variant)
 		}
 	}
-	return build.MappingPath, appVersion, nil
+	if upload.SymbolsID == "" {
+		// Read from the app that ships rather than derived here, so the id keyed on
+		// is the id reported. See android_symbolsid.go.
+		upload.SymbolsID = build.SymbolsID()
+	}
+	return upload, nil
 }
 
 // androidBuild is one obfuscated variant found in an AGP output tree.
@@ -144,40 +157,28 @@ func findAndroidBuilds(root string) ([]*androidBuild, error) {
 // it as the observability service version; a build that leaves that at its default
 // reports the SDK's version instead, and needs a symbols id to be symbolicated.
 func (b *androidBuild) AppVersion() string {
-	for _, metadataPath := range b.outputMetadataPaths() {
-		content, err := os.ReadFile(metadataPath)
-		if err != nil {
-			continue
-		}
-		var metadata struct {
-			VariantName string `json:"variantName"`
-			Elements    []struct {
-				VersionName string `json:"versionName"`
-			} `json:"elements"`
-		}
-		if err := json.Unmarshal(content, &metadata); err != nil {
-			continue
-		}
-		// A module builds many variants into one outputs tree, so the metadata has
-		// to name this one: taking another variant's version would key the upload
-		// to a build these symbols do not describe.
-		if metadata.VariantName != b.Variant {
-			continue
-		}
-		for _, element := range metadata.Elements {
-			if element.VersionName != "" {
-				return element.VersionName
-			}
+	for _, app := range b.packagedApps() {
+		if app.VersionName != "" {
+			return app.VersionName
 		}
 	}
 	return ""
 }
 
-// outputMetadataPaths are where AGP writes packaging metadata, which is under the
-// APK's flavor/buildType directories rather than the variant directory the mapping
-// uses — hence the wildcards, with the variant identified by the file's contents.
-func (b *androidBuild) outputMetadataPaths() []string {
-	var paths []string
+// androidPackagedApp is an APK or AAB AGP built for the variant, named by the
+// output metadata written beside it.
+type androidPackagedApp struct {
+	Path        string
+	VersionName string
+}
+
+// packagedApps reads AGP's packaging metadata for this variant. The metadata is
+// written under the APK's flavor/buildType directories rather than the variant
+// directory the mapping uses — hence the wildcards, with the variant identified
+// by each file's contents. A module builds every variant into one outputs tree,
+// so reading another's would describe a different app.
+func (b *androidBuild) packagedApps() []androidPackagedApp {
+	var metadataPaths []string
 	for _, glob := range []string{
 		filepath.Join("outputs", "apk", "*", "*", androidOutputMetadataName),
 		filepath.Join("outputs", "apk", "*", androidOutputMetadataName),
@@ -187,8 +188,34 @@ func (b *androidBuild) outputMetadataPaths() []string {
 		if err != nil {
 			continue
 		}
-		paths = append(paths, found...)
+		metadataPaths = append(metadataPaths, found...)
 	}
-	sort.Strings(paths)
-	return paths
+	sort.Strings(metadataPaths)
+
+	var apps []androidPackagedApp
+	for _, metadataPath := range metadataPaths {
+		content, err := os.ReadFile(metadataPath)
+		if err != nil {
+			continue
+		}
+		var metadata struct {
+			VariantName string `json:"variantName"`
+			Elements    []struct {
+				VersionName string `json:"versionName"`
+				OutputFile  string `json:"outputFile"`
+			} `json:"elements"`
+		}
+		if err := json.Unmarshal(content, &metadata); err != nil || metadata.VariantName != b.Variant {
+			continue
+		}
+		for _, element := range metadata.Elements {
+			app := androidPackagedApp{VersionName: element.VersionName}
+			if element.OutputFile != "" {
+				// outputFile is recorded relative to the metadata, as a bare name.
+				app.Path = filepath.Join(filepath.Dir(metadataPath), filepath.Base(element.OutputFile))
+			}
+			apps = append(apps, app)
+		}
+	}
+	return apps
 }

--- a/cmd/symbols/android_discover_test.go
+++ b/cmd/symbols/android_discover_test.go
@@ -1,0 +1,208 @@
+package symbols
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeAndroidMapping lays out the AGP output an obfuscated build leaves behind:
+// module/build/outputs/mapping/<variant>/mapping.txt.
+func writeAndroidMapping(t *testing.T, root, module, variant, content string) string {
+	t.Helper()
+	dir := filepath.Join(root, module, "build", "outputs", "mapping", variant)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, androidMappingFileName)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+// writeAndroidOutputMetadata lays out what AGP records when it packages the app,
+// under the flavor/buildType directories the APK is written to.
+func writeAndroidOutputMetadata(t *testing.T, root, module, variant, versionName string, apkDirs ...string) {
+	t.Helper()
+	dir := filepath.Join(append([]string{root, module, "build", "outputs", "apk"}, apkDirs...)...)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	metadata := `{
+	  "version": 3,
+	  "artifactType": {"type": "APK", "kind": "Directory"},
+	  "applicationId": "com.example.app",
+	  "variantName": "` + variant + `",
+	  "elements": [{"type": "SINGLE", "versionCode": 7, "versionName": "` + versionName + `", "outputFile": "app.apk"}]
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, androidOutputMetadataName), []byte(metadata), 0o644))
+}
+
+func TestDiscoverAndroidBuildFromProjectRoot(t *testing.T) {
+	root := t.TempDir()
+	mapping := writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+
+	build, err := discoverAndroidBuild(root)
+	require.NoError(t, err)
+	require.NotNil(t, build)
+	assert.Equal(t, mapping, build.MappingPath)
+	assert.Equal(t, "composeRelease", build.Variant)
+	assert.Equal(t, filepath.Join(root, "app", "build"), build.BuildDir)
+}
+
+// Someone in the module directory rather than the project root is pointing at the
+// same build, and gets the same answer.
+func TestDiscoverAndroidBuildFromModuleDirectory(t *testing.T) {
+	root := t.TempDir()
+	mapping := writeAndroidMapping(t, root, "app", "release", "com.example.App -> a.a:\n")
+
+	build, err := discoverAndroidBuild(filepath.Join(root, "app"))
+	require.NoError(t, err)
+	require.NotNil(t, build)
+	assert.Equal(t, mapping, build.MappingPath)
+	assert.Equal(t, "release", build.Variant)
+}
+
+func TestDiscoverAndroidBuildFromNestedModule(t *testing.T) {
+	root := t.TempDir()
+	mapping := writeAndroidMapping(t, root, filepath.Join("features", "checkout"), "release", "com.example.App -> a.a:\n")
+
+	build, err := discoverAndroidBuild(root)
+	require.NoError(t, err)
+	require.NotNil(t, build)
+	assert.Equal(t, mapping, build.MappingPath)
+}
+
+// Each variant is a different app, and uploading the wrong one symbolicates every
+// frame into the wrong place, so this asks rather than picks.
+func TestDiscoverAndroidBuildRefusesToGuessBetweenVariants(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+	writeAndroidMapping(t, root, "app", "javaRelease", "com.example.App -> a.a:\n")
+
+	_, err := discoverAndroidBuild(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "composeRelease")
+	assert.Contains(t, err.Error(), "javaRelease")
+	assert.Contains(t, err.Error(), "--"+pathFlag)
+}
+
+// R8 writes an empty mapping for a variant it did not obfuscate. There is nothing
+// to retrace with, so it is not a build worth finding — and finding it would make
+// a real variant beside it look ambiguous.
+func TestDiscoverAndroidBuildIgnoresEmptyMapping(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "debug", "")
+	mapping := writeAndroidMapping(t, root, "app", "release", "com.example.App -> a.a:\n")
+
+	build, err := discoverAndroidBuild(root)
+	require.NoError(t, err)
+	require.NotNil(t, build)
+	assert.Equal(t, mapping, build.MappingPath)
+}
+
+// A mapping.txt that is not in an AGP output tree — one staged by a build script,
+// say — is left to the ordinary search rather than claimed here.
+func TestDiscoverAndroidBuildIgnoresUnconventionalLayout(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "app", "build", "symbols", "composeRelease")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, androidMappingFileName), []byte("x -> a:\n"), 0o644))
+
+	build, err := discoverAndroidBuild(root)
+	require.NoError(t, err)
+	assert.Nil(t, build)
+}
+
+func TestAndroidBuildAppVersion(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+	writeAndroidOutputMetadata(t, root, "app", "composeRelease", "1.0.1", "compose", "release")
+
+	build, err := discoverAndroidBuild(root)
+	require.NoError(t, err)
+	require.NotNil(t, build)
+	assert.Equal(t, "1.0.1", build.AppVersion())
+}
+
+// Without product flavors the APK lands one directory shallower.
+func TestAndroidBuildAppVersionWithoutFlavors(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "release", "com.example.App -> a.a:\n")
+	writeAndroidOutputMetadata(t, root, "app", "release", "2.3.4", "release")
+
+	build, err := discoverAndroidBuild(root)
+	require.NoError(t, err)
+	require.NotNil(t, build)
+	assert.Equal(t, "2.3.4", build.AppVersion())
+}
+
+// One outputs tree holds every variant the module has ever packaged. Taking a
+// version from the wrong one would key these symbols to a build they do not describe.
+func TestAndroidBuildAppVersionIgnoresOtherVariants(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+	writeAndroidOutputMetadata(t, root, "app", "javaRelease", "9.9.9", "java", "release")
+
+	build, err := discoverAndroidBuild(root)
+	require.NoError(t, err)
+	require.NotNil(t, build)
+	assert.Empty(t, build.AppVersion())
+}
+
+// A mapping with no packaged app beside it still uploads; it just has no version
+// to be keyed by.
+func TestAndroidBuildAppVersionMissing(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+
+	build, err := discoverAndroidBuild(root)
+	require.NoError(t, err)
+	require.NotNil(t, build)
+	assert.Empty(t, build.AppVersion())
+}
+
+func TestResolveAndroidBuildFillsInPathAndVersion(t *testing.T) {
+	root := t.TempDir()
+	mapping := writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+	writeAndroidOutputMetadata(t, root, "app", "composeRelease", "1.0.1", "compose", "release")
+
+	path, version, err := resolveAndroidBuild(root, "")
+	require.NoError(t, err)
+	assert.Equal(t, mapping, path)
+	assert.Equal(t, "1.0.1", version)
+}
+
+// What the caller asked for wins: an explicit version is the one the app reports,
+// whatever the build was packaged as.
+func TestResolveAndroidBuildKeepsExplicitVersion(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+	writeAndroidOutputMetadata(t, root, "app", "composeRelease", "1.0.1", "compose", "release")
+
+	_, version, err := resolveAndroidBuild(root, "2.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", version)
+}
+
+// An explicit --path names the mapping, so there is nothing to discover.
+func TestResolveAndroidBuildLeavesExplicitFileAlone(t *testing.T) {
+	root := t.TempDir()
+	mapping := writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+
+	path, version, err := resolveAndroidBuild(mapping, "")
+	require.NoError(t, err)
+	assert.Equal(t, mapping, path)
+	assert.Empty(t, version)
+}
+
+// The mapping is stored as mapping.txt however deep it was found, because that is
+// where symbolication reads it.
+func TestGetAllSymbolFilesAndroidFlattensName(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+
+	files, err := getAllSymbolFiles(root, typeAndroid)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, androidMappingFileName, files[0].Name)
+	assert.Equal(t, "1.2.3/mapping.txt", getS3Key(androidSymbolsIDPrefix, "", "1.2.3", "", files[0].Name))
+}

--- a/cmd/symbols/android_discover_test.go
+++ b/cmd/symbols/android_discover_test.go
@@ -165,10 +165,10 @@ func TestResolveAndroidBuildFillsInPathAndVersion(t *testing.T) {
 	mapping := writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
 	writeAndroidOutputMetadata(t, root, "app", "composeRelease", "1.0.1", "compose", "release")
 
-	path, version, err := resolveAndroidBuild(root, "")
+	resolved, err := resolveAndroidBuild(androidUpload{Path: root})
 	require.NoError(t, err)
-	assert.Equal(t, mapping, path)
-	assert.Equal(t, "1.0.1", version)
+	assert.Equal(t, mapping, resolved.Path)
+	assert.Equal(t, "1.0.1", resolved.AppVersion)
 }
 
 // What the caller asked for wins: an explicit version is the one the app reports,
@@ -178,9 +178,9 @@ func TestResolveAndroidBuildKeepsExplicitVersion(t *testing.T) {
 	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
 	writeAndroidOutputMetadata(t, root, "app", "composeRelease", "1.0.1", "compose", "release")
 
-	_, version, err := resolveAndroidBuild(root, "2.0.0")
+	resolved, err := resolveAndroidBuild(androidUpload{Path: root, AppVersion: "2.0.0"})
 	require.NoError(t, err)
-	assert.Equal(t, "2.0.0", version)
+	assert.Equal(t, "2.0.0", resolved.AppVersion)
 }
 
 // An explicit --path names the mapping, so there is nothing to discover.
@@ -188,10 +188,10 @@ func TestResolveAndroidBuildLeavesExplicitFileAlone(t *testing.T) {
 	root := t.TempDir()
 	mapping := writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
 
-	path, version, err := resolveAndroidBuild(mapping, "")
+	resolved, err := resolveAndroidBuild(androidUpload{Path: mapping})
 	require.NoError(t, err)
-	assert.Equal(t, mapping, path)
-	assert.Empty(t, version)
+	assert.Equal(t, mapping, resolved.Path)
+	assert.Empty(t, resolved.AppVersion)
 }
 
 // The mapping is stored as mapping.txt however deep it was found, because that is

--- a/cmd/symbols/android_symbolsid.go
+++ b/cmd/symbols/android_symbolsid.go
@@ -1,0 +1,87 @@
+package symbols
+
+import (
+	"archive/zip"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// The symbols id an Android build reports.
+//
+// A release build stamps a content-derived id of its mapping into
+// assets/ld_symbols_id.txt, and the SDK reports it as
+// `launchdarkly.symbols_id.htlhash` so symbolication can find the mapping by
+// content instead of by app version. Uploading on that lane means keying the
+// object by the same id.
+//
+// The id is read out of the packaged app rather than from a file the build staged
+// beside the mapping, because the packaged app is the thing that will run: what it
+// carries is exactly what will be reported. That leaves nothing for a build script
+// to hand over, and no way for the two to disagree.
+
+const (
+	// androidSymbolsIDAsset is the asset the build writes the id to, packaged at
+	// assets/ in an APK and base/assets/ in an app bundle.
+	androidSymbolsIDAsset = "ld_symbols_id.txt"
+
+	apkSymbolsIDEntry = "assets/" + androidSymbolsIDAsset
+	aabSymbolsIDEntry = "base/assets/" + androidSymbolsIDAsset
+
+	// symbolsIDAssetMaxBytes caps how much of the asset is read. The id is 32
+	// bytes; anything remotely larger is not one, and is not worth reading.
+	symbolsIDAssetMaxBytes = 128
+)
+
+// symbolsIDPattern is the shape of a symbols id: the first 16 bytes of a SHA-256
+// as lowercase hex. It matches the check the SDK applies before reporting one, so
+// an id the app would discard is not uploaded to a lane nothing will ask for.
+var symbolsIDPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
+
+// SymbolsID returns the symbols id the variant's packaged app will report, or ""
+// when the build does not stamp one — in which case the mapping belongs on the
+// Version Lane, as before.
+func (b *androidBuild) SymbolsID() string {
+	for _, app := range b.packagedApps() {
+		if app.Path == "" {
+			continue
+		}
+		if id := symbolsIDFromPackagedApp(app.Path); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+// symbolsIDFromPackagedApp reads the stamped id out of an APK or AAB, both of
+// which are zips. Best-effort: an app that stamps no id, or a file that cannot be
+// read as one, yields "" so the upload falls back to the Version Lane rather than
+// failing a build over it.
+func symbolsIDFromPackagedApp(path string) string {
+	archive, err := zip.OpenReader(path)
+	if err != nil {
+		return ""
+	}
+	defer archive.Close()
+
+	for _, file := range archive.File {
+		if file.Name != apkSymbolsIDEntry && file.Name != aabSymbolsIDEntry {
+			continue
+		}
+		reader, err := file.Open()
+		if err != nil {
+			return ""
+		}
+		content, err := io.ReadAll(io.LimitReader(reader, symbolsIDAssetMaxBytes))
+		_ = reader.Close()
+		if err != nil {
+			return ""
+		}
+		id := strings.TrimSpace(string(content))
+		if symbolsIDPattern.MatchString(id) {
+			return id
+		}
+		return ""
+	}
+	return ""
+}

--- a/cmd/symbols/android_symbolsid_test.go
+++ b/cmd/symbols/android_symbolsid_test.go
@@ -1,0 +1,161 @@
+package symbols
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeZip builds an APK/AAB stand-in: both are zips, and only one entry matters
+// here.
+func writeZip(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	defer file.Close()
+
+	archive := zip.NewWriter(file)
+	for name, content := range entries {
+		entry, err := archive.Create(name)
+		require.NoError(t, err)
+		_, err = entry.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, archive.Close())
+}
+
+// writeAndroidApk packages an app beside the metadata that names it, which is how
+// the APK for a variant is found.
+func writeAndroidApk(t *testing.T, root, module string, entries map[string]string, apkDirs ...string) string {
+	t.Helper()
+	path := filepath.Join(append([]string{root, module, "build", "outputs", "apk"}, append(apkDirs, "app.apk")...)...)
+	writeZip(t, path, entries)
+	return path
+}
+
+const stampedSymbolsID = "7e0d66142a85de6c6b2850dcbba5f066"
+
+func TestSymbolsIDFromPackagedAPK(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.apk")
+	writeZip(t, path, map[string]string{
+		"AndroidManifest.xml": "binary",
+		apkSymbolsIDEntry:     stampedSymbolsID + "\n",
+	})
+
+	assert.Equal(t, stampedSymbolsID, symbolsIDFromPackagedApp(path))
+}
+
+func TestSymbolsIDFromAppBundle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.aab")
+	writeZip(t, path, map[string]string{aabSymbolsIDEntry: stampedSymbolsID})
+
+	assert.Equal(t, stampedSymbolsID, symbolsIDFromPackagedApp(path))
+}
+
+// An app that does not stamp an id has nothing to be keyed by, and belongs on the
+// Version Lane.
+func TestSymbolsIDFromPackagedAppWithoutAsset(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.apk")
+	writeZip(t, path, map[string]string{"AndroidManifest.xml": "binary"})
+
+	assert.Empty(t, symbolsIDFromPackagedApp(path))
+}
+
+// The SDK reports only a 32-hex-char id, so anything else names a lane that will
+// never be asked for — and an id is part of a storage key, which is not somewhere
+// arbitrary text from a file belongs.
+func TestSymbolsIDFromPackagedAppRejectsMalformedID(t *testing.T) {
+	for _, id := range []string{
+		"",
+		"   ",
+		"not-a-symbols-id",
+		"7E0D66142A85DE6C6B2850DCBBA5F066",
+		"7e0d66142a85de6c6b2850dcbba5f0",
+		"../../../../etc/passwd",
+	} {
+		path := filepath.Join(t.TempDir(), "app.apk")
+		writeZip(t, path, map[string]string{apkSymbolsIDEntry: id})
+		assert.Empty(t, symbolsIDFromPackagedApp(path), "expected rejected: %q", id)
+	}
+}
+
+func TestSymbolsIDFromPackagedAppUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	notAZip := filepath.Join(dir, "app.apk")
+	require.NoError(t, os.WriteFile(notAZip, []byte("this is not a zip"), 0o644))
+
+	assert.Empty(t, symbolsIDFromPackagedApp(notAZip))
+	assert.Empty(t, symbolsIDFromPackagedApp(filepath.Join(dir, "missing.apk")))
+}
+
+func TestAndroidBuildSymbolsID(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+	writeAndroidOutputMetadata(t, root, "app", "composeRelease", "1.0.1", "compose", "release")
+	writeAndroidApk(t, root, "app", map[string]string{apkSymbolsIDEntry: stampedSymbolsID}, "compose", "release")
+
+	build, err := discoverAndroidBuild(root)
+	require.NoError(t, err)
+	require.NotNil(t, build)
+	assert.Equal(t, stampedSymbolsID, build.SymbolsID())
+}
+
+// Another variant's APK describes another build, whose id would send this mapping
+// to a lane that build's app already occupies.
+func TestAndroidBuildSymbolsIDIgnoresOtherVariants(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+	writeAndroidOutputMetadata(t, root, "app", "javaRelease", "1.0.1", "java", "release")
+	writeAndroidApk(t, root, "app", map[string]string{apkSymbolsIDEntry: stampedSymbolsID}, "java", "release")
+
+	build, err := discoverAndroidBuild(root)
+	require.NoError(t, err)
+	require.NotNil(t, build)
+	assert.Empty(t, build.SymbolsID())
+}
+
+func TestResolveAndroidBuildUsesStampedSymbolsID(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+	writeAndroidOutputMetadata(t, root, "app", "composeRelease", "1.0.1", "compose", "release")
+	writeAndroidApk(t, root, "app", map[string]string{apkSymbolsIDEntry: stampedSymbolsID}, "compose", "release")
+
+	resolved, err := resolveAndroidBuild(androidUpload{Path: root})
+	require.NoError(t, err)
+	assert.Equal(t, stampedSymbolsID, resolved.SymbolsID)
+
+	// The id fully addresses the mapping, so it supersedes the version.
+	assert.Equal(t,
+		"_sym/android/id/"+stampedSymbolsID+"/mapping.txt",
+		getS3Key(androidSymbolsIDPrefix, resolved.SymbolsID, resolved.AppVersion, "", androidMappingFileName),
+	)
+}
+
+func TestResolveAndroidBuildKeepsExplicitSymbolsID(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+	writeAndroidOutputMetadata(t, root, "app", "composeRelease", "1.0.1", "compose", "release")
+	writeAndroidApk(t, root, "app", map[string]string{apkSymbolsIDEntry: stampedSymbolsID}, "compose", "release")
+
+	const explicit = "0123456789abcdef0123456789abcdef"
+	resolved, err := resolveAndroidBuild(androidUpload{Path: root, SymbolsID: explicit})
+	require.NoError(t, err)
+	assert.Equal(t, explicit, resolved.SymbolsID)
+}
+
+// A mapping with no packaged app beside it still uploads, on the Version Lane.
+func TestResolveAndroidBuildWithoutPackagedApp(t *testing.T) {
+	root := t.TempDir()
+	writeAndroidMapping(t, root, "app", "composeRelease", "com.example.App -> a.a:\n")
+	writeAndroidOutputMetadata(t, root, "app", "composeRelease", "1.0.1", "compose", "release")
+
+	resolved, err := resolveAndroidBuild(androidUpload{Path: root})
+	require.NoError(t, err)
+	assert.Empty(t, resolved.SymbolsID)
+	assert.Equal(t, "1.0.1", resolved.AppVersion)
+}

--- a/cmd/symbols/apple_upload.go
+++ b/cmd/symbols/apple_upload.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/fs"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,12 +73,16 @@ func uploadAppleDSYMs(apiKey, projectID, path, backendURL string, includeSources
 
 	keys := make([]string, len(maps))
 	digests := make([]string, len(maps))
+	bodies := make([]uploadBody, len(maps))
 	for i, m := range maps {
 		keys[i] = m.Key
+		// Compressed here rather than at the point of sending, so a digest below
+		// describes the bytes that get stored.
+		bodies[i] = compressBody(m.Data)
 		if m.Kind == kindSources {
 			// Sources are keyed by their image's UUID rather than by their own
 			// contents, so only a digest can show that re-sending them is a no-op.
-			digests[i] = contentDigest(m.Data)
+			digests[i] = contentDigest(bodies[i].Data)
 		}
 	}
 
@@ -100,7 +103,7 @@ func uploadAppleDSYMs(apiKey, projectID, path, backendURL string, includeSources
 			skipped++
 			continue
 		}
-		if err := uploadBytes(m.Data, uploadURLs[i], m.label()); err != nil {
+		if err := uploadBytes(bodies[i], uploadURLs[i], m.label()); err != nil {
 			return fmt.Errorf("failed to upload symbol map for %s: %w", m.UUID, err)
 		}
 	}
@@ -246,23 +249,19 @@ func archLabel(cpuType uint32) string {
 	}
 }
 
-func uploadBytes(data []byte, uploadURL, name string) error {
-	req, err := http.NewRequest("PUT", uploadURL, bytes.NewReader(data))
-	if err != nil {
+// uploadBytes sends an artifact built in memory. It takes an already-compressed
+// body rather than raw bytes so that a caller which sends a digest hashes exactly
+// what gets stored; see compress.go.
+func uploadBytes(body uploadBody, uploadURL, name string) error {
+	if err := putObject(uploadURL, bytes.NewReader(body.Data), int64(len(body.Data)), body.Encoding); err != nil {
 		return err
 	}
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
+	if body.Encoding == gzipEncoding {
+		fmt.Printf("[LaunchDarkly] Uploaded symbol map %s (%s gzipped to %s)\n",
+			name, byteSize(int64(body.RawSize)), byteSize(int64(len(body.Data))))
+		return nil
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("upload failed with status code: %d", resp.StatusCode)
-	}
-
-	fmt.Printf("[LaunchDarkly] Uploaded symbol map %s\n", name)
+	fmt.Printf("[LaunchDarkly] Uploaded symbol map %s (%s)\n", name, byteSize(int64(len(body.Data))))
 	return nil
 }

--- a/cmd/symbols/compress.go
+++ b/cmd/symbols/compress.go
@@ -1,0 +1,90 @@
+package symbols
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Uploads are gzipped.
+//
+// A release R8 mapping is tens of megabytes of text, a React Native source map
+// several, and every build sends one again; compressed, that is roughly an eighth
+// of the bytes. The object is marked Content-Encoding: gzip, which keeps it
+// self-describing: storage returns the header on read, an HTTP client inflates it
+// in transit, and the symbolication reader inflates whatever still arrives
+// compressed.
+//
+// Compression is settled before an upload URL is requested rather than at the point
+// of sending, because the digest that proves an object is already stored has to be
+// the digest of the bytes that get stored.
+
+// gzipEncoding is the Content-Encoding an upload is marked with.
+const gzipEncoding = "gzip"
+
+// uploadBody is what a PUT sends: the bytes, and how they are encoded.
+type uploadBody struct {
+	Data     []byte
+	Encoding string
+	// RawSize is the artifact's size before compression, for reporting.
+	RawSize int
+}
+
+// compressBody gzips an artifact held in memory, keeping it as it is when
+// compressing gains nothing — a .srcbundle already gzips its own entries, and
+// wrapping one again would only put a reader a step further from it.
+func compressBody(data []byte) uploadBody {
+	compressed, err := gzipBytes(data)
+	if err != nil || len(compressed) >= len(data) {
+		return uploadBody{Data: data, RawSize: len(data)}
+	}
+	return uploadBody{Data: compressed, Encoding: gzipEncoding, RawSize: len(data)}
+}
+
+func gzipBytes(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	if _, err := writer.Write(data); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// gzipFile compresses a file on disk, streaming it through the compressor so that a
+// mapping large enough to be worth compressing is never held in memory whole.
+func gzipFile(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	if _, err := io.Copy(writer, file); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// byteSize renders a size the way upload progress reports it.
+func byteSize(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for rest := n / unit; rest >= unit; rest /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGT"[exp])
+}

--- a/cmd/symbols/compress_test.go
+++ b/cmd/symbols/compress_test.go
@@ -1,0 +1,142 @@
+package symbols
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/rand"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// receivedUpload is what a presigned PUT looked like on the wire.
+type receivedUpload struct {
+	Encoding string
+	Length   int64
+	Body     []byte
+}
+
+// uploadTestServer stands in for the presigned URL, recording the one PUT made to it.
+func uploadTestServer(t *testing.T) (*httptest.Server, *receivedUpload) {
+	t.Helper()
+	var got receivedUpload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.Encoding = r.Header.Get("Content-Encoding")
+		got.Length = r.ContentLength
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		got.Body = body
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &got
+}
+
+func ungzip(t *testing.T, data []byte) []byte {
+	t.Helper()
+	reader, err := gzip.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	defer reader.Close()
+	out, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	return out
+}
+
+func TestUploadFileSendsGzip(t *testing.T) {
+	mapping := strings.Repeat("com.example.app.Class -> a.b.c:\n    12:12:void method() -> a\n", 500)
+	path := filepath.Join(t.TempDir(), androidMappingFileName)
+	require.NoError(t, os.WriteFile(path, []byte(mapping), 0o644))
+
+	srv, got := uploadTestServer(t)
+	stdout, _ := captureOutput(t, func() {
+		require.NoError(t, uploadFile(path, srv.URL, androidMappingFileName))
+	})
+
+	assert.Equal(t, gzipEncoding, got.Encoding)
+	assert.Equal(t, mapping, string(ungzip(t, got.Body)), "the artifact has to survive the round trip")
+	assert.Less(t, len(got.Body), len(mapping)/10, "a mapping should compress by at least 10x")
+	// S3 will not take a chunked upload, so the length has to be known up front.
+	assert.Equal(t, int64(len(got.Body)), got.Length)
+	assert.Contains(t, stdout, "gzipped to")
+}
+
+// An artifact that is already compressed can come out of gzip bigger. Storing that
+// costs bytes and puts a reader a step further from the artifact, for nothing.
+func TestUploadFileSendsIncompressibleFileAsIs(t *testing.T) {
+	incompressible := make([]byte, 8192)
+	_, err := rand.Read(incompressible)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "sources.srcbundle")
+	require.NoError(t, os.WriteFile(path, incompressible, 0o644))
+
+	srv, got := uploadTestServer(t)
+	_, _ = captureOutput(t, func() {
+		require.NoError(t, uploadFile(path, srv.URL, "sources.srcbundle"))
+	})
+
+	assert.Empty(t, got.Encoding)
+	assert.Equal(t, incompressible, got.Body)
+	assert.Equal(t, int64(len(incompressible)), got.Length)
+}
+
+func TestUploadFileReportsAMissingFile(t *testing.T) {
+	srv, _ := uploadTestServer(t)
+	assert.Error(t, uploadFile(filepath.Join(t.TempDir(), "absent.txt"), srv.URL, "absent.txt"))
+}
+
+// The digest that proves an object is already stored is compared against the ETag of
+// the stored bytes, so it has to be taken after compression. Hashing the artifact
+// instead would never match, and every source bundle would be re-sent forever.
+func TestUploadBytesDigestDescribesTheStoredBytes(t *testing.T) {
+	body := compressBody([]byte(strings.Repeat("package com.example;\n", 500)))
+	require.Equal(t, gzipEncoding, body.Encoding, "this fixture is meant to compress")
+
+	srv, got := uploadTestServer(t)
+	_, _ = captureOutput(t, func() {
+		require.NoError(t, uploadBytes(body, srv.URL, androidSourceBundleName))
+	})
+
+	assert.Equal(t, gzipEncoding, got.Encoding)
+	assert.Equal(t, contentDigest(body.Data), contentDigest(got.Body))
+}
+
+func TestCompressBody(t *testing.T) {
+	data := []byte(strings.Repeat("com.example.App -> a.a:\n", 500))
+
+	body := compressBody(data)
+	assert.Equal(t, gzipEncoding, body.Encoding)
+	assert.Equal(t, len(data), body.RawSize)
+	assert.Equal(t, data, ungzip(t, body.Data))
+}
+
+// A .srcbundle gzips its own entries, so there is nothing left for another pass to
+// take out and the artifact is sent as it is.
+func TestCompressBodyKeepsIncompressibleData(t *testing.T) {
+	data := make([]byte, 4096)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+
+	body := compressBody(data)
+	assert.Empty(t, body.Encoding)
+	assert.Equal(t, data, body.Data)
+}
+
+func TestCompressBodyOnEmptyData(t *testing.T) {
+	body := compressBody(nil)
+	assert.Empty(t, body.Encoding)
+	assert.Empty(t, body.Data)
+}
+
+func TestByteSize(t *testing.T) {
+	assert.Equal(t, "0 B", byteSize(0))
+	assert.Equal(t, "512 B", byteSize(512))
+	assert.Equal(t, "1.0 KB", byteSize(1024))
+	assert.Equal(t, "1.5 MB", byteSize(1024*1024*3/2))
+	assert.Equal(t, "61.3 MB", byteSize(64266122))
+}

--- a/cmd/symbols/flutter_upload.go
+++ b/cmd/symbols/flutter_upload.go
@@ -76,7 +76,9 @@ func uploadFlutterSymbols(apiKey, projectID, path, appVersion, backendURL string
 			skipped++
 			continue
 		}
-		if err := uploadBytes(u.Data, uploadURLs[i], u.Label); err != nil {
+		// Nothing here carries a digest, so unlike the Apple uploader this can wait
+		// until a map is known to be going, and skip the work for one that isn't.
+		if err := uploadBytes(compressBody(u.Data), uploadURLs[i], u.Label); err != nil {
 			return fmt.Errorf("failed to upload symbol map %s: %w", u.Label, err)
 		}
 	}

--- a/cmd/symbols/upload.go
+++ b/cmd/symbols/upload.go
@@ -235,6 +235,14 @@ func runE(client resources.Client) func(cmd *cobra.Command, args []string) error
 			return uploadFlutterSymbols(viper.GetString(cliflags.AccessTokenFlag), projectResult.ID, path, appVersion, backendUrl, skipExisting)
 		}
 
+		// An Android project already knows where R8 put the mapping and what version
+		// it shipped, so read both out of the build instead of asking for them.
+		if symbolType == typeAndroid {
+			if path, appVersion, err = resolveAndroidBuild(path, appVersion); err != nil {
+				return err
+			}
+		}
+
 		symbolsIDPrefix := symbolsIDPrefixForType(symbolType)
 
 		fmt.Printf("Starting to upload %s symbols from %s\n", symbolType, path)
@@ -430,6 +438,15 @@ func isSymbolUploadFile(symbolType, name string) bool {
 	return isReactNativeUploadFile(name)
 }
 
+// uploadName is the name an artifact is stored under, given its path relative to
+// the directory searched.
+func uploadName(symbolType, relPath string) string {
+	if symbolType == typeAndroid {
+		return filepath.Base(relPath)
+	}
+	return relPath
+}
+
 func getAllSymbolFiles(path, symbolType string) ([]SymbolFile, error) {
 	var files []SymbolFile
 
@@ -468,7 +485,11 @@ func getAllSymbolFiles(path, symbolType string) ([]SymbolFile, error) {
 
 			files = append(files, SymbolFile{
 				Path: filePath,
-				Name: relPath,
+				// Symbolication reads an Android mapping at <lane>/mapping.txt, so
+				// the object is named for the file alone however deep it was found.
+				// A React Native bundle keeps its path, which is part of how a map
+				// is matched to the bundle that references it.
+				Name: uploadName(symbolType, relPath),
 			})
 		}
 
@@ -690,13 +711,13 @@ func initFlags(cmd *cobra.Command) {
 	_ = cmd.Flags().SetAnnotation(cliflags.ProjectFlag, "required", []string{"true"})
 	_ = viper.BindPFlag(cliflags.ProjectFlag, cmd.Flags().Lookup(cliflags.ProjectFlag))
 
-	cmd.Flags().String(appVersionFlag, "", "The current version of your deploy")
+	cmd.Flags().String(appVersionFlag, "", fmt.Sprintf("The current version of your deploy. With --type %s this is read from the packaged build when omitted", typeAndroid))
 	_ = viper.BindPFlag(appVersionFlag, cmd.Flags().Lookup(appVersionFlag))
 
 	cmd.Flags().String(symbolsIdFlag, "", "The symbols id (launchdarkly.symbols_id.htlhash) to key uploads by (Symbols Id Lane). If omitted, a *.symbolsid sidecar next to the bundle is used when present")
 	_ = viper.BindPFlag(symbolsIdFlag, cmd.Flags().Lookup(symbolsIdFlag))
 
-	cmd.Flags().String(pathFlag, defaultPath, "Sets the directory of where the symbol files are")
+	cmd.Flags().String(pathFlag, defaultPath, fmt.Sprintf("Sets the directory of where the symbol files are. With --type %s, run from your project root and the R8 mapping is found for you", typeAndroid))
 	_ = viper.BindPFlag(pathFlag, cmd.Flags().Lookup(pathFlag))
 
 	cmd.Flags().String(basePathFlag, "", "An optional base path for the uploaded symbol files")

--- a/cmd/symbols/upload.go
+++ b/cmd/symbols/upload.go
@@ -235,12 +235,15 @@ func runE(client resources.Client) func(cmd *cobra.Command, args []string) error
 			return uploadFlutterSymbols(viper.GetString(cliflags.AccessTokenFlag), projectResult.ID, path, appVersion, backendUrl, skipExisting)
 		}
 
-		// An Android project already knows where R8 put the mapping and what version
-		// it shipped, so read both out of the build instead of asking for them.
+		// An Android project already knows where R8 put the mapping, what version it
+		// shipped, and which symbols id the app reports, so read all three out of
+		// the build instead of asking for them.
 		if symbolType == typeAndroid {
-			if path, appVersion, err = resolveAndroidBuild(path, appVersion); err != nil {
-				return err
+			resolved, aErr := resolveAndroidBuild(androidUpload{Path: path, AppVersion: appVersion, SymbolsID: symbolsID})
+			if aErr != nil {
+				return aErr
 			}
+			path, appVersion, symbolsID = resolved.Path, resolved.AppVersion, resolved.SymbolsID
 		}
 
 		symbolsIDPrefix := symbolsIDPrefixForType(symbolType)
@@ -714,7 +717,7 @@ func initFlags(cmd *cobra.Command) {
 	cmd.Flags().String(appVersionFlag, "", fmt.Sprintf("The current version of your deploy. With --type %s this is read from the packaged build when omitted", typeAndroid))
 	_ = viper.BindPFlag(appVersionFlag, cmd.Flags().Lookup(appVersionFlag))
 
-	cmd.Flags().String(symbolsIdFlag, "", "The symbols id (launchdarkly.symbols_id.htlhash) to key uploads by (Symbols Id Lane). If omitted, a *.symbolsid sidecar next to the bundle is used when present")
+	cmd.Flags().String(symbolsIdFlag, "", fmt.Sprintf("The symbols id (launchdarkly.symbols_id.htlhash) to key uploads by (Symbols Id Lane). If omitted, a *.symbolsid sidecar next to the bundle is used when present, and with --type %s the id the packaged app reports", typeAndroid))
 	_ = viper.BindPFlag(symbolsIdFlag, cmd.Flags().Lookup(symbolsIdFlag))
 
 	cmd.Flags().String(pathFlag, defaultPath, fmt.Sprintf("Sets the directory of where the symbol files are. With --type %s, run from your project root and the R8 mapping is found for you", typeAndroid))

--- a/cmd/symbols/upload.go
+++ b/cmd/symbols/upload.go
@@ -291,7 +291,7 @@ func runE(client resources.Client) func(cmd *cobra.Command, args []string) error
 		// mapping's id and not the bundle's, an object being there says nothing
 		// about these sources — a source-only change keeps the mapping's id — so the
 		// bundle is skipped only when its digest matches what is already stored.
-		var sourceBundle []byte
+		var sourceBundle *uploadBody
 		if symbolType == typeAndroid && viper.GetBool(includeSourcesFlag) {
 			sourceRoot := viper.GetString(sourcePathFlag)
 			data, count, bErr := buildAndroidSourceBundle(sourceRoot)
@@ -302,7 +302,10 @@ func runE(client resources.Client) func(cmd *cobra.Command, args []string) error
 				// Not fatal: the mapping alone still retraces, just without source.
 				fmt.Printf("No .java/.kt sources found under %s; skipping source bundle\n", sourceRoot)
 			} else {
-				sourceBundle = data
+				// Compressed here rather than at the point of sending, so the digest
+				// below describes the bytes that get stored.
+				body := compressBody(data)
+				sourceBundle = &body
 				bundleName := filepath.Join(filepath.Dir(files[0].Name), androidSourceBundleName)
 				s3Keys = append(s3Keys, getS3Key(symbolsIDPrefix, firstSymbolsID, appVersion, basePath, bundleName))
 				fmt.Printf("Built source bundle from %s (%d files, %d bytes)\n", sourceRoot, count, len(data))
@@ -314,7 +317,7 @@ func runE(client resources.Client) func(cmd *cobra.Command, args []string) error
 		// and we never have to read a large mapping back off disk to hash it.
 		digests := make([]string, len(s3Keys))
 		if sourceBundle != nil {
-			digests[len(s3Keys)-1] = contentDigest(sourceBundle)
+			digests[len(s3Keys)-1] = contentDigest(sourceBundle.Data)
 		}
 
 		uploadUrls, err := getSymbolUploadUrls(viper.GetString(cliflags.AccessTokenFlag), projectResult.ID, s3Keys, digests, backendUrl, skipExisting)
@@ -344,7 +347,7 @@ func runE(client resources.Client) func(cmd *cobra.Command, args []string) error
 			if alreadyUploaded(uploadUrls[len(files)]) {
 				fmt.Printf("Skipping %s, already uploaded\n", androidSourceBundleName)
 				skipped++
-			} else if err := uploadBytes(sourceBundle, uploadUrls[len(files)], androidSourceBundleName); err != nil {
+			} else if err := uploadBytes(*sourceBundle, uploadUrls[len(files)], androidSourceBundleName); err != nil {
 				return fmt.Errorf("failed to upload source bundle: %w", err)
 			}
 		}
@@ -677,15 +680,59 @@ func requestSymbolUploadUrls(apiKey, projectID string, paths, digests []string, 
 	return urlsResp.Data.GetSymbolUploadUrls, nil
 }
 
+// uploadFile sends a file on disk, gzipped. Nothing keyed to a file carries a
+// digest — those keys are derived from the artifact's own contents — so unlike an
+// artifact held in memory this can be compressed here, as it is read.
 func uploadFile(filePath, uploadUrl, name string) error {
-	fileContent, err := os.ReadFile(filePath)
+	info, err := os.Stat(filePath)
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest("PUT", uploadUrl, bytes.NewBuffer(fileContent))
+	compressed, err := gzipFile(filePath)
 	if err != nil {
 		return err
+	}
+
+	// Compressing an artifact that is already compressed can make it bigger; send
+	// the file as it is rather than pay to store the difference.
+	if int64(len(compressed)) >= info.Size() {
+		file, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		if err := putObject(uploadUrl, file, info.Size(), ""); err != nil {
+			return err
+		}
+		fmt.Printf("[LaunchDarkly] Uploaded %s to %s (%s)\n", filePath, name, byteSize(info.Size()))
+		return nil
+	}
+
+	if err := putObject(uploadUrl, bytes.NewReader(compressed), int64(len(compressed)), gzipEncoding); err != nil {
+		return err
+	}
+	fmt.Printf("[LaunchDarkly] Uploaded %s to %s (%s gzipped to %s)\n",
+		filePath, name, byteSize(info.Size()), byteSize(int64(len(compressed))))
+	return nil
+}
+
+// putObject PUTs a body to a presigned URL.
+//
+// The length is passed explicitly because S3 will not take a chunked upload, and
+// net/http only measures a body it recognises — a file streamed from disk would
+// otherwise be sent with no Content-Length at all.
+func putObject(uploadURL string, body io.Reader, length int64, encoding string) error {
+	req, err := http.NewRequest("PUT", uploadURL, body)
+	if err != nil {
+		return err
+	}
+	req.ContentLength = length
+	if encoding != "" {
+		// Stored as object metadata and handed back on read, so the object says how
+		// to read it instead of the reader having to guess.
+		req.Header.Set("Content-Encoding", encoding)
 	}
 
 	client := &http.Client{}
@@ -698,8 +745,6 @@ func uploadFile(filePath, uploadUrl, name string) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("upload failed with status code: %d", resp.StatusCode)
 	}
-
-	fmt.Printf("[LaunchDarkly] Uploaded %s to %s\n", filePath, name)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Three changes that together let `ldcli symbols upload --type android` run from an Android project root with no flags, and cut what every upload sends.

**Find the mapping and app version in the build.** The command previously needed a `--path` pointing at a directory holding `mapping.txt` and an `--app-version` matching what the app reports, so every project had to add build-script code to stage the mapping and plumb its version into CI. The Android Gradle Plugin already writes both — R8's mapping at `<module>/build/outputs/mapping/<variant>/mapping.txt`, and the packaged version in `output-metadata.json` beside the APK. Several obfuscated variants is an error naming them rather than a guess, since only one is the build being shipped. An Android mapping is also now stored as `mapping.txt` however deep it was found; symbolication reads it at `<lane>/mapping.txt`, so a mapping uploaded from a nested path used to be keyed where nothing looks.

**Read the symbols id out of the packaged app.** A build that stamps a content-derived id into `assets/ld_symbols_id.txt` had to also stage a `mapping.txt.symbolsid` sidecar next to a copy of the mapping, purely so the upload could be keyed by the id the app reports. The APK/AAB already carries that asset, and it is the app that will run, so reading it there needs nothing handed over by the build and leaves no way for the two to disagree. An id that doesn't match the 32-hex-char shape the SDK reports is ignored rather than keyed on.

**Gzip what an upload sends.** The e2e app's mapping is 61.3 MB and gzips to 5.0 MB in under half a second; React Native and Apple artifacts compress on the same order. Objects are marked `Content-Encoding: gzip` so they stay self-describing. In-memory artifacts are compressed *before* an upload URL is requested, because the digest that proves an object is already stored is compared against the ETag of the stored bytes — hashing the uncompressed artifact would never match and every source bundle would be re-sent. Files are streamed through the compressor so a large mapping is never held in memory whole. Anything gzip doesn't shrink is sent as-is, so a `.srcbundle` isn't wrapped twice.

## Ordering

The backend read side must ship first: https://github.com/launchdarkly/observability/pull/1611. Until it is deployed, a compressed mapping would reach the parser as bytes it cannot read.

## Test plan

- [x] `go test ./cmd/symbols/`
- [x] Discovery picks the single obfuscated variant and errors naming them when there are several
- [x] Symbols id is read from a packaged APK/AAB and ignored when malformed
- [x] Compression skips artifacts it cannot shrink, and digests are computed over the stored bytes

Made with [Cursor](https://cursor.com)