### PR TITLE
chore: fix CODEOWNERS pattern so default ownership applies

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo.
 
-- @launchdarkly/team-foundation
+* @launchdarkly/team-foundation


### PR DESCRIPTION
## The problem

The default-owner line in `CODEOWNERS` matches nothing:

```
- @launchdarkly/team-foundation
```

The leading `-` is a leftover Markdown list marker, but CODEOWNERS reads the first token on a line as the **file pattern**. `-` is legal pattern syntax — it matches a file literally named `-` — so GitHub parses the line, finds no such file, and assigns the team to zero paths. The repo has had no effective code owner.

This fails silently. GitHub's own validator reports nothing:

```
$ gh api repos/launchdarkly/ldcli/codeowners/errors
{"errors":[]}
```

That empty result is not evidence the file works — the validator flags *unparseable* lines and unresolvable owners, not patterns that parse fine and match nothing. It returns `{"errors":[]}` both before and after this change.

## The fix

Replace `-` with `*`, the catch-all pattern the comment above it already describes. One character; no change to who owns the repo.

## Evidence it has been inert

`@launchdarkly/team-foundation` has never been auto-requested as a reviewer. Across the last 15 PRs, the only review request is an individual added by hand:

```
#773 requested=[Vadman97]
#771 requested=[]
#769 requested=[]
#768 requested=[]
#767 requested=[]     ... and so on
```

The bug predates every current owner. It has been present since the repo was open-sourced in #78, and five PRs have since re-pointed the owner across `ldcli-app-platform` → `team-feature-management` → `team-fm-next` → `team-fm-foundations` → `team-foundation` (#382, #622, #633, #653, #715) without anyone noticing the line was inert. Worth noting: the `/cmd/dev_server @launchdarkly/team-fundamentals` line that existed between #622 and #637 *was* well-formed, so for that window `dev_server` was the only owned path in the repo.

**Practical impact is the missing auto-request.** No ruleset on this repo requires code-owner approval today, so nothing was being bypassed — but PRs get no owner routing, and any tooling that reads CODEOWNERS to answer "who owns ldcli" gets an empty answer.

## Why `team-foundation` is the right owner

I confirmed this rather than inheriting it from the broken line:

- It is the most recent deliberate assignment (#715, Jun 2026).
- The team exists, has 9 members, and holds `maintain` (write) access to this repo — so `*` resolves to a valid owner.
- Its roster overlaps the actual contributors: `nieblara` is both the top human committer here and a member; `cspath1` authored the last-but-one CODEOWNERS change.

**One caveat for the reviewer.** Ownership of this repo is genuinely contested. The [Proposing the Agent Platform team](https://launchdarkly.atlassian.net/wiki/spaces/~628cca61c65b720069616073/pages/5007245516/Proposing+the+Agent+Platform+team) doc states that `ld-cli` "is also formally owned by `team-foundation` per CODEOWNERS, but operationally the work is orphaned," and proposes moving it to a new Agent Platform team. That proposal is still at PLANNED status, so `team-foundation` remains the formal owner today.

**This PR deliberately does not re-decide ownership** — it makes the declared owner take effect. If Agent Platform lands, that is a one-line follow-up to the same file, and it will actually work once this is in.

## Org-wide check for the same bug

I pulled `CODEOWNERS` from all **759 non-archived** `launchdarkly` repos (checking `CODEOWNERS`, `.github/CODEOWNERS`, and `docs/CODEOWNERS`) and parsed every rule. 271 repos have the file; 488 have none.

**`ldcli` is the only repo with the list-marker bug.** No repo uses the other constructs GitHub silently drops (`!` negation, `[...]` character ranges).

Two adjacent findings, both also returning `{"errors":[]}`, neither fixed here:

| Repo | Line | Problem |
|---|---|---|
| `gha-ld-gosec` | `@launchdarkly/team-product-security` | Owner with **no pattern**. The owner is read as the pattern, so this file — its only rule — also owns nothing. Same silent-failure class as this bug. |
| `ethersphere` | `/dbt/models/stg`, `/dbt/models/workspace_revops`, `/looker`, `/dbt/data` | Four patterns with **no owner**. Each declares a path and assigns nobody. |

`gha-ld-gosec` is worth a look by whoever owns it — it is a security-tooling repo whose intended owner is `team-product-security`.

## Separate finding, not fixed here

`gonfalon`'s [`.github/workflows/codeowners-coverage.yml`](https://github.com/launchdarkly/gonfalon/blob/main/.github/workflows/codeowners-coverage.yml) has `continue-on-error: true` on the step that ends in `exit 1` for new files lacking coverage, so coverage gaps never fail CI. The step comment ("Report coverage gaps but don't fail the check") suggests this is intentional, but it sits alongside an `::error::` annotation and an `exit 1` that both read as enforcement. Flagging for the reviewer — it is a different repo and belongs in its own change.

## Testing

CODEOWNERS is not exercised by CI. Verified by inspection:

- Branch file validates clean: `gh api "repos/launchdarkly/ldcli/codeowners/errors?ref=fix/codeowners-default-pattern"` → `{"errors":[]}`.
- Owner resolves: `team-foundation` confirmed attached to this repo with `maintain` permission.
- The real confirmation is post-merge — the next PR should auto-request `@launchdarkly/team-foundation`. Worth a glance on the PR after this one.

via LD Research 🤖

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-character fix in CODEOWNERS with no runtime or security impact; only enables intended GitHub review routing.
> 
> **Overview**
> **Fixes a silent CODEOWNERS misconfiguration** so the repo’s declared default owner actually applies.
> 
> The default-owner line used `-` as the pattern (a leftover Markdown list marker). GitHub treats that as a literal filename, so `@launchdarkly/team-foundation` was never assigned to any path and PRs did not get automatic owner review requests. The line is changed to `*` so it matches the catch-all behavior described in the comment above it; the owning team is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 303d4c576099f9760cc2e185b04b1bc6df886380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->